### PR TITLE
Refactored variable serializing

### DIFF
--- a/devutils/rename_vars.py
+++ b/devutils/rename_vars.py
@@ -27,8 +27,8 @@ from fastoad.io.xml.exceptions import (
     FastXpathTranslatorXPathError,
     FastXpathTranslatorVariableError,
 )
-from fastoad.io.xml.openmdao_basic_io import BasicVarXpathTranslator
 from fastoad.io.xml.translator import VarXpathTranslator
+from fastoad.io.xml.variable_io_standard import BasicVarXpathTranslator
 
 from tests import root_folder_path
 

--- a/src/fastoad/cmd/api.py
+++ b/src/fastoad/cmd/api.py
@@ -23,14 +23,15 @@ from typing import IO, Union
 
 import openmdao.api as om
 from fastoad.cmd.exceptions import FastFileExistsError
+from fastoad.io import VariableIO
 from fastoad.io.configuration import FASTOADProblem
-from fastoad.io.xml import OMXmlIO, OMLegacy1XmlIO
+from fastoad.io.xml import VariableLegacy1XmlFormatter
 from fastoad.module_management import BundleLoader
 from fastoad.module_management import OpenMDAOSystemRegistry
 from fastoad.openmdao.variables import VariableList
+from fastoad.utils.resource_management.copy import copy_resource
 
 from . import resources
-from ..utils.resource_management.copy import copy_resource
 
 # Logger for this module
 _LOGGER = logging.getLogger(__name__)
@@ -58,6 +59,10 @@ def generate_configuration_file(configuration_file_path: str, overwrite: bool = 
 
     copy_resource(resources, SAMPLE_FILENAME, configuration_file_path)
     _LOGGER.info("Sample configuration written in %s", configuration_file_path)
+
+
+class VariableXmlIO(object):
+    pass
 
 
 def generate_inputs(
@@ -88,9 +93,9 @@ def generate_inputs(
 
     if source_path:
         if source_path_schema == "legacy":
-            source = OMLegacy1XmlIO(source_path)
+            source = VariableIO(source_path, formatter=VariableLegacy1XmlFormatter())
         else:
-            source = OMXmlIO(source_path)
+            source = VariableIO(source_path)
     else:
         source = None
 

--- a/src/fastoad/io/__init__.py
+++ b/src/fastoad/io/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Package for handling input/output streams
 """
@@ -14,3 +13,6 @@ Package for handling input/output streams
 #  GNU General Public License for more details.
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from .formatter import IVariableIOFormatter
+from .variable_io import VariableIO

--- a/src/fastoad/io/configuration/configuration.py
+++ b/src/fastoad/io/configuration/configuration.py
@@ -21,15 +21,15 @@ from copy import deepcopy
 
 import openmdao.api as om
 import toml
-from fastoad.io.configuration.exceptions import (
+from fastoad.io.variable_io import VariableIO
+from fastoad.module_management import OpenMDAOSystemRegistry
+from fastoad.openmdao.variables import VariableList
+
+from .exceptions import (
     FASTConfigurationBaseKeyBuildingError,
     FASTConfigurationBadOpenMDAOInstructionError,
     FASTConfigurationNoProblemDefined,
 )
-from fastoad.io.serialize import OMFileIOSubclass
-from fastoad.io.xml import OMXmlIO
-from fastoad.module_management import OpenMDAOSystemRegistry
-from fastoad.openmdao.variables import VariableList
 
 # Logger for this module
 _LOGGER = logging.getLogger(__name__)
@@ -123,7 +123,7 @@ class FASTOADProblem(om.Problem):
 
         self.build_model()
 
-    def write_needed_inputs(self, input_data: OMFileIOSubclass = None):
+    def write_needed_inputs(self, input_data: VariableIO = None):
         """
         Writes the input file of the problem with unconnected inputs of the configured problem.
 
@@ -141,7 +141,7 @@ class FASTOADProblem(om.Problem):
             if input_data:
                 ref_vars = input_data.read()
                 variables.update(ref_vars)
-            writer = OMXmlIO(self.input_file_path)
+            writer = VariableIO(self.input_file_path)
             writer.write(variables)
 
     def read_inputs(self):
@@ -152,7 +152,7 @@ class FASTOADProblem(om.Problem):
         """
         if self.input_file_path:
             # Reads input file
-            reader = OMXmlIO(self.input_file_path)
+            reader = VariableIO(self.input_file_path)
             ivc = reader.read().to_ivc()
 
             # ivc will be added through add_subsystem, but we must use set_order() to
@@ -176,7 +176,7 @@ class FASTOADProblem(om.Problem):
         Once problem is run, writes all outputs in the configured output file.
         """
         if self.output_file_path:
-            writer = OMXmlIO(self.output_file_path)
+            writer = VariableIO(self.output_file_path)
             variables = VariableList.from_problem(self)
             writer.write(variables)
 

--- a/src/fastoad/io/configuration/tests/test_configuration.py
+++ b/src/fastoad/io/configuration/tests/test_configuration.py
@@ -20,7 +20,7 @@ from shutil import rmtree
 import numpy as np
 import openmdao.api as om
 import pytest
-from fastoad.io.xml import OMXmlIO
+from fastoad.io import VariableIO
 
 from .. import (
     FASTOADProblem,
@@ -88,7 +88,7 @@ def test_problem_definition_with_xml_ref(cleanup):
     problem = FASTOADProblem()
     problem.configure(pth.join(DATA_FOLDER_PATH, "valid_sellar.toml"))
 
-    input_data = OMXmlIO(pth.join(DATA_FOLDER_PATH, "ref_inputs.xml"))
+    input_data = VariableIO(pth.join(DATA_FOLDER_PATH, "ref_inputs.xml"))
 
     problem.write_needed_inputs(input_data)
     problem.read_inputs()
@@ -109,7 +109,7 @@ def test_problem_definition_with_xml_ref_run_optim(cleanup):
     problem = FASTOADProblem()
     problem.configure(pth.join(DATA_FOLDER_PATH, "valid_sellar.toml"))
 
-    input_data = OMXmlIO(pth.join(DATA_FOLDER_PATH, "ref_inputs.xml"))
+    input_data = VariableIO(pth.join(DATA_FOLDER_PATH, "ref_inputs.xml"))
 
     problem.write_needed_inputs(input_data)
 

--- a/src/fastoad/io/formatter.py
+++ b/src/fastoad/io/formatter.py
@@ -1,0 +1,43 @@
+#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  FAST is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from abc import ABC, abstractmethod
+from typing import Union, IO
+
+from fastoad.openmdao.variables import VariableList
+
+
+class IVariableIOFormatter(ABC):
+    """
+    Interface for formatter classes to be used in VariableIO class.
+
+    The file format is defined by the implementation of this interface.
+    """
+
+    @abstractmethod
+    def read_variables(self, data_source: Union[str, IO]) -> VariableList:
+        """
+        Reads variables from provided data source file.
+
+        :param data_source:
+        :return: a list of Variable instance
+        """
+
+    @abstractmethod
+    def write_variables(self, data_source: Union[str, IO], variables: VariableList):
+        """
+        Writes variables to defined data source file.
+
+        :param data_source:
+        :param variables:
+       """

--- a/src/fastoad/io/xml/__init__.py
+++ b/src/fastoad/io/xml/__init__.py
@@ -14,6 +14,6 @@ Package for handling XML files
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from .openmdao_basic_io import OMXmlIO
-from .openmdao_custom_io import OMCustomXmlIO
-from .openmdao_legacy_io import OMLegacy1XmlIO
+from .variable_io_base import VariableXmlBaseFormatter
+from .variable_io_legacy import VariableLegacy1XmlFormatter
+from .variable_io_standard import VariableXmlStandardFormatter

--- a/src/fastoad/io/xml/exceptions.py
+++ b/src/fastoad/io/xml/exceptions.py
@@ -16,12 +16,6 @@
 from fastoad.exceptions import FastError
 
 
-class FastMissingTranslatorError(FastError):
-    """
-    Raised when the 'XPath<->OpenMDAO variable names' translator has not been set
-    """
-
-
 class FastXPathEvalError(FastError):
     """
     Raised when some xpath could not be resolved
@@ -60,13 +54,7 @@ class FastXpathTranslatorXPathError(FastError):
         self.xpath = xpath
 
 
-class FastOMXmlIOBadPathSeparatorError(FastError):
-    """
-    Raised when the defined path separator is incorrect
-    """
-
-
-class FastOMXmlIODuplicateVariableError(FastError):
+class FastXmlFormatterDuplicateVariableError(FastError):
     """
     Raised a variable is defined more than once in a XML file
     """

--- a/src/fastoad/io/xml/tests/test_variable_io_legacy.py
+++ b/src/fastoad/io/xml/tests/test_variable_io_legacy.py
@@ -1,5 +1,5 @@
 """
-Test module for openmdao_legacy_io.py
+Test module for variable_io_legacy.py
 """
 #  This file is part of FAST : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
@@ -20,8 +20,8 @@ from shutil import rmtree
 import pytest
 from numpy.testing import assert_allclose
 
-from .. import OMXmlIO
-from ..openmdao_legacy_io import OMLegacy1XmlIO
+from .. import VariableLegacy1XmlFormatter
+from ... import VariableIO
 
 DATA_FOLDER_PATH = pth.join(pth.dirname(__file__), "data")
 RESULTS_FOLDER_PATH = pth.join(
@@ -41,7 +41,7 @@ def test_legacy1(cleanup):
     # test read ---------------------------------------------------------------
     filename = pth.join(DATA_FOLDER_PATH, "CeRAS01_baseline.xml")
 
-    xml_read = OMLegacy1XmlIO(filename)
+    xml_read = VariableIO(filename, formatter=VariableLegacy1XmlFormatter())
     var_list = xml_read.read()
 
     entry_count = len(var_list)
@@ -59,11 +59,11 @@ def test_legacy1(cleanup):
 
     # test write ---------------------------------------------------------------
     new_filename = pth.join(result_folder, "CeRAS01_baseline.xml")
-    xml_write = OMLegacy1XmlIO(new_filename)
+    xml_write = VariableIO(new_filename, formatter=VariableLegacy1XmlFormatter())
     xml_write.write(var_list)
 
     # check by reading without conversion table
     # -> this will give the actual number of entries in the file
-    xml_check = OMXmlIO(new_filename)
+    xml_check = VariableIO(new_filename)
     check_vars = xml_check.read()
     assert len(check_vars) == entry_count

--- a/src/fastoad/io/xml/variable_io_legacy.py
+++ b/src/fastoad/io/xml/variable_io_legacy.py
@@ -14,7 +14,7 @@ Readers for legacy XML format
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from fastoad.io.xml import OMCustomXmlIO
+from fastoad.io.xml import VariableXmlBaseFormatter
 from fastoad.io.xml.translator import VarXpathTranslator
 from importlib_resources import open_text
 
@@ -23,17 +23,15 @@ from . import resources
 CONVERSION_FILENAME_1 = "legacy1.txt"
 
 
-class OMLegacy1XmlIO(OMCustomXmlIO):
+class VariableLegacy1XmlFormatter(VariableXmlBaseFormatter):
     """
-    Reader for legacy XML format (version "1")
+    Formatter for legacy XML format (version "1")
     """
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self):
         translator = VarXpathTranslator()
-
         with open_text(resources, CONVERSION_FILENAME_1) as translation_table:
             translator.read_translation_table(translation_table)
+        super().__init__(translator)
 
         self.xml_unit_attribute = "unit"
-        self.set_translator(translator)

--- a/src/fastoad/models/aerodynamics/components/tests/test_components.py
+++ b/src/fastoad/models/aerodynamics/components/tests/test_components.py
@@ -18,7 +18,7 @@ test module for modules in aerodynamics/components
 import os.path as pth
 
 import numpy as np
-from fastoad.io.xml import OMXmlIO
+from fastoad.io import VariableIO
 from fastoad.utils.physics import Atmosphere
 from openmdao.core.group import Group
 from openmdao.core.indepvarcomp import IndepVarComp
@@ -37,7 +37,7 @@ from ..oswald import OswaldCoefficient
 
 def get_indep_var_comp(var_names):
     """ Reads required input data and returns an IndepVarcomp() instance"""
-    reader = OMXmlIO(pth.join(pth.dirname(__file__), "data", "aerodynamics_inputs.xml"))
+    reader = VariableIO(pth.join(pth.dirname(__file__), "data", "aerodynamics_inputs.xml"))
     reader.path_separator = ":"
     ivc = reader.read(only=var_names).to_ivc()
     return ivc

--- a/src/fastoad/models/aerodynamics/tests/test_aerodynamics.py
+++ b/src/fastoad/models/aerodynamics/tests/test_aerodynamics.py
@@ -18,7 +18,7 @@ import os.path as pth
 from platform import system
 
 import pytest
-from fastoad.io.xml import OMXmlIO
+from fastoad.io import VariableIO
 from pytest import approx
 
 from tests.testing_utilities import run_system
@@ -32,7 +32,7 @@ xfoil_path = None if system() == "Windows" else get_xfoil_path()
 
 def get_indep_var_comp(var_names):
     """ Reads required input data and returns an IndepVarcomp() instance"""
-    reader = OMXmlIO(pth.join(pth.dirname(__file__), "data", "aerodynamics_inputs.xml"))
+    reader = VariableIO(pth.join(pth.dirname(__file__), "data", "aerodynamics_inputs.xml"))
     reader.path_separator = ":"
     ivc = reader.read(only=var_names).to_ivc()
     return ivc

--- a/src/fastoad/models/geometry/tests/test_aero_center.py
+++ b/src/fastoad/models/geometry/tests/test_aero_center.py
@@ -14,7 +14,7 @@
 import os.path as pth
 
 import pytest
-from fastoad.io.xml import OMXmlIO
+from fastoad.io import VariableIO
 
 from tests.testing_utilities import run_system
 from ..compute_aero_center import ComputeAeroCenter
@@ -26,12 +26,12 @@ RESULTS_FOLDER_PATH = pth.join(
 
 
 @pytest.fixture(scope="module")
-def input_xml() -> OMXmlIO:
+def input_xml() -> VariableIO:
     """
     :return: access to the sample xml data
     """
     # TODO: have more consistency in input data (no need for the whole geometry_inputs_full.xml)
-    return OMXmlIO(pth.join(pth.dirname(__file__), "data", "geometry_inputs_full.xml"))
+    return VariableIO(pth.join(pth.dirname(__file__), "data", "geometry_inputs_full.xml"))
 
 
 def test_compute_aero_center(input_xml):

--- a/src/fastoad/models/geometry/tests/test_geometry_geom_comps.py
+++ b/src/fastoad/models/geometry/tests/test_geometry_geom_comps.py
@@ -17,7 +17,7 @@ Test module for geometry functions of cg components
 import os.path as pth
 
 import pytest
-from fastoad.io.xml import OMXmlIO
+from fastoad.io import VariableIO
 from fastoad.models.weight.cg.cg_components import ComputeHTcg, ComputeVTcg, UpdateMLG
 
 from tests.testing_utilities import run_system
@@ -58,12 +58,12 @@ from ..geom_components.wing.components import (
 
 # pylint: disable=redefined-outer-name  # needed for pytest fixtures
 @pytest.fixture(scope="module")
-def input_xml() -> OMXmlIO:
+def input_xml() -> VariableIO:
     """
     :return: access to the sample xml data
     """
     # TODO: have more consistency in input data (no need for the whole geometry_inputs_full.xml)
-    return OMXmlIO(pth.join(pth.dirname(__file__), "data", "geometry_inputs_full.xml"))
+    return VariableIO(pth.join(pth.dirname(__file__), "data", "geometry_inputs_full.xml"))
 
 
 def test_compute_fuselage_cabin_sizing(input_xml):

--- a/src/fastoad/models/handling_qualities/tests/test_static_margin.py
+++ b/src/fastoad/models/handling_qualities/tests/test_static_margin.py
@@ -15,7 +15,7 @@ import os.path as pth
 
 import openmdao.api as om
 import pytest
-from fastoad.io.xml import OMXmlIO
+from fastoad.io import VariableIO
 
 from tests.testing_utilities import run_system
 from ..compute_static_margin import ComputeStaticMargin
@@ -27,12 +27,12 @@ RESULTS_FOLDER_PATH = pth.join(
 
 
 @pytest.fixture(scope="module")
-def input_xml() -> OMXmlIO:
+def input_xml() -> VariableIO:
     """
     :return: access to the sample xml data
     """
     # TODO: have more consistency in input data (no need for the whole geometry_inputs_full.xml)
-    return OMXmlIO(pth.join(pth.dirname(__file__), "data", "geometry_inputs_full.xml"))
+    return VariableIO(pth.join(pth.dirname(__file__), "data", "geometry_inputs_full.xml"))
 
 
 def test_compute_static_margin(input_xml):

--- a/src/fastoad/models/handling_qualities/tests/test_tail_areas.py
+++ b/src/fastoad/models/handling_qualities/tests/test_tail_areas.py
@@ -14,7 +14,7 @@
 import os.path as pth
 
 import pytest
-from fastoad.io.xml import OMXmlIO
+from fastoad.io import VariableIO
 
 from tests.testing_utilities import run_system
 from ..tail_sizing.compute_ht_area import ComputeHTArea
@@ -25,12 +25,12 @@ DATA_FOLDER_PATH = pth.join(pth.dirname(__file__), "data")
 
 # pylint: disable=redefined-outer-name  # needed for pytest fixtures
 @pytest.fixture(scope="module")
-def input_xml() -> OMXmlIO:
+def input_xml() -> VariableIO:
     """
     :return: access to the sample xml data
     """
     # TODO: have more consistency in input data (no need for the whole geometry_inputs_full.xml)
-    return OMXmlIO(pth.join(DATA_FOLDER_PATH, "hq_inputs.xml"))
+    return VariableIO(pth.join(DATA_FOLDER_PATH, "hq_inputs.xml"))
 
 
 def test_compute_ht_area(input_xml):

--- a/src/fastoad/models/weight/cg/tests/test_geometry_cg_components.py
+++ b/src/fastoad/models/weight/cg/tests/test_geometry_cg_components.py
@@ -17,7 +17,7 @@ Test module for geometry functions of cg components
 import os.path as pth
 
 import pytest
-from fastoad.io.xml import OMXmlIO
+from fastoad.io import VariableIO
 
 from tests.testing_utilities import run_system
 from ..cg import ComputeAircraftCG
@@ -36,12 +36,12 @@ from ..cg_components import ComputeWingCG
 
 # pylint: disable=redefined-outer-name  # needed for pytest fixtures
 @pytest.fixture(scope="module")
-def input_xml() -> OMXmlIO:
+def input_xml() -> VariableIO:
     """
     :return: access to the sample xml data
     """
     # TODO: have more consistency in input data (no need for the whole geometry_inputs_full.xml)
-    return OMXmlIO(pth.join(pth.dirname(__file__), "data", "cg_inputs.xml"))
+    return VariableIO(pth.join(pth.dirname(__file__), "data", "cg_inputs.xml"))
 
 
 def test_compute_cg_control_surfaces(input_xml):

--- a/src/fastoad/models/weight/mass_breakdown/tests/test_mass_breakdown.py
+++ b/src/fastoad/models/weight/mass_breakdown/tests/test_mass_breakdown.py
@@ -19,7 +19,7 @@ import os.path as pth
 
 import openmdao.api as om
 import pytest
-from fastoad.io.xml.openmdao_basic_io import OMXmlIO
+from fastoad.io import VariableIO
 
 from tests.testing_utilities import run_system
 from ..a_airframe import (
@@ -55,7 +55,7 @@ from ..payload import ComputePayload
 
 def get_indep_var_comp(var_names):
     """ Reads required input data and returns an IndepVarcomp() instance"""
-    reader = OMXmlIO(pth.join(pth.dirname(__file__), "data", "mass_breakdown_inputs.xml"))
+    reader = VariableIO(pth.join(pth.dirname(__file__), "data", "mass_breakdown_inputs.xml"))
     reader.path_separator = ":"
     ivc = reader.read(only=var_names).to_ivc()
     return ivc
@@ -587,7 +587,7 @@ def test_evaluate_oew():
     """
     Tests a simple evaluation of Operating Empty Weight from sample XML data.
     """
-    reader = OMXmlIO(pth.join(pth.dirname(__file__), "data", "mass_breakdown_inputs.xml"))
+    reader = VariableIO(pth.join(pth.dirname(__file__), "data", "mass_breakdown_inputs.xml"))
     reader.path_separator = ":"
     input_vars = reader.read().to_ivc()
 
@@ -602,7 +602,7 @@ def test_loop_compute_oew():
     Tests a weight computation loop using matching the max payload criterion.
     """
     # With payload from npax
-    reader = OMXmlIO(pth.join(pth.dirname(__file__), "data", "mass_breakdown_inputs.xml"))
+    reader = VariableIO(pth.join(pth.dirname(__file__), "data", "mass_breakdown_inputs.xml"))
     reader.path_separator = ":"
     input_vars = reader.read(
         ignore=[
@@ -616,7 +616,7 @@ def test_loop_compute_oew():
     assert oew == pytest.approx(41591, abs=1)
 
     # with payload as input
-    reader = OMXmlIO(pth.join(pth.dirname(__file__), "data", "mass_breakdown_inputs.xml"))
+    reader = VariableIO(pth.join(pth.dirname(__file__), "data", "mass_breakdown_inputs.xml"))
     reader.path_separator = ":"
     input_vars = reader.read(
         ignore=["data:weight:aircraft:MLW", "data:weight:aircraft:MZFW",]

--- a/src/fastoad/notebooks/tutorial/01_tutorial.ipynb
+++ b/src/fastoad/notebooks/tutorial/01_tutorial.ipynb
@@ -1922,11 +1922,11 @@
    "outputs": [],
    "source": [
     "import os.path as pth\n",
-    "from fastoad.io.xml import OMXmlIO\n",
+    "from fastoad.io import VariableIO\n",
     "from fastoad.utils.postprocessing import VariableViewer\n",
     "RESULTS_FOLDER_PATH = 'workdir'\n",
     "RESULT_FILE = pth.join(RESULTS_FOLDER_PATH, 'problem_outputs.xml')\n",
-    "result_xml = OMXmlIO(RESULT_FILE)"
+    "result_xml = VariableIO(RESULT_FILE)"
    ]
   },
   {

--- a/src/fastoad/notebooks/tutorial/02_postprocessing.ipynb
+++ b/src/fastoad/notebooks/tutorial/02_postprocessing.ipynb
@@ -25,7 +25,7 @@
    ],
    "source": [
     "import os.path as pth\n",
-    "from fastoad.io.xml import OMXmlIO\n",
+    "from fastoad.io import VariableIO\n",
     "from fastoad.utils.postprocessing.analysis_and_plots import wing_geometry_plot, \\\n",
     "drag_polar_plot, mass_breakdown_sun_plot, aircraft_geometry_plot, mass_breakdown_bar_plot"
    ]
@@ -42,8 +42,8 @@
     "REF_FILE = pth.join(DATA_FOLDER_PATH, 'CeRAS01_baseline.xml')\n",
     "RESULT_FILE = pth.join(RESULTS_FOLDER_PATH, 'problem_outputs.xml')\n",
     "\n",
-    "ref_xml = OMXmlIO(REF_FILE)\n",
-    "result_xml = OMXmlIO(RESULT_FILE)"
+    "ref_xml = VariableIO(REF_FILE)\n",
+    "result_xml = VariableIO(RESULT_FILE)"
    ]
   },
   {

--- a/src/fastoad/utils/postprocessing/analysis_and_plots.py
+++ b/src/fastoad/utils/postprocessing/analysis_and_plots.py
@@ -16,13 +16,13 @@ Defines the analysis and plotting functions for postprocessing
 import numpy as np
 import plotly
 import plotly.graph_objects as go
-from fastoad.io.xml import OMXmlIO
+from fastoad.io import VariableIO
 from plotly.subplots import make_subplots
 
 COLS = plotly.colors.DEFAULT_PLOTLY_COLORS
 
 
-def wing_geometry_plot(aircraft_xml: OMXmlIO, name=None, fig=None) -> go.FigureWidget:
+def wing_geometry_plot(aircraft_xml: VariableIO, name=None, fig=None) -> go.FigureWidget:
     """
     Returns a figure plot of the top view of the wing.
     Different designs can be superposed by providing an existing fig.
@@ -87,7 +87,7 @@ def wing_geometry_plot(aircraft_xml: OMXmlIO, name=None, fig=None) -> go.FigureW
 
 
 # pylint: disable-msg=too-many-locals
-def aircraft_geometry_plot(aircraft_xml: OMXmlIO, name=None, fig=None) -> go.FigureWidget:
+def aircraft_geometry_plot(aircraft_xml: VariableIO, name=None, fig=None) -> go.FigureWidget:
     """
     Returns a figure plot of the top view of the wing.
     Different designs can be superposed by providing an existing fig.
@@ -210,7 +210,7 @@ def aircraft_geometry_plot(aircraft_xml: OMXmlIO, name=None, fig=None) -> go.Fig
     return fig
 
 
-def drag_polar_plot(aircraft_xml: OMXmlIO, name=None, fig=None) -> go.FigureWidget:
+def drag_polar_plot(aircraft_xml: VariableIO, name=None, fig=None) -> go.FigureWidget:
     """
     Returns a figure plot of the aircraft drag polar.
     Different designs can be superposed by providing an existing fig.
@@ -249,7 +249,7 @@ def drag_polar_plot(aircraft_xml: OMXmlIO, name=None, fig=None) -> go.FigureWidg
 
 
 # pylint: disable-msg=too-many-locals
-def mass_breakdown_bar_plot(aircraft_xml: OMXmlIO, name=None, fig=None) -> go.FigureWidget:
+def mass_breakdown_bar_plot(aircraft_xml: VariableIO, name=None, fig=None) -> go.FigureWidget:
     """
     Returns a figure plot of the aircraft mass breakdown using bar plots.
     Different designs can be superposed by providing an existing fig.
@@ -308,10 +308,7 @@ def mass_breakdown_bar_plot(aircraft_xml: OMXmlIO, name=None, fig=None) -> go.Fi
     return fig
 
 
-# pylint: disable-msg=too-many-locals
-# pylint: disable-msg=too-many-statements
-# pylint: disable=invalid-name # that's a common naming
-def mass_breakdown_sun_plot(aircraft_xml: OMXmlIO):
+def mass_breakdown_sun_plot(aircraft_xml: VariableIO):
     """
     Returns a figure sunburst plot of the mass breakdown.
     On the left a MTOW sunburst and on the right a OWE sunburst.

--- a/src/fastoad/utils/postprocessing/tests/test_analysis_and_plots.py
+++ b/src/fastoad/utils/postprocessing/tests/test_analysis_and_plots.py
@@ -16,7 +16,7 @@ Tests for analysis and plots functions
 
 import os.path as pth
 
-from fastoad.io.xml import OMXmlIO
+from fastoad.io import VariableIO
 from fastoad.utils.postprocessing.analysis_and_plots import (
     wing_geometry_plot,
     drag_polar_plot,
@@ -35,7 +35,7 @@ def test_wing_geometry_plot():
 
     filename = pth.join(DATA_FOLDER_PATH, "problem_outputs.xml")
 
-    xml = OMXmlIO(filename)
+    xml = VariableIO(filename)
 
     # First plot
     # This is a rudimentary test as plot are difficult to verify
@@ -60,7 +60,7 @@ def test_aircraft_geometry_plot():
 
     filename = pth.join(DATA_FOLDER_PATH, "problem_outputs.xml")
 
-    xml = OMXmlIO(filename)
+    xml = VariableIO(filename)
 
     # First plot
     # This is a rudimentary test as plot are difficult to verify
@@ -85,7 +85,7 @@ def test_mass_breakdown_bar_plot():
 
     filename = pth.join(DATA_FOLDER_PATH, "problem_outputs.xml")
 
-    xml = OMXmlIO(filename)
+    xml = VariableIO(filename)
 
     # First plot
     # This is a rudimentary test as plot are difficult to verify
@@ -110,7 +110,7 @@ def test_drag_polar_plot():
 
     filename = pth.join(DATA_FOLDER_PATH, "problem_outputs.xml")
 
-    xml = OMXmlIO(filename)
+    xml = VariableIO(filename)
 
     # First plot
     # This is a rudimentary test as plot are difficult to verify
@@ -125,7 +125,7 @@ def test_mass_breakdown_sun_plot():
 
     filename = pth.join(DATA_FOLDER_PATH, "problem_outputs.xml")
 
-    xml = OMXmlIO(filename)
+    xml = VariableIO(filename)
 
     # First plot
     # This is a rudimentary test as plot are difficult to verify

--- a/src/fastoad/utils/postprocessing/tests/test_variable_viewer.py
+++ b/src/fastoad/utils/postprocessing/tests/test_variable_viewer.py
@@ -17,9 +17,10 @@ Tests for FAST-OAD dataframe
 import os.path as pth
 
 import pandas as pd
-from fastoad.io.xml import OMXmlIO
-from fastoad.utils.postprocessing import VariableViewer
+from fastoad.io import VariableIO
 from pandas.util.testing import assert_frame_equal
+
+from .. import VariableViewer
 
 DATA_FOLDER_PATH = pth.join(pth.dirname(__file__), "data")
 RESULTS_FOLDER_PATH = pth.join(pth.dirname(__file__), "results")
@@ -31,7 +32,7 @@ def test_variable_reader_display():
     """
     filename = pth.join(DATA_FOLDER_PATH, "problem_outputs.xml")
 
-    xml = OMXmlIO(filename)
+    xml = VariableIO(filename)
 
     # pylint: disable=invalid-name # that's a common naming
     df = VariableViewer()
@@ -97,7 +98,7 @@ def test_variable_reader_load():
 
     filename = pth.join(DATA_FOLDER_PATH, "light_data.xml")
 
-    xml = OMXmlIO(filename)
+    xml = VariableIO(filename)
 
     # Testing file to df
     variable_viewer = VariableViewer()
@@ -161,7 +162,7 @@ def test_variable_reader_save():
 
     filename = pth.join(RESULTS_FOLDER_PATH, "light_data.xml")
 
-    xml = OMXmlIO(filename)
+    xml = VariableIO(filename)
 
     # Testing file to df
     variable_viewer = VariableViewer()

--- a/src/fastoad/utils/postprocessing/variable_viewer.py
+++ b/src/fastoad/utils/postprocessing/variable_viewer.py
@@ -20,7 +20,7 @@ import ipysheet as sh
 import ipywidgets as widgets
 import pandas as pd
 from IPython.display import display, clear_output
-from fastoad.io.serialize import AbstractOMFileIO
+from fastoad.io import VariableIO
 from fastoad.openmdao.variables import VariableList
 
 pd.set_option("display.max_rows", None)
@@ -65,7 +65,7 @@ class VariableViewer:
         # A tag used to select all submodules
         self.all_tag = "--ALL--"
 
-    def load(self, file: AbstractOMFileIO = None):
+    def load(self, file: VariableIO = None):
         """
         Loads the file file and stores it in a dataframe.
 
@@ -78,7 +78,7 @@ class VariableViewer:
         self.dataframe = self._file_to_df(file)
         self.dataframe = self.dataframe.reset_index(drop=True)
 
-    def save(self, file: AbstractOMFileIO = None):
+    def save(self, file: VariableIO = None):
         """
         Save the dataframe to the file file.
 
@@ -97,7 +97,7 @@ class VariableViewer:
         return self._render_sheet()
 
     @staticmethod
-    def _file_to_df(file: AbstractOMFileIO) -> pd.DataFrame:
+    def _file_to_df(file: VariableIO) -> pd.DataFrame:
         """
         Returns the equivalent pandas dataframe of the file.
 
@@ -109,7 +109,7 @@ class VariableViewer:
 
     # pylint: disable=invalid-name # that's a common naming
     @staticmethod
-    def _df_to_file(df: pd.DataFrame, file: AbstractOMFileIO):
+    def _df_to_file(df: pd.DataFrame, file: VariableIO):
         """
         Returns the equivalent file of the pandas dataframe .
 

--- a/tests/integration_tests/oad_process/test_oad_process.py
+++ b/tests/integration_tests/oad_process/test_oad_process.py
@@ -24,8 +24,9 @@ import openmdao.api as om
 import pandas as pd
 import pytest
 from fastoad import api
+from fastoad.io import VariableIO
 from fastoad.io.configuration import FASTOADProblem
-from fastoad.io.xml import OMLegacy1XmlIO
+from fastoad.io.xml import VariableLegacy1XmlFormatter
 from numpy.testing import assert_allclose
 
 from tests import root_folder_path
@@ -50,7 +51,9 @@ def test_oad_process(cleanup):
     problem = FASTOADProblem()
     problem.configure(pth.join(DATA_FOLDER_PATH, "oad_process.toml"))
 
-    ref_input_reader = OMLegacy1XmlIO(pth.join(DATA_FOLDER_PATH, "CeRAS01_baseline.xml"))
+    ref_input_reader = VariableIO(
+        pth.join(DATA_FOLDER_PATH, "CeRAS01_baseline.xml"), formatter=VariableLegacy1XmlFormatter()
+    )
     problem.write_needed_inputs(ref_input_reader)
     problem.read_inputs()
     problem.setup()
@@ -106,7 +109,9 @@ def test_non_regression(cleanup):
         problem.model.aerodynamics.landing._OPTIONS["xfoil_alpha_max"] = 22.0
 
     # Generation and reading of inputs ----------------------------------------
-    ref_input_reader = OMLegacy1XmlIO(pth.join(DATA_FOLDER_PATH, "CeRAS01_legacy.xml"))
+    ref_input_reader = VariableIO(
+        pth.join(DATA_FOLDER_PATH, "CeRAS01_legacy.xml"), formatter=VariableLegacy1XmlFormatter()
+    )
     problem.write_needed_inputs(ref_input_reader)
     problem.read_inputs()
     problem.setup()
@@ -142,7 +147,10 @@ def test_non_regression(cleanup):
         atol=1,
     )
 
-    ref_var_list = OMLegacy1XmlIO(pth.join(DATA_FOLDER_PATH, "CeRAS01_legacy_result.xml")).read()
+    ref_var_list = VariableIO(
+        pth.join(DATA_FOLDER_PATH, "CeRAS01_legacy_result.xml"),
+        formatter=VariableLegacy1XmlFormatter(),
+    ).read()
 
     row_list = []
     for ref_var in ref_var_list:


### PR DESCRIPTION
Design has been changed from inheritance to dependency injection:

  - class VariableIO will always be used for reading/writing variables
  - "formatter" classes will be provided to VariableIO to define the file format.
  - XML formatters are named:
    - VariableXmlBaseFormatter : the versatile formatter that accepts any translator (which is now required at instantiation -> no more need for afterward check)
    - VariableXmlStandardFormatter : the formatter that directly translates variable names into XPath
    - VariableXmlLegacy1Formatter : the legacy format
  - class VariableIO uses VariableXmlBaseFormatter as default one.