### PR TITLE
Issue 124 link payload to npax

### DIFF
--- a/src/fastoad/modules/options.py
+++ b/src/fastoad/modules/options.py
@@ -21,7 +21,7 @@ ENGINE_LOCATION_OPTION = 'engine_location'
 TAIL_TYPE_OPTION = 'tail_type'
 AIRCRAFT_TYPE_OPTION = 'ac_type'
 CABIN_SIZING_OPTION = 'cabin_sizing'
-
+PAYLOAD_FROM_NPAX = 'payload_from_npax'
 
 class OpenMdaoOptionDispatcherGroup(om.Group):
     """

--- a/src/fastoad/modules/weight/mass_breakdown/mass_breakdown.py
+++ b/src/fastoad/modules/weight/mass_breakdown/mass_breakdown.py
@@ -17,7 +17,7 @@ Main components for mass breakdown
 import openmdao.api as om
 
 from fastoad.modules.options import OpenMdaoOptionDispatcherGroup, ENGINE_LOCATION_OPTION, \
-    TAIL_TYPE_OPTION, AIRCRAFT_TYPE_OPTION
+    TAIL_TYPE_OPTION, AIRCRAFT_TYPE_OPTION, PAYLOAD_FROM_NPAX
 from fastoad.modules.weight.mass_breakdown.a_airframe import WingWeight, FuselageWeight, \
     EmpennageWeight, FlightControlsWeight, LandingGearWeight, PylonsWeight, PaintWeight
 from fastoad.modules.weight.mass_breakdown.b_propulsion import EngineWeight, FuelLinesWeight, \
@@ -29,6 +29,7 @@ from fastoad.modules.weight.mass_breakdown.cs25 import Loads
 from fastoad.modules.weight.mass_breakdown.d_furniture import CargoConfigurationWeight, \
     PassengerSeatsWeight, FoodWaterWeight, SecurityKitWeight, ToiletsWeight
 from fastoad.modules.weight.mass_breakdown.e_crew import CrewWeight
+from fastoad.modules.weight.mass_breakdown.payload import ComputePayload
 from fastoad.modules.weight.mass_breakdown.update_mlw_and_mzfw import UpdateMLWandMZFW
 
 
@@ -43,14 +44,21 @@ class MassBreakdown(OpenMdaoOptionDispatcherGroup):
     This model cycles for having consistent OWE, MZFW and MLW.
     Consistency with MTOW can be achieved by cycling with a model that computes MTOW from OWE,
     which should come from a mission computation that will assess needed block fuel.
+
+    Options:
+    - payload_from_npax: If True (default), payload masses will be computed from NPAX, if False
+                         design payload mass and maximum payload mass must be provided.
     """
 
     def initialize(self):
         self.options.declare(ENGINE_LOCATION_OPTION, types=float, default=1.0)
         self.options.declare(TAIL_TYPE_OPTION, types=float, default=0.)
         self.options.declare(AIRCRAFT_TYPE_OPTION, types=float, default=2.0)
+        self.options.declare(PAYLOAD_FROM_NPAX, types=bool, default=True)
 
     def setup(self):
+        if self.options[PAYLOAD_FROM_NPAX]:
+            self.add_subsystem('payload', ComputePayload(), promotes=['*'])
         self.add_subsystem('owe', OperatingWeightEmpty(), promotes=['*'])
         self.add_subsystem('update_mzfw_and_mlw', UpdateMLWandMZFW(), promotes=['*'])
 

--- a/src/fastoad/modules/weight/mass_breakdown/payload.py
+++ b/src/fastoad/modules/weight/mass_breakdown/payload.py
@@ -1,0 +1,41 @@
+""" Payload mass computation"""
+
+#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  Copyright (C) 2020  ONERA/ISAE
+#  FAST is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import numpy as np
+from openmdao import api as om
+
+
+class ComputePayload(om.ExplicitComponent):
+    """ Computes payload from NPAX """
+
+    def setup(self):
+        self.add_input('data:TLAR:NPAX', val=np.nan)
+        self.add_input('settings:weight:aircraft:payload:design_mass_per_passenger',
+                       val=90.72, units='kg', desc='Design value of mass per passenger')
+        self.add_input('settings:weight:aircraft:payload:max_mass_per_passenger',
+                       val=130.72, units='kg', desc='Maximum value of mass per passenger')
+
+        self.add_output('data:weight:aircraft:payload', units='kg')
+        self.add_output('data:weight:aircraft:max_payload', units='kg')
+
+        self.declare_partials('*', '*', method='fd')
+
+    def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
+        npax = inputs['data:TLAR:NPAX']
+        mass_per_pax = inputs['settings:weight:aircraft:payload:design_mass_per_passenger']
+        max_mass_per_pax = inputs['settings:weight:aircraft:payload:max_mass_per_passenger']
+
+        outputs['data:weight:aircraft:payload'] = npax * mass_per_pax
+        outputs['data:weight:aircraft:max_payload'] = npax * max_mass_per_pax

--- a/src/fastoad/openmdao/resources/variable_descriptions.txt
+++ b/src/fastoad/openmdao/resources/variable_descriptions.txt
@@ -289,7 +289,7 @@ settings:weight:aircraft:CG:range	distance between front position and aft positi
 data:TLAR:approach_speed	top-level requirement: approach speed
 data:TLAR:cruise_mach	top-level requirement: cruise Mach number
 data:TLAR:max_TOFL	top-level requirement: maximum takeoff field length
-data:TLAR:NPAX	top-level requirement: number of passengers
+data:TLAR:NPAX	top-level requirement: number of passengers, assuming a classic eco/business class repartition
 data:TLAR:range	top-level requirement: design range
 data:weight:aircraft:additional_fuel_capacity	fuel mass capacity of wing that exceeds sizing mission requirement
 data:weight:aircraft:CG:aft:MAC_position	most aft X-position of center of gravity as ratio of mean aerodynamic chord


### PR DESCRIPTION
Solves #124.

Payload is now computed from NPAX, unless the option `payload_from_npax`is set to False for mass breakdown.

Assumptions of weight per passenger are now in settings variables.