### PR TITLE
No more messages for trying to register an already registered factory

### DIFF
--- a/src/fastoad/module_management/exceptions.py
+++ b/src/fastoad/module_management/exceptions.py
@@ -1,0 +1,27 @@
+"""
+Exceptions for module_management package
+"""
+#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  Copyright (C) 2019  ONERA/ISAE
+#  FAST is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from fastoad.exceptions import FastError
+
+
+class FastDuplicateFactoryError(FastError):
+    """
+    Raised when trying to register a factory with an already used name
+    """
+
+    def __init__(self, factory_name):
+        super().__init__('Name "%s" is already used.' % factory_name)
+        self.factory_name = factory_name

--- a/src/fastoad/module_management/openmdao_system_factory.py
+++ b/src/fastoad/module_management/openmdao_system_factory.py
@@ -18,7 +18,7 @@ The base layer for registering and retrieving OpenMDAO systems
 import logging
 from typing import List
 
-from fastoad.module_management.bundle_loader import FastDuplicateFactoryError
+from fastoad.module_management.exceptions import FastDuplicateFactoryError
 from fastoad.openmdao.types import SystemSubclass
 from . import BundleLoader
 from .constants import SERVICE_OPENMDAO_SYSTEM

--- a/src/fastoad/utils/files/subfolder_provider.py
+++ b/src/fastoad/utils/files/subfolder_provider.py
@@ -18,14 +18,12 @@ import os
 import os.path as pth
 from typing import List, Union
 
-from pelix.ipopo.decorators import SingletonFactory, Provides, Instantiate
-
+from fastoad.module_management import BundleLoader
 from fastoad.module_management.constants import SERVICE_RESULT_FOLDER_PROVIDER
 
 
-@SingletonFactory('org.fast.subfolderprovider.factory')
-@Provides(SERVICE_RESULT_FOLDER_PROVIDER)
-@Instantiate('org.fast.subfolderprovider')
+# Note: the "SubfolderProvider" service is registered right after the class
+# declaration
 class SubfolderProvider:
     """
     Service for providing subfolders after having set once a unique root folder.
@@ -63,3 +61,6 @@ class SubfolderProvider:
             os.makedirs(result_folder, exist_ok=True)
 
         return result_folder
+
+
+BundleLoader().context.register_service(SERVICE_RESULT_FOLDER_PROVIDER, SubfolderProvider(), {})

--- a/tests/unit_tests/module_management/dummy_pelix_bundles/hello_world_with_decorators.py
+++ b/tests/unit_tests/module_management/dummy_pelix_bundles/hello_world_with_decorators.py
@@ -1,6 +1,5 @@
-# -*- coding: utf-8 -*-
 """
-Basic "Hello World" services
+Basic "Hello World" services using iPOPO decorators
 """
 #  This file is part of FAST : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2019  ONERA/ISAE
@@ -24,7 +23,6 @@ from pelix.ipopo.decorators import ComponentFactory, Provides, Instantiate, \
     Property
 
 # Define the component factory, with a given name
-from fastoad.module_management import BundleLoader
 
 
 # First, let's register 2 factories the iPOPO way
@@ -48,32 +46,3 @@ class Greetings1:
 class Greetings2:
     def hello(self, name='World'):
         return 'Hi, {0}!'.format(name)
-
-
-# Register factories without instantiating with our wrapping of iPOPO
-class OtherGreetings:
-    def hello(self, name='World'):
-        return 'Hello again, {0}!'.format(name)
-
-
-loader = BundleLoader()
-loader.register_factory(OtherGreetings,
-                        factory_name='another-hello-world-factory',
-                        service_names=['hello.world', 'hello.world.no.instance'],
-                        properties={'Prop1': 3,
-                                    'Prop 2': 'Says.Hello',
-                                    'Instantiated': False}
-                        )
-
-
-class OtherGreetings2:
-    def hello(self, name='Universe'):
-        return 'Hello again, {0}!'.format(name)
-
-
-# This one provides a different service and tests registering without properties
-loader = BundleLoader()
-loader.register_factory(OtherGreetings2,
-                        factory_name='hello-universe-factory',
-                        service_names=['hello.universe']
-                        )

--- a/tests/unit_tests/module_management/dummy_pelix_bundles/hello_world_without_decorators.py
+++ b/tests/unit_tests/module_management/dummy_pelix_bundles/hello_world_without_decorators.py
@@ -1,0 +1,50 @@
+"""
+Basic "Hello World" services without using iPOPO decorators
+"""
+#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  Copyright (C) 2019  ONERA/ISAE
+#  FAST is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+# Dummy classes, so let's make pylint not too picky
+# pylint: disable=missing-docstring
+# pylint: disable=no-self-use
+# pylint: disable=too-few-public-methods
+
+# Define the component factory, with a given name
+from fastoad.module_management import BundleLoader
+
+
+# Register factories without instantiating with our wrapping of iPOPO
+class OtherGreetings:
+    def hello(self, name='World'):
+        return 'Hello again, {0}!'.format(name)
+
+
+BundleLoader().register_factory(OtherGreetings,
+                                factory_name='another-hello-world-factory',
+                                service_names=['hello.world', 'hello.world.no.instance'],
+                                properties={'Prop1': 3,
+                                            'Prop 2': 'Says.Hello',
+                                            'Instantiated': False}
+                                )
+
+
+class OtherGreetings2:
+    def hello(self, name='Universe'):
+        return 'Hello again, {0}!'.format(name)
+
+
+# This one provides a different service and tests registering without properties
+BundleLoader().register_factory(OtherGreetings2,
+                                factory_name='hello-universe-factory',
+                                service_names=['hello.universe']
+                                )

--- a/tests/unit_tests/module_management/test_bundle_loader.py
+++ b/tests/unit_tests/module_management/test_bundle_loader.py
@@ -22,7 +22,7 @@ import pytest
 from pelix.framework import FrameworkFactory
 
 from fastoad.module_management import BundleLoader
-from fastoad.module_management.bundle_loader import FastDuplicateFactoryError
+from fastoad.module_management.exceptions import FastDuplicateFactoryError
 
 _LOGGER = logging.getLogger(__name__)
 """Logger for this module"""
@@ -101,7 +101,8 @@ def test_install_packages(delete_framework):
     loader = BundleLoader()
 
     loader.install_packages(pth.join(pth.dirname(__file__), "dummy_pelix_bundles"))
-    assert loader.framework.get_bundle_by_name("dummy_pelix_bundles.hello_world") is not None
+    assert loader.framework.get_bundle_by_name(
+        "dummy_pelix_bundles.hello_world_with_decorators") is not None
 
 
 def test_register_factory(delete_framework):
@@ -132,7 +133,7 @@ def test_get_services(delete_framework):
     """
     loader = BundleLoader()
     loader.install_packages(
-        pth.join(pth.dirname(__file__), "dummy_pelix_bundles"))
+        pth.join(pth.dirname(__file__), "dummy_pelix_bundles"), True)
 
     # Missing service
     services = loader.get_services("does.not.exists")
@@ -179,7 +180,7 @@ def test_instantiate_component(delete_framework):
     """
     loader = BundleLoader()
     loader.install_packages(
-        pth.join(pth.dirname(__file__), "dummy_pelix_bundles"))
+        pth.join(pth.dirname(__file__), "dummy_pelix_bundles"), True)
 
     # 2 services should already be instantiated
     services = loader.get_services("hello.world")
@@ -201,7 +202,7 @@ def test_get_factory_names(delete_framework):
     """
     loader = BundleLoader()
     loader.install_packages(
-        pth.join(pth.dirname(__file__), "dummy_pelix_bundles"))
+        pth.join(pth.dirname(__file__), "dummy_pelix_bundles"), True)
 
     # Missing service
     factory_names = loader.get_factory_names("does.not.exists")

--- a/tests/unit_tests/module_management/test_openmdao_system_factory.py
+++ b/tests/unit_tests/module_management/test_openmdao_system_factory.py
@@ -33,8 +33,12 @@ _LOGGER = logging.getLogger(__name__)
 logging.basicConfig(level=logging.DEBUG)
 
 
+# pylint: disable=redefined-outer-name  # pytest fixture
+# pylint: disable=unused-argument  # pytest fixture
+
 @pytest.fixture()
 def framework_load_unload():
+    """ Loads and unloads Pelix framework for each test """
     # Starts Pelix framework and load components
     OpenMDAOSystemFactory.explore_folder(pth.join(root_folder_path, 'tests', 'sellar_example'))
     yield
@@ -59,7 +63,7 @@ def test_get_system(framework_load_unload):
 
     # Get component 1 #########################################################
     disc1_component = OpenMDAOSystemFactory.get_system('sellar.disc1')
-    assert disc1_component._Discipline == 'generic'
+    assert disc1_component._Discipline == 'generic'  # pylint: disable=protected-access
     assert disc1_component is not None
     disc1_component.setup()
     outputs = {}
@@ -88,7 +92,7 @@ def test_get_systems_from_properties(framework_load_unload):
     systems = OpenMDAOSystemFactory.get_systems_from_properties({'Number': 1})
     assert len(systems) == 1
     disc1_component = systems[0]
-    assert disc1_component._Discipline == 'generic'
+    assert disc1_component._Discipline == 'generic'  # pylint: disable=protected-access
     assert disc1_component is not None
     disc1_component.setup()
     outputs = {}
@@ -178,7 +182,3 @@ def test_sellar(framework_load_unload):
 
     fastoad_problem.run_driver()
     assert classical_problem['f'] == fastoad_problem['f']  # both problems have run
-
-
-if __name__ == "__main__":
-    test_sellar()


### PR DESCRIPTION
iPOPO bundles are no more started unless it is asked, so iPOPO does not
try any more to register a factory we have already registered
programmatically.