### PR TITLE
Xfoil fix

### DIFF
--- a/src/fastoad/models/aerodynamics/aerodynamics_landing.py
+++ b/src/fastoad/models/aerodynamics/aerodynamics_landing.py
@@ -29,19 +29,20 @@ class AerodynamicsLanding(OpenMdaoOptionDispatcherGroup):
     """
     Computes maximum CL of the aircraft in landing conditions.
 
-    Maximum CL without high-lift is computed using XFoil (or provided as input if option use_xfoil
-    is set to False).
-    Contribution of high-lift devices is modelled according to their geometry (span and chord ratio) and
-    their deflection angles.
+    Maximum 2D CL without high-lift is computed using XFoil (or provided as input if option
+    use_xfoil is set to False). 3D CL is deduced using sweep angle.
+
+    Contribution of high-lift devices is modelled according to their geometry (span and chord ratio)
+    and their deflection angles.
 
     Options:
       - use_xfoil:
-         - if True, maximum CL without high-lift aerodynamics:aircraft:landing:CL_max_clean is
-           computed using XFOIL
-         - if False, aerodynamics:aircraft:landing:CL_max_clean must be provided as input (but
+         - if True, maximum 2D CL without high-lift aerodynamics:aircraft:landing:CL_max_clean_2D
+           is computed using XFOIL
+         - if False, aerodynamics:aircraft:landing:CL_max_clean_2D must be provided as input (but
            process is faster)
       - alpha_min, alpha_max:
-         - used if use_xfoil is True. Sets the alpha range that is explored to find maximum CL
+         - used if use_xfoil is True. Sets the alpha range that is explored to find maximum 2D CL
            without high-lift
       - xfoil_exe_path:
          - the path to the XFOIL executable. Needed for non-Windows OS.
@@ -63,8 +64,9 @@ class AerodynamicsLanding(OpenMdaoOptionDispatcherGroup):
             self.add_subsystem(
                 "xfoil_run",
                 XfoilPolar(alpha_start=start, alpha_end=end, iter_limit=iter_limit),
-                promotes=["data:geometry:wing:sweep_25", "data:geometry:wing:thickness_ratio"],
+                promotes=["data:geometry:wing:thickness_ratio"],
             )
+        self.add_subsystem("CL_2D_to_3D", Compute3DMaxCL(), promotes=["*"])
         self.add_subsystem(
             "delta_cl_landing", ComputeDeltaHighLift(landing_flag=True), promotes=["*"]
         )
@@ -74,11 +76,15 @@ class AerodynamicsLanding(OpenMdaoOptionDispatcherGroup):
             self.connect("data:aerodynamics:aircraft:landing:mach", "xfoil_run.xfoil:mach")
             self.connect("data:aerodynamics:aircraft:landing:reynolds", "xfoil_run.xfoil:reynolds")
             self.connect(
-                "xfoil_run.xfoil:CL_max_clean", "data:aerodynamics:aircraft:landing:CL_max_clean"
+                "xfoil_run.xfoil:CL_max_2D", "data:aerodynamics:aircraft:landing:CL_max_clean_2D"
             )
 
 
 class ComputeMachReynolds(om.ExplicitComponent):
+    """
+    Mach and Reynolds computation
+    """
+
     def setup(self):
         self.add_input("data:geometry:wing:MAC:length", val=np.nan, units="m")
         self.add_input("data:TLAR:approach_speed", val=np.nan, units="m/s")
@@ -97,3 +103,24 @@ class ComputeMachReynolds(om.ExplicitComponent):
 
         outputs["data:aerodynamics:aircraft:landing:mach"] = mach
         outputs["data:aerodynamics:aircraft:landing:reynolds"] = reynolds
+
+
+class Compute3DMaxCL(om.ExplicitComponent):
+    """
+    Computes 3D max CL from 2D CL (XFOIL-computed) and sweep angle
+    """
+
+    def setup(self):
+        self.add_input("data:geometry:wing:sweep_25", val=np.nan, units="rad")
+        self.add_input("data:aerodynamics:aircraft:landing:CL_max_clean_2D", val=np.nan)
+
+        self.add_output("data:aerodynamics:aircraft:landing:CL_max_clean")
+
+        self.declare_partials("*", "*", method="fd")
+
+    def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
+        sweep_25 = inputs["data:geometry:wing:sweep_25"]
+        cl_max_2d = inputs["data:aerodynamics:aircraft:landing:CL_max_clean_2D"]
+        outputs["data:aerodynamics:aircraft:landing:CL_max_clean"] = (
+            cl_max_2d * 0.9 * np.cos(sweep_25)
+        )

--- a/src/fastoad/models/aerodynamics/external/xfoil/tests/test_xfoil.py
+++ b/src/fastoad/models/aerodynamics/external/xfoil/tests/test_xfoil.py
@@ -44,37 +44,34 @@ def test_compute():
     ivc = IndepVarComp()
     ivc.add_output("xfoil:reynolds", 18000000)
     ivc.add_output("xfoil:mach", 0.20)
-    ivc.add_output("data:geometry:wing:sweep_25", 25.0)
     ivc.add_output("data:geometry:wing:thickness_ratio", 0.1284)
 
     xfoil_comp = XfoilPolar(
         alpha_start=15.0, alpha_end=25.0, iter_limit=20, xfoil_exe_path=xfoil_path
     )
     problem = run_system(xfoil_comp, ivc)
-    assert problem["xfoil:Cl_max_2D"] == pytest.approx(1.94, 1e-2)
-    assert problem["xfoil:CL_max_clean"] == pytest.approx(1.58, 1e-2)
+    assert problem["xfoil:CL_max_2D"] == pytest.approx(1.94, 1e-2)
     assert not pth.exists(XFOIL_RESULTS)
 
     xfoil_comp = XfoilPolar(
         alpha_start=12.0, alpha_end=20.0, iter_limit=20, xfoil_exe_path=xfoil_path
     )  # will stop before real max CL
     problem = run_system(xfoil_comp, ivc)
-    assert problem["xfoil:Cl_max_2D"] == pytest.approx(1.92, 1e-2)
+    assert problem["xfoil:CL_max_2D"] == pytest.approx(1.92, 1e-2)
     assert not pth.exists(XFOIL_RESULTS)
 
     xfoil_comp = XfoilPolar(
         alpha_start=50.0, alpha_end=55.0, iter_limit=2, xfoil_exe_path=xfoil_path
     )  # will not converge
     problem = run_system(xfoil_comp, ivc)
-    assert problem["xfoil:Cl_max_2D"] == pytest.approx(DEFAULT_2D_CL_MAX, 1e-2)
+    assert problem["xfoil:CL_max_2D"] == pytest.approx(DEFAULT_2D_CL_MAX, 1e-2)
     assert not pth.exists(XFOIL_RESULTS)
 
     xfoil_comp = XfoilPolar(
         iter_limit=20, result_folder_path=XFOIL_RESULTS, xfoil_exe_path=xfoil_path
     )
     problem = run_system(xfoil_comp, ivc)
-    assert problem["xfoil:Cl_max_2D"] == pytest.approx(1.94, 1e-2)
-    assert problem["xfoil:CL_max_clean"] == pytest.approx(1.58, 1e-2)
+    assert problem["xfoil:CL_max_2D"] == pytest.approx(1.94, 1e-2)
     assert pth.exists(XFOIL_RESULTS)
     assert pth.exists(pth.join(XFOIL_RESULTS, "polar_result.txt"))
 
@@ -87,7 +84,6 @@ def test_compute_with_provided_path():
     ivc = IndepVarComp()
     ivc.add_output("xfoil:reynolds", 18000000)
     ivc.add_output("xfoil:mach", 0.20)
-    ivc.add_output("data:geometry:wing:sweep_25", 25.0)
     ivc.add_output("data:geometry:wing:thickness_ratio", 0.1284)
 
     xfoil_comp = XfoilPolar(alpha_start=18.0, alpha_end=21.0, iter_limit=20)
@@ -101,5 +97,4 @@ def test_compute_with_provided_path():
         else pth.join(pth.dirname(__file__), pth.pardir, "xfoil699", "xfoil.exe")
     )
     problem = run_system(xfoil_comp, ivc)
-    assert problem["xfoil:Cl_max_2D"] == pytest.approx(1.94, 1e-2)
-    assert problem["xfoil:CL_max_clean"] == pytest.approx(1.58, 1e-2)
+    assert problem["xfoil:CL_max_2D"] == pytest.approx(1.94, 1e-2)

--- a/src/fastoad/models/aerodynamics/external/xfoil/xfoil_polar.py
+++ b/src/fastoad/models/aerodynamics/external/xfoil/xfoil_polar.py
@@ -56,7 +56,7 @@ _XFOIL_PATH_LIMIT = 64
 
 class XfoilPolar(ExternalCodeComp):
     """
-    Runs a polar computation with XFOIL and returns the max lift coefficient
+    Runs a polar computation with XFOIL and returns the 2D max lift coefficient
     """
 
     _xfoil_output_names = ["alpha", "CL", "CD", "CDp", "CM", "Top_Xtr", "Bot_Xtr"]
@@ -75,11 +75,9 @@ class XfoilPolar(ExternalCodeComp):
 
         self.add_input("xfoil:reynolds", val=np.nan)
         self.add_input("xfoil:mach", val=np.nan)
-        self.add_input("data:geometry:wing:sweep_25", val=np.nan, units="deg")
         self.add_input("data:geometry:wing:thickness_ratio", val=np.nan)
 
-        self.add_output("xfoil:Cl_max_2D")
-        self.add_output("xfoil:CL_max_clean")
+        self.add_output("xfoil:CL_max_2D")
 
         self.declare_partials("*", "*", method="fd")
 
@@ -93,7 +91,6 @@ class XfoilPolar(ExternalCodeComp):
         # Get inputs
         reynolds = inputs["xfoil:reynolds"]
         mach = inputs["xfoil:mach"]
-        sweep_25 = inputs["data:geometry:wing:sweep_25"]
         thickness_ratio = inputs["data:geometry:wing:thickness_ratio"]
 
         # Pre-processing (populating temp directory) -----------------------------------------------
@@ -154,13 +151,7 @@ class XfoilPolar(ExternalCodeComp):
 
         # Post-processing --------------------------------------------------------------------------
         result_array = self._read_polar(tmp_result_file_path)
-        if result_array is not None:
-            cl_max_2d = self._get_max_cl(result_array["alpha"], result_array["CL"])
-        else:
-            cl_max_2d = 1.9
-
-        outputs["xfoil:Cl_max_2D"] = cl_max_2d
-        outputs["xfoil:CL_max_clean"] = cl_max_2d * 0.9 * np.cos(np.radians(sweep_25))
+        outputs["xfoil:CL_max_2D"] = self._get_max_cl(result_array["alpha"], result_array["CL"])
 
         # Getting output files if needed
         if self.options[OPTION_RESULT_FOLDER_PATH] != "":

--- a/src/fastoad/models/aerodynamics/tests/data/aerodynamics_inputs.xml
+++ b/src/fastoad/models/aerodynamics/tests/data/aerodynamics_inputs.xml
@@ -111,7 +111,7 @@
     <aerodynamics>
       <aircraft>
         <landing>
-          <CL_max_clean>1.55<!--maximum lift coefficient in landing conditions without high-lift devices--></CL_max_clean>
+          <CL_max_clean_2D>1.9<!--maximum lift coefficient in landing conditions without high-lift devices--></CL_max_clean_2D>
         </landing>
       </aircraft>
     </aerodynamics>

--- a/src/fastoad/models/aerodynamics/tests/test_aerodynamics.py
+++ b/src/fastoad/models/aerodynamics/tests/test_aerodynamics.py
@@ -85,15 +85,13 @@ def test_aerodynamics_landing_without_xfoil():
         "data:geometry:slat:span_ratio",
         "xfoil:mach",
         "tuning:aerodynamics:aircraft:landing:CL_max:landing_gear_effect:k",
+        "data:aerodynamics:aircraft:landing:CL_max_clean_2D",
     ]
 
-    xfoil_path = None if system() == "Windows" else get_xfoil_path()
-
-    input_list.append("data:aerodynamics:aircraft:landing:CL_max_clean")
     ivc = get_indep_var_comp(input_list)
     problem = run_system(AerodynamicsLanding(use_xfoil=False), ivc)
-    assert problem["data:aerodynamics:aircraft:landing:CL_max_clean"] == approx(1.55, abs=1e-5)
-    assert problem["data:aerodynamics:aircraft:landing:CL_max"] == approx(2.77819, abs=1e-5)
+    assert problem["data:aerodynamics:aircraft:landing:CL_max_clean"] == approx(1.54978, abs=1e-5)
+    assert problem["data:aerodynamics:aircraft:landing:CL_max"] == approx(2.77798, abs=1e-5)
 
 
 def test_aerodynamics_high_speed():

--- a/src/fastoad/notebooks/tutorial/data/CeRAS01_baseline.xml
+++ b/src/fastoad/notebooks/tutorial/data/CeRAS01_baseline.xml
@@ -548,6 +548,7 @@
         <landing>
           <mach>0.19455259748464468<!--considered Mach number for landing phase--></mach>
           <CL_max_clean>1.586002<!--maximum lift coefficient in landing conditions without high-lift devices--></CL_max_clean>
+          <CL_max_clean_2D>1.94</CL_max_clean_2D>
           <CL_max>2.8040043507055152<!--maximum lift coefficient in landing conditions--></CL_max>
           <reynolds>18158331.910758447<!--considered Reynolds number for landing phase--></reynolds>
           <additional_CL_capacity>0.12868945907293527<!--at landing, is equal to (maximum lift coefficient)-(maximum required lift coefficient)--></additional_CL_capacity>


### PR DESCRIPTION
Makes XFOIL computations more robust:
- default settings for polar computation are back to conservative values to ensure maximum success rate
- a default CL value was returned if converged alpha points did not reach 5°, but process was crashing if not point had converged. The default CL value is now returned even if no point converged.
- the conversion from the XFOIL-computed-2D-CL to a 3D-CL was done in the Xfoil component and is now done outside of it. It allows to bypass XFOIL runs while still taking sweep angle into account in CL max landing. By removing one input and one output of the XfoilPolar class, it may also reduce the number of calls of this component by OpenMDAO.

PS: GitHub tests are currently broken, but the test suite runs Ok on my computer ^^'