### PR TITLE
Added limitation on OpenMDAO version in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
     numpy
     scipy
     pandas
-    openmdao
+    openmdao>=2.9.1
     lxml
     ipopo
     toml


### PR DESCRIPTION
tested with pip installation (`pip install git+https://github.com/...`), it makes OpenMDAO being upgraded to v2.9.1 if needed