### PR TITLE
Engine rework

### DIFF
--- a/src/fastoad/models/propulsion/engine.py
+++ b/src/fastoad/models/propulsion/engine.py
@@ -135,18 +135,18 @@ class EngineTable(om.ExplicitComponent, ABC):
         thrust = f(Mach, altitude, thrust rate, flight phase)
     """
 
-    def setup(self):
+    def initialize(self):
         self.options.declare(
-            "mach_min", default=0.0, types=float, desc="Minimum value Mach number ",
+            "mach_min", default=0.0, types=float, desc="Minimum value Mach number "
         )
         self.options.declare(
-            "mach_max", default=1.0, types=float, desc="Maximum value for Mach number ",
+            "mach_max", default=1.0, types=float, desc="Maximum value for Mach number "
         )
         self.options.declare(
-            "mach_step_count", default=100, types=int, desc="Step count for Mach number",
+            "mach_step_count", default=100, types=int, desc="Step count for Mach number"
         )
         self.options.declare(
-            "altitude_min", default=0.0, types=float, desc="Minimum value for altitude in meters",
+            "altitude_min", default=0.0, types=float, desc="Minimum value for altitude in meters"
         )
         self.options.declare(
             "altitude_max",
@@ -155,21 +155,21 @@ class EngineTable(om.ExplicitComponent, ABC):
             desc="Maximum value for altitude in meters",
         )
         self.options.declare(
-            "altitude_step_count", default=100, types=int, desc="Step count for thrust rate",
+            "altitude_step_count", default=100, types=int, desc="Step count for thrust rate"
         )
 
         self.options.declare(
-            "thrust_rate_min", default=0.0, types=float, desc="Minimum value for thrust rate",
+            "thrust_rate_min", default=0.0, types=float, desc="Minimum value for thrust rate"
         )
         self.options.declare(
-            "thrust_rate_max", default=1.0, types=float, desc="Maximum value for thrust rate",
+            "thrust_rate_max", default=1.0, types=float, desc="Maximum value for thrust rate"
         )
         self.options.declare(
-            "thrust_rate_step_count", default=20, types=int, desc="Step count for thrust rate",
+            "thrust_rate_step_count", default=20, types=int, desc="Step count for thrust rate"
         )
-
         self.options.declare("flight_phases", default=[phase for phase in FlightPhase], types=list)
 
+    def setup(self):
         shape = self._get_shape()
         self.add_output("private:propulsion:table:mach", shape=shape[0])
         self.add_output("private:propulsion:table:altitude", shape=shape[1], units="m")

--- a/src/fastoad/models/propulsion/engine.py
+++ b/src/fastoad/models/propulsion/engine.py
@@ -1,6 +1,4 @@
-"""
-Base module for engine models.
-"""
+"""Base module for engine models."""
 
 #  This file is part of FAST : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
@@ -28,7 +26,7 @@ from scipy.interpolate import RegularGridInterpolator
 
 class IEngine(ABC):
     """
-    Interface for Engine models
+    Interface for Engine models.
     """
 
     # pylint: disable=too-few-public-methods  # that is the needed interface
@@ -122,15 +120,18 @@ class OMIEngine(om.ExplicitComponent, ABC):
     @abstractmethod
     def get_engine(inputs) -> IEngine:
         """
+        This method defines the IEngine-derived instance used by the OpenMDAO component.
 
         :param inputs: input parameters that define the engine
-        :return: a :class`IEngineSubclass` instance
+        :return: the engine instance
         """
 
 
 class EngineTable(om.ExplicitComponent, ABC):
     """
-    This class computes engine tables, that is to say 2 4D tables:
+    This class computes engine tables.
+
+    Engine tables are two 4D tables:
 
         Specific Fuel Consumption = f(Mach, altitude, thrust rate, flight phase)
         thrust = f(Mach, altitude, thrust rate, flight phase)
@@ -203,6 +204,7 @@ class EngineTable(om.ExplicitComponent, ABC):
     @abstractmethod
     def get_engine(inputs) -> IEngine:
         """
+        This method defines the engine instance used for generating the table.
 
         :param inputs: input parameters that define the engine
         :return: a :class`IEngineSubclass` instance
@@ -218,7 +220,7 @@ class EngineTable(om.ExplicitComponent, ABC):
         flight_phase: Union[FlightPhase, Sequence[FlightPhase]],
     ):
         """
-        Convenience method for interpolating SFC from SFC table as provided by :meth:`compute`
+        Convenience method for interpolating in SFC table provided by :meth:`compute`.
 
         Note: `mach`, `altitude`, `thrust_rate` and `flight_phase` must have the same size.
 
@@ -243,7 +245,7 @@ class EngineTable(om.ExplicitComponent, ABC):
         flight_phase: Union[FlightPhase, Sequence[FlightPhase]],
     ):
         """
-        Convenience method for interpolating thrust from thrust table as provided by :meth:`compute`
+        Convenience method for interpolating in thrust table provided by :meth:`compute`.
 
         Note: `mach`, `altitude`, `thrust_rate` and `flight_phase` must have the same size.
 
@@ -268,7 +270,7 @@ class EngineTable(om.ExplicitComponent, ABC):
         flight_phase: Union[FlightPhase, Sequence[FlightPhase]],
     ):
         """
-        Convenience method for interpolating values from table as provided by :meth:`compute`
+        Convenience method for interpolating values from tables provided by :meth:`compute`.
 
         Note: `mach`, `altitude`, `thrust_rate` and `flight_phase` must have the same size.
 
@@ -309,7 +311,7 @@ class EngineTable(om.ExplicitComponent, ABC):
     @classmethod
     def add_inputs(cls, me: Component):
         """
-        Convenience method for easily adding inputs in setup() method
+        Convenience method for easily adding inputs in setup() method.
 
         To be used in the setup() method of an OpenMDAO component that will use
         the engine table.

--- a/src/fastoad/models/propulsion/fuel_engine/rubber_engine/openmdao.py
+++ b/src/fastoad/models/propulsion/fuel_engine/rubber_engine/openmdao.py
@@ -16,6 +16,7 @@ OpenMDAO wrapping of RubberEngine
 
 import numpy as np
 from fastoad.models.propulsion import OMIEngine, IEngine
+from fastoad.models.propulsion.engine import EngineTable
 from fastoad.openmdao.validity_checker import ValidityDomainChecker
 
 from .rubber_engine import RubberEngine
@@ -45,6 +46,59 @@ from .rubber_engine import RubberEngine
 class OMRubberEngine(OMIEngine):
     """
     Parametric engine model as OpenMDAO component
+
+    See :class:`RubberEngine` for more information.
+    """
+
+    def setup(self):
+        super().setup()
+        self.add_input("data:propulsion:rubber_engine:bypass_ratio", np.nan)
+        self.add_input("data:propulsion:rubber_engine:overall_pressure_ratio", np.nan)
+        self.add_input("data:propulsion:rubber_engine:turbine_inlet_temperature", np.nan, units="K")
+        self.add_input("data:propulsion:MTO_thrust", np.nan, units="N")
+        self.add_input("data:propulsion:rubber_engine:maximum_mach", np.nan)
+        self.add_input("data:propulsion:rubber_engine:design_altitude", np.nan, units="m")
+        self.add_input(
+            "data:propulsion:rubber_engine:delta_t4_climb",
+            -50,
+            desc="As it is a delta, unit is K or °C, but is not "
+            "specified to avoid OpenMDAO making unwanted conversion",
+        )
+        self.add_input(
+            "data:propulsion:rubber_engine:delta_t4_cruise",
+            -100,
+            desc="As it is a delta, unit is K or °C, but is not "
+            "specified to avoid OpenMDAO making unwanted conversion",
+        )
+
+    @staticmethod
+    def get_engine(inputs) -> IEngine:
+        """
+
+        :param inputs: input parameters that define the engine
+        :return: an :class:`RubberEngine` instance
+        """
+        engine_params = {
+            "bypass_ratio": inputs["data:propulsion:rubber_engine:bypass_ratio"],
+            "overall_pressure_ratio": inputs[
+                "data:propulsion:rubber_engine:overall_pressure_ratio"
+            ],
+            "turbine_inlet_temperature": inputs[
+                "data:propulsion:rubber_engine:turbine_inlet_temperature"
+            ],
+            "maximum_mach": inputs["data:propulsion:rubber_engine:maximum_mach"],
+            "design_altitude": inputs["data:propulsion:rubber_engine:design_altitude"],
+            "delta_t4_climb": inputs["data:propulsion:rubber_engine:delta_t4_climb"],
+            "delta_t4_cruise": inputs["data:propulsion:rubber_engine:delta_t4_cruise"],
+            "mto_thrust": inputs["data:propulsion:MTO_thrust"],
+        }
+
+        return RubberEngine(**engine_params)
+
+
+class RubberEngineTable(EngineTable):
+    """
+    OpenMDAO component for computing engine table from parametric engine model
 
     See :class:`RubberEngine` for more information.
     """

--- a/src/fastoad/models/propulsion/fuel_engine/rubber_engine/openmdao.py
+++ b/src/fastoad/models/propulsion/fuel_engine/rubber_engine/openmdao.py
@@ -15,7 +15,7 @@ OpenMDAO wrapping of RubberEngine
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import numpy as np
-from fastoad.models.propulsion import OMIEngine, IEngineSubclass
+from fastoad.models.propulsion import OMIEngine, IEngine
 from fastoad.openmdao.validity_checker import ValidityDomainChecker
 
 from .rubber_engine import RubberEngine
@@ -71,7 +71,7 @@ class OMRubberEngine(OMIEngine):
         )
 
     @staticmethod
-    def get_engine(inputs) -> IEngineSubclass:
+    def get_engine(inputs) -> IEngine:
         """
 
         :param inputs: input parameters that define the engine

--- a/src/fastoad/models/propulsion/fuel_engine/rubber_engine/rubber_engine.py
+++ b/src/fastoad/models/propulsion/fuel_engine/rubber_engine/rubber_engine.py
@@ -111,18 +111,6 @@ class RubberEngine(IEngine):
         thrust: Optional[Union[float, Sequence]] = None,
     ) -> Tuple[Union[float, Sequence], Union[float, Sequence], Union[float, Sequence]]:
         # pylint: disable=too-many-arguments  # they define the trajectory
-        """
-        see :meth:`fastoad.modules.propulsion.engine.IEngine.compute_flight_points` for more info
-
-
-        :param mach: Mach number
-        :param altitude: (unit=m) altitude w.r.t. to sea level
-        :param phase: flight phase
-        :param use_thrust_rate: tells if thrust_rate or thrust should be used (works element-wise)
-        :param thrust_rate: thrust rate (unit=none)
-        :param thrust: required thrust (unit=N)
-        :return: SFC (in kg/s/N), thrust rate, thrust (in N)
-        """
         return self.compute_flight_points_from_dt4(
             mach, altitude, self._get_delta_t4(phase), use_thrust_rate, thrust_rate, thrust
         )

--- a/src/fastoad/models/propulsion/tests/__init__.py
+++ b/src/fastoad/models/propulsion/tests/__init__.py
@@ -1,6 +1,3 @@
-"""
-Package for propulsion modules
-"""
 #  This file is part of FAST : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
@@ -13,5 +10,3 @@ Package for propulsion modules
 #  GNU General Public License for more details.
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
-from .engine import IEngine, OMIEngine

--- a/src/fastoad/models/propulsion/tests/test_engine.py
+++ b/src/fastoad/models/propulsion/tests/test_engine.py
@@ -1,0 +1,55 @@
+#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  FAST is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from typing import Union, Sequence, Optional, Tuple
+
+import numpy as np
+from fastoad.constants import FlightPhase
+from fastoad.models.propulsion.engine import EngineTable
+
+from tests.testing_utilities import run_system
+from ..engine import IEngine
+
+
+class DummyEngine(IEngine):
+    def compute_flight_points(
+        self,
+        mach: Union[float, Sequence],
+        altitude: Union[float, Sequence],
+        phase: Union[FlightPhase, Sequence],
+        use_thrust_rate: Optional[Union[bool, Sequence]] = None,
+        thrust_rate: Optional[Union[float, Sequence]] = None,
+        thrust: Optional[Union[float, Sequence]] = None,
+    ) -> Tuple[Union[float, Sequence], Union[float, Sequence], Union[float, Sequence]]:
+
+        sfc = altitude + mach
+        thrust = phase.astype(np.float) + thrust_rate
+
+        return sfc, 0.0, thrust
+
+
+def test_EngineTable_DummyEngine():
+    class DummyTable(EngineTable):
+        @staticmethod
+        def get_engine(inputs) -> IEngine:
+            return DummyEngine()
+
+    table = DummyTable()
+    problem = run_system(table, None)
+
+    assert problem["private:propulsion:table:mach"].shape == (101,)
+    assert problem["private:propulsion:table:altitude"].shape == (101,)
+    assert problem["private:propulsion:table:thrust_rate"].shape == (21,)
+    assert problem["private:propulsion:table:flight_phase"].shape == (4,)
+    assert problem["private:propulsion:table:SFC"].shape == (101, 101, 21, 4)
+    assert problem["private:propulsion:table:thrust"].shape == (101, 101, 21, 4)

--- a/src/fastoad/models/propulsion/tests/test_engine.py
+++ b/src/fastoad/models/propulsion/tests/test_engine.py
@@ -49,57 +49,24 @@ def test_EngineTable_DummyEngine():
     table = DummyTable()
     problem = run_system(table, None)
 
-    assert problem["private:propulsion:table:mach"].shape == (101,)
-    assert problem["private:propulsion:table:altitude"].shape == (101,)
-    assert problem["private:propulsion:table:thrust_rate"].shape == (21,)
-    assert problem["private:propulsion:table:flight_phase"].shape == (4,)
-    assert problem["private:propulsion:table:SFC"].shape == (101, 101, 21, 4)
-    assert problem["private:propulsion:table:thrust"].shape == (101, 101, 21, 4)
-
-    # now with custom table shape
-    nb_mach_step = 20
-    nb_altitude_step = 15
-    nb_thrust_rate_step = 42
-    flight_phases = [FlightPhase.CRUISE, FlightPhase.CLIMB]
-    min_mach, max_mach = 0.2, 0.8
-    min_altitude, max_altitude = 1000.0, 10000.0
-    min_thrust_rate, max_thrust_rate = 0.3, 0.9
-
-    table = DummyTable(
-        mach_step_count=nb_mach_step,
-        altitude_step_count=nb_altitude_step,
-        thrust_rate_step_count=nb_thrust_rate_step,
-        flight_phases=flight_phases,
-        mach_min=min_mach,
-        mach_max=max_mach,
-        altitude_min=min_altitude,
-        altitude_max=max_altitude,
-        thrust_rate_min=min_thrust_rate,
-        thrust_rate_max=max_thrust_rate,
+    expected_shape = (
+        EngineTable.MACH_STEP_COUNT + 1,
+        EngineTable.ALTITUDE_STEP_COUNT + 1,
+        EngineTable.THRUST_RATE_STEP_COUNT + 1,
+        len(EngineTable.FLIGHT_PHASES),
     )
-    problem = run_system(table, None)
+    assert problem["private:propulsion:table:mach"].shape == (expected_shape[0],)
+    assert problem["private:propulsion:table:altitude"].shape == (expected_shape[1],)
+    assert problem["private:propulsion:table:thrust_rate"].shape == (expected_shape[2],)
+    assert problem["private:propulsion:table:flight_phase"].shape == (expected_shape[3],)
+    assert problem["private:propulsion:table:SFC"].shape == expected_shape
+    assert problem["private:propulsion:table:thrust"].shape == expected_shape
 
-    assert problem["private:propulsion:table:mach"].shape == (nb_mach_step + 1,)
-    assert problem["private:propulsion:table:altitude"].shape == (nb_altitude_step + 1,)
-    assert problem["private:propulsion:table:thrust_rate"].shape == (nb_thrust_rate_step + 1,)
-    assert problem["private:propulsion:table:flight_phase"].shape == (2,)
-    assert problem["private:propulsion:table:SFC"].shape == (
-        nb_mach_step + 1,
-        nb_altitude_step + 1,
-        nb_thrust_rate_step + 1,
-        2,
-    )
-    assert problem["private:propulsion:table:thrust"].shape == (
-        nb_mach_step + 1,
-        nb_altitude_step + 1,
-        nb_thrust_rate_step + 1,
-        2,
-    )
-
-    for i in range(nb_mach_step + 1):
-        for j in range(nb_altitude_step + 1):
-            for k in range(nb_thrust_rate_step + 1):
-                for l in range(2):
+    # Simple iterative check. Some elements are skipped for speeding up the test.
+    for i in range(0, expected_shape[0], 5):
+        for j in range(0, expected_shape[1], 5):
+            for k in range(0, expected_shape[2], 2):
+                for l in range(expected_shape[3]):
                     assert (
                         problem["private:propulsion:table:SFC"][i, j, k, l]
                         == problem["private:propulsion:table:altitude"][j]

--- a/src/fastoad/register.py
+++ b/src/fastoad/register.py
@@ -23,6 +23,7 @@ from fastoad.models.handling_qualities.tail_sizing.compute_tail_areas import Com
 from fastoad.models.loops.compute_wing_area import ComputeWingArea
 from fastoad.models.performances import BreguetFromOWE
 from fastoad.models.propulsion.fuel_engine.rubber_engine import OMRubberEngine
+from fastoad.models.propulsion.fuel_engine.rubber_engine.openmdao import RubberEngineTable
 from fastoad.models.weight.weight import Weight
 from fastoad.module_management import OpenMDAOSystemRegistry
 from fastoad.module_management.constants import ModelDomain
@@ -87,6 +88,13 @@ def register_openmdao_systems():
     OpenMDAOSystemRegistry.register_system(
         OMRubberEngine,
         "fastoad.propulsion.rubber_engine",
+        domain=ModelDomain.PROPULSION,
+        desc=rubber_engine_description,
+    )
+
+    OpenMDAOSystemRegistry.register_system(
+        RubberEngineTable,
+        "fastoad.propulsion.rubber_engine.table",
         domain=ModelDomain.PROPULSION,
         desc=rubber_engine_description,
     )

--- a/tests/testing_utilities.py
+++ b/tests/testing_utilities.py
@@ -25,12 +25,16 @@ _LOGGER = logging.getLogger(__name__)
 
 
 def run_system(
-    component: SystemSubclass, input_vars: om.IndepVarComp, setup_mode="auto", add_solvers=False
+    component: SystemSubclass,
+    input_vars: om.IndepVarComp = None,
+    setup_mode="auto",
+    add_solvers=False,
 ):
     """ Runs and returns an OpenMDAO problem with provided component and data"""
     problem = om.Problem()
     model = problem.model
-    model.add_subsystem("inputs", input_vars, promotes=["*"])
+    if input_vars:
+        model.add_subsystem("inputs", input_vars, promotes=["*"])
     model.add_subsystem("component", component, promotes=["*"])
     if add_solvers:
         model.nonlinear_solver = om.NewtonSolver()


### PR DESCRIPTION
This PR reworks the engine model definition for preparing the upcoming development of a time-dependent performance module.

The engine module will output SFC and thrust as tables, so any component that need them will just interpolate in provided tables.