### PR TITLE
Non regression fix

### DIFF
--- a/src/fastoad/io/xml/resources/legacy1.txt
+++ b/src/fastoad/io/xml/resources/legacy1.txt
@@ -418,6 +418,7 @@ data:geometry:propulsion:fan:length, Aircraft/geometry/propulsion/fan_length
 data:geometry:propulsion:nacelle:y, Aircraft/geometry/propulsion/y_nacell
 data:geometry:landing_gear:height, Aircraft/geometry/LG/LG_height
 data:aerodynamics:aircraft:landing:CL_max_clean, Aircraft/aerodynamics/CZ_max_clean
+data:aerodynamics:aircraft:landing:CL_max_clean_2D, Aircraft/aerodynamics/CZ_max_clean_2D
 data:aerodynamics:aircraft:landing:CL_max, Aircraft/aerodynamics/CZ_max_landing
 data:aerodynamics:aircraft:takeoff:CL0_clean, Aircraft/aerodynamics/Cz_0_AOA
 data:aerodynamics:aircraft:takeoff:CL_alpha, Aircraft/aerodynamics/Cz_alpha_low

--- a/tests/integration_tests/oad_process/data/CeRAS01_legacy.xml
+++ b/tests/integration_tests/oad_process/data/CeRAS01_legacy.xml
@@ -420,6 +420,7 @@
             <CL_alpha_ht>3.46981756498</CL_alpha_ht>
             <CL_alpha_vt>2.54615644328</CL_alpha_vt>
             <CZ_max_clean>1.586002</CZ_max_clean>
+            <CZ_max_clean_2D>1.94</CZ_max_clean_2D>
             <CZ_max_landing>2.8022927874308396</CZ_max_landing>
             <Cz_0_AOA>0.02228</Cz_0_AOA>
             <Cz_alpha_low>4.58079757207</Cz_alpha_low>


### PR DESCRIPTION
Added an input needed for the non-regression test to work on platforms that do not have XFOIL.

Also changed `VariableList.from_problem()` so that non-promoted variables are excluded by default. Otherwise, non-promoted variables get written in XML files using their absolute name.