### PR TITLE
Added MANIFEST.in file for non-code files fixing issue #95

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 recursive-include src/fastoad *.toml
+recursive-include src/fastoad *.xml
 recursive-include src/fastoad *.txt
 recursive-include src/fastoad *.dat
 recursive-include src/fastoad *.png


### PR DESCRIPTION
Non-code files can in some cases ignored by the setup process. The method to solved the problem was taken from [Adding Non-Code Files](https://python-packaging.readthedocs.io/en/latest/non-code-files.html).

I tested `pip install git+https://github.com/fast-aircraft-design/FAST-OAD.git@issue-95_fix-pip_non_code_files` and it is working perfectly.