### PR TITLE
Engine rework

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/cache@v2
         if: startsWith(runner.os, 'macOS')
         with:
-          path: ~/Library/Caches/pypoetry
+          path: /Users/runner/Library/Caches/pypoetry
           key: ${{ runner.os }}-Py${{ matrix.python-version }}-pypoetry-${{ hashFiles('**/poetry.lock') }}
           restore-keys: |
             ${{ runner.os }}-Py${{ matrix.python-version }}-pypoetry-

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -153,6 +153,8 @@ pygments_style = "sphinx"
 # If true, keep warnings as "system message" paragraphs in the built documents.
 # keep_warnings = False
 
+# Use docstring from class and __init__
+autoclass_content = "both"
 
 # -- Options for HTML output ---------------------------------------------------
 

--- a/src/fastoad/cmd/resources/fastoad.toml
+++ b/src/fastoad/cmd/resources/fastoad.toml
@@ -30,7 +30,7 @@ driver = "om.ScipyOptimizeDriver(tol=1e-6, optimizer='COBYLA')"
         use_xfoil = false
     [model.performance]
         id = "fastoad.performances.breguet"
-        embed_propulsion = true
+        propulsion_id = "fastoad.wrapper.propulsion.rubber_engine"
     [model.hq.tail_sizing]
         id = "fastoad.handling_qualities.tail_sizing"
     [model.hq.static_margin]

--- a/src/fastoad/cmd/resources/fastoad.toml
+++ b/src/fastoad/cmd/resources/fastoad.toml
@@ -30,8 +30,7 @@ driver = "om.ScipyOptimizeDriver(tol=1e-6, optimizer='COBYLA')"
         use_xfoil = false
     [model.performance]
         id = "fastoad.performances.breguet"
-    [model.propulsion]
-        id = "fastoad.propulsion.rubber_engine"
+        embed_propulsion = true
     [model.hq.tail_sizing]
         id = "fastoad.handling_qualities.tail_sizing"
     [model.hq.static_margin]

--- a/src/fastoad/exceptions.py
+++ b/src/fastoad/exceptions.py
@@ -38,3 +38,9 @@ class XMLReadError(FastError):
 
     This exception indicates that an error occurred when reading an xml file.
     """
+
+
+class FastUnknownFlightPhaseError(FastError):
+    """
+    Raised when an unknown flight phase code has been encountered
+    """

--- a/src/fastoad/models/performances/breguet.py
+++ b/src/fastoad/models/performances/breguet.py
@@ -17,7 +17,7 @@ Simple module for performances
 import numpy as np
 import openmdao.api as om
 from fastoad.constants import FlightPhase
-from fastoad.models.propulsion.fuel_engine.rubber_engine.openmdao import DirectRubberEngine
+from fastoad.models.propulsion.fuel_engine.rubber_engine.openmdao import OMRubberEngineWrapper
 from fastoad.utils.physics import Atmosphere
 from scipy.constants import g
 
@@ -99,7 +99,7 @@ class _Consumption(om.ExplicitComponent):
 
 class _BreguetEngine(om.ExplicitComponent):
     def initialize(self):
-        self._engine = DirectRubberEngine()
+        self._engine = OMRubberEngineWrapper()
 
     def setup(self):
         self._engine.setup(self)

--- a/src/fastoad/models/performances/breguet.py
+++ b/src/fastoad/models/performances/breguet.py
@@ -142,7 +142,6 @@ class _BreguetEngine(om.ExplicitComponent):
             inputs["data:TLAR:cruise_mach"],
             inputs["data:mission:sizing:cruise:altitude"],
             FlightPhase.CRUISE,
-            False,
             thrust=thrust,
         )
         outputs["data:propulsion:thrust"] = thrust

--- a/src/fastoad/models/performances/breguet.py
+++ b/src/fastoad/models/performances/breguet.py
@@ -1,6 +1,4 @@
-"""
-Simple module for performances
-"""
+"""Simple module for performances."""
 #  This file is part of FAST : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
@@ -29,13 +27,14 @@ CLIMB_DESCENT_DISTANCE = 500  # in km, distance of climb + descent
 
 class BreguetFromMTOW(om.Group):
     """
-    Estimation of fuel consumption through Breguet formula with a rough estimate
-    of climb and descent phases.
+    Estimation of fuel consumption through Breguet formula.
+
+    It uses a rough estimate of climb and descent phases.
 
     MTOW (Max TakeOff Weight) being an input, the model computes the ZFW (Zero Fuel
     Weight) considering that all fuel but the reserve has been consumed during the
     mission.
-    This model does not ensure consistency with OWE (Operating Empty Weight)
+    This model does not ensure consistency with OWE (Operating Empty Weight).
     """
 
     def initialize(self):
@@ -60,8 +59,9 @@ class BreguetFromMTOW(om.Group):
 
 class BreguetFromOWE(BreguetFromMTOW):
     """
-    Estimation of fuel consumption through Breguet formula with a rough estimate
-    of climb and descent phases.
+    Estimation of fuel consumption through Breguet formula.
+
+    It uses a rough estimate of climb and descent phases.
 
     For the sizing mission, the Breguet formula links MTOW (Max TakeOff Weight) to
     ZFW (Zero Fuel Weight).
@@ -110,6 +110,9 @@ class _Consumption(om.ExplicitComponent):
 
 class _BreguetEngine(om.ExplicitComponent):
     def __init__(self, **kwargs):
+        """
+        Computes thrust, SFC and thrust rate by direct call to engine model.
+        """
         super().__init__(**kwargs)
         self._engine_wrapper = BundleLoader().instantiate_component(self.options["propulsion_id"])
 
@@ -151,7 +154,7 @@ class _BreguetEngine(om.ExplicitComponent):
 
 class _BreguetPropulsion(om.ExplicitComponent):
     """
-    Link with engine computation
+    Link with engine computation.
     """
 
     def setup(self):
@@ -193,7 +196,7 @@ class _BreguetPropulsion(om.ExplicitComponent):
 class _FuelWeightFromMTOW(om.ExplicitComponent):
     """
     Estimation of fuel consumption through Breguet formula with a rough estimate
-    of climb and descent phases
+    of climb and descent phases.
     """
 
     def setup(self):
@@ -246,7 +249,7 @@ class _FuelWeightFromMTOW(om.ExplicitComponent):
 class _MTOWFromOWE(om.ImplicitComponent):
     """
     Estimation of fuel consumption through Breguet formula with a rough estimate
-    of climb and descent phases
+    of climb and descent phases.
     """
 
     def setup(self):
@@ -281,7 +284,9 @@ class _MTOWFromOWE(om.ImplicitComponent):
 
 
 class _Distances(om.ExplicitComponent):
-    """ Rough estimation of distances for each flight phase"""
+    """
+    Rough estimation of distances for each flight phase.
+    """
 
     def setup(self):
         self.add_input("data:TLAR:range", np.nan, units="m")
@@ -302,7 +307,7 @@ class _Distances(om.ExplicitComponent):
 
 class _CruiseMassRatio(om.ExplicitComponent):
     """
-    Estimation of fuel consumption through Breguet formula for a given cruise distance
+    Estimation of fuel consumption through Breguet formula for a given cruise distance.
     """
 
     def setup(self):

--- a/src/fastoad/models/performances/breguet.py
+++ b/src/fastoad/models/performances/breguet.py
@@ -47,7 +47,7 @@ class BreguetFromMTOW(om.Group):
         self.add_subsystem("consumption", _Consumption(), promotes=["*"])
 
 
-class BreguetFromOWE(om.Group):
+class BreguetFromOWE(BreguetFromMTOW):
     """
     Estimation of fuel consumption through Breguet formula with a rough estimate
     of climb and descent phases.
@@ -59,12 +59,8 @@ class BreguetFromOWE(om.Group):
     """
 
     def setup(self):
-        self.add_subsystem("propulsion", _BreguetPropulsion(), promotes=["*"])
-        self.add_subsystem("distances", _Distances(), promotes=["*"])
-        self.add_subsystem("cruise_mass_ratio", _CruiseMassRatio(), promotes=["*"])
+        super().setup()
         self.add_subsystem("mtow", _MTOWFromOWE(), promotes=["*"])
-        self.add_subsystem("fuel_weights", _FuelWeightFromMTOW(), promotes=["*"])
-        self.add_subsystem("consumption", _Consumption(), promotes=["*"])
 
         self.nonlinear_solver = om.NewtonSolver()
         self.nonlinear_solver.options["iprint"] = 0

--- a/src/fastoad/models/performances/tests/test_breguet.py
+++ b/src/fastoad/models/performances/tests/test_breguet.py
@@ -150,9 +150,6 @@ def test_breguet_from_owe_with_rubber_engine():
     group.add_subsystem("breguet", BreguetFromOWE(), promotes=["*"])
     group.nonlinear_solver = om.NonlinearBlockGS()
     problem = run_system(group, ivc)
-    print(problem["data:propulsion:SFC"])
-    print(problem["data:propulsion:required_thrust"])
-    print(problem["data:mission:sizing:cruise:mass_ratio"])
 
     engine = RubberEngine(5, 30, 1500, 100000, 0.95, 35000 * foot, -50)
     assert_allclose(
@@ -175,12 +172,6 @@ def test_breguet_from_owe_with_rubber_engine():
         BreguetFromOWE(propulsion_id="fastoad.wrapper.propulsion.rubber_engine"), ivc
     )
 
-    print(problem2["data:propulsion:SFC"])
-    print(problem2["data:propulsion:thrust"])
-    print(problem2["data:mission:sizing:cruise:mass_ratio"])
-    print(problem2["data:weight:aircraft:MTOW"])
-    print(problem2["data:mission:sizing:ZFW"])
-    print(problem2["data:mission:sizing:fuel"])
     assert_allclose(
         engine.compute_flight_points(
             0.78, 35000 * foot, FlightPhase.CRUISE, thrust=problem2["data:propulsion:thrust"],

--- a/src/fastoad/models/performances/tests/test_breguet.py
+++ b/src/fastoad/models/performances/tests/test_breguet.py
@@ -98,7 +98,9 @@ def test_breguet_from_mtow_with_rubber_engine():
     assert_allclose(problem["data:mission:sizing:fuel:unitary"], 0.0642, rtol=1e-3)
 
     # With direct call to rubber engine
-    problem2 = run_system(BreguetFromMTOW(embed_propulsion=True), ivc)
+    problem2 = run_system(
+        BreguetFromMTOW(propulsion_id="fastoad.wrapper.propulsion.rubber_engine"), ivc
+    )
 
     assert_allclose(problem2["data:mission:sizing:ZFW"], 65076.0, atol=1)
     assert_allclose(problem2["data:mission:sizing:fuel"], 8924.0, atol=1)
@@ -169,7 +171,9 @@ def test_breguet_from_owe_with_rubber_engine():
     assert_allclose(problem["data:mission:sizing:fuel:unitary"], 0.0642, rtol=1e-3)
 
     # With direct call to rubber engine
-    problem2 = run_system(BreguetFromOWE(embed_propulsion=True), ivc)
+    problem2 = run_system(
+        BreguetFromOWE(propulsion_id="fastoad.wrapper.propulsion.rubber_engine"), ivc
+    )
 
     print(problem2["data:propulsion:SFC"])
     print(problem2["data:propulsion:thrust"])

--- a/src/fastoad/models/performances/tests/test_breguet.py
+++ b/src/fastoad/models/performances/tests/test_breguet.py
@@ -19,7 +19,7 @@ from scipy.constants import foot
 
 from tests.testing_utilities import run_system
 from ..breguet import BreguetFromMTOW, BreguetFromOWE
-from ...propulsion.fuel_engine.rubber_engine import OMRubberEngine
+from ...propulsion.fuel_engine.rubber_engine import OMRubberEngineComponent
 
 
 def test_breguet_from_mtow():
@@ -89,7 +89,7 @@ def test_breguet_from_mtow_with_rubber_engine():
     # With rubber engine OM component
     group = om.Group()
     group.add_subsystem("breguet", BreguetFromMTOW(), promotes=["*"])
-    group.add_subsystem("engine", OMRubberEngine(), promotes=["*"])
+    group.add_subsystem("engine", OMRubberEngineComponent(), promotes=["*"])
     group.nonlinear_solver = om.NonlinearBlockGS()
     problem = run_system(group, ivc)
 
@@ -144,7 +144,7 @@ def test_breguet_from_owe_with_rubber_engine():
     # With rubber engine OM component
     group = om.Group()
 
-    group.add_subsystem("engine", OMRubberEngine(), promotes=["*"])
+    group.add_subsystem("engine", OMRubberEngineComponent(), promotes=["*"])
     group.add_subsystem("breguet", BreguetFromOWE(), promotes=["*"])
     group.nonlinear_solver = om.NonlinearBlockGS()
     problem = run_system(group, ivc)

--- a/src/fastoad/models/propulsion/__init__.py
+++ b/src/fastoad/models/propulsion/__init__.py
@@ -14,4 +14,4 @@ Package for propulsion modules
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from .engine import IEngine, IEngineSubclass, OMIEngine
+from .engine import IEngine, OMIEngine

--- a/src/fastoad/models/propulsion/__init__.py
+++ b/src/fastoad/models/propulsion/__init__.py
@@ -14,4 +14,4 @@ Package for propulsion modules
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from .engine import IEngine, OMIEngine
+from .engine import IEngine, IOMEngineWrapper, BaseOMEngineComponent

--- a/src/fastoad/models/propulsion/engine.py
+++ b/src/fastoad/models/propulsion/engine.py
@@ -72,34 +72,47 @@ class IEngine(ABC):
         """
 
 
-class DirectEngine:
+class IOMEngineWrapper:
     """
-    Base class for OpenMDAO wrapping of subclasses of :class`IEngine`.
+    Interface for wrapping a :class:`IEngine` subclass in OpenMDAO
 
-    Classes that implements this interface should add their own inputs in setup()
-    and implement :meth:`get_engine`.
+    The implementation class defines the needed input variables for instantiating the
+    :class:`IEngine` subclass in :meth:`setup` and use them for instantiation in
+    :meth:`get_engine`
+
+    see :class:`~fastoad.models.propulsion.fuel_engine.rubber_engine.OMRubberEngineWrapper` for
+    an example of implementation.
     """
 
     @abstractmethod
-    def setup(self, comp: Component):
+    def setup(self, component: Component):
         """
+        Defines the needed OpenMDAO inputs for engine instantiation as done in :meth:`get_engine`
 
-        :param comp:
-        :return:
+        Use `add_inputs` and `declare_partials` methods of the provided `component`
+
+        :param component:
         """
 
     @staticmethod
     @abstractmethod
     def get_engine(inputs) -> IEngine:
         """
-        This method defines the engine instance used for generating the table.
+        This method defines the used IEngine subclass instance.
 
-        :param inputs: input parameters that define the engine
-        :return: a :class`IEngineSubclass` instance
+        :param inputs: OpenMDAO input vector where parameters that define the engine are
+        :return: a :class:`IEngineSubclass` instance
         """
 
 
-class OMIEngine(om.ExplicitComponent, ABC):
+class BaseOMEngineComponent(om.ExplicitComponent, ABC):
+    """
+    Base class for OpenMDAO wrapping of subclasses of :class:`IEngineForOpenMDAO`.
+
+    Classes that implements this interface should add their own inputs in setup()
+    and implement :meth:`get_engine`.
+    """
+
     def initialize(self):
         self.options.declare("flight_point_count", 1, types=(int, tuple))
 
@@ -134,9 +147,9 @@ class OMIEngine(om.ExplicitComponent, ABC):
 
     @staticmethod
     @abstractmethod
-    def get_engine() -> DirectEngine:
+    def get_engine() -> IOMEngineWrapper:
         """
-        This method defines the engine instance used for generating the table.
+        This method defines the used :class:`IEngineForOpenMDAO` instance.
 
-        :return: a :class`DirectEngine` instance
+        :return: a :class:`IOMEngineWrapper` instance
         """

--- a/src/fastoad/models/propulsion/engine.py
+++ b/src/fastoad/models/propulsion/engine.py
@@ -1,5 +1,5 @@
 """
-Base module for engine models
+Base module for engine models.
 """
 
 #  This file is part of FAST : A framework for rapid Overall Aircraft Design
@@ -27,12 +27,9 @@ IEngineSubclass = TypeVar("IEngineSubclass", bound="IEngine")
 
 class IEngine(ABC):
     """
-    Interface for Engine models
+    Interface that should be implemented by engine models.
     """
 
-    # pylint: disable=too-few-public-methods  # that is the needed interface
-
-    # pylint: disable=too-many-arguments  # they define the trajectory
     @abstractmethod
     def compute_flight_points(
         self,
@@ -122,6 +119,7 @@ class OMIEngine(om.ExplicitComponent, ABC):
     @abstractmethod
     def get_engine(inputs) -> IEngineSubclass:
         """
+        This method defines the engine instance used for generating the table.
 
         :param inputs: input parameters that define the engine
         :return: a :class`IEngineSubclass` instance

--- a/src/fastoad/models/propulsion/fuel_engine/rubber_engine/__init__.py
+++ b/src/fastoad/models/propulsion/fuel_engine/rubber_engine/__init__.py
@@ -18,5 +18,5 @@ This module provides a parametric model for turbofan:
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from .openmdao import OMRubberEngine
+from .openmdao import OMRubberEngineComponent, OMRubberEngineWrapper
 from .rubber_engine import RubberEngine

--- a/src/fastoad/models/propulsion/fuel_engine/rubber_engine/__init__.py
+++ b/src/fastoad/models/propulsion/fuel_engine/rubber_engine/__init__.py
@@ -1,5 +1,5 @@
 """
-This module provides a parametric model for turbofan:
+Provides a parametric model for turbofan:
 
 - as a pure Python
 - as OpenMDAO modules

--- a/src/fastoad/models/propulsion/fuel_engine/rubber_engine/exceptions.py
+++ b/src/fastoad/models/propulsion/fuel_engine/rubber_engine/exceptions.py
@@ -1,6 +1,4 @@
-"""
-Exceptions for rubber_engine package
-"""
+"""Exceptions for rubber_engine package."""
 
 
 #  This file is part of FAST : A framework for rapid Overall Aircraft Design
@@ -18,4 +16,6 @@ Exceptions for rubber_engine package
 
 
 class FastRubberEngineInconsistentInputParametersError(Exception):
-    """ Raised when provied parameter combination is incorrect """
+    """
+    Raised when provided parameter combination is incorrect.
+    """

--- a/src/fastoad/models/propulsion/fuel_engine/rubber_engine/openmdao.py
+++ b/src/fastoad/models/propulsion/fuel_engine/rubber_engine/openmdao.py
@@ -28,6 +28,48 @@ from .rubber_engine import RubberEngine
 # as an OpenMDAO component with OpenMDAOSystemRegistry.register_system() in fastoad.register
 @RegisterPropulsion("fastoad.wrapper.propulsion.rubber_engine")
 class OMRubberEngineWrapper(IOMEngineWrapper):
+    """
+    Wrapper class for allowing direct call of :class:`~.rubber_engine.RubberEngine` in an
+    OpenMDAO component.
+
+    Example of usage of this class::
+
+        import openmdao.api as om
+
+        class MyComponent(om.ExplicitComponent):
+            def initialize():
+                self._engine_wrapper = OMRubberEngineWrapper()
+
+            def setup():
+                # Adds OpenMDAO variables that define the engine
+                self._engine_wrapper.setup(self)
+
+                # Do the normal setup
+                self.add_input("my_input")
+                [finish the setup...]
+
+            def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
+                [do something]
+
+                # Get the engine instance, with parameters defined from OpenMDAO inputs
+                engine = self._engine_wrapper.get_engine(inputs)
+
+                # Run the engine model. This is a pure Python call. You have to define
+                # its inputs before, and to use its outputs according to your needs
+                sfc, thrust_rate, thrust = engine.compute_flight_points(
+                    mach,
+                    altitude,
+                    flight_phase,
+                    use_thrust_rate,
+                    thrust_rate,
+                    thrust
+                    )
+
+                [do something else]
+
+        )
+    """
+
     def setup(self, component: Component):
         component.add_input("data:propulsion:rubber_engine:bypass_ratio", np.nan)
         component.add_input("data:propulsion:rubber_engine:overall_pressure_ratio", np.nan)

--- a/src/fastoad/models/propulsion/fuel_engine/rubber_engine/openmdao.py
+++ b/src/fastoad/models/propulsion/fuel_engine/rubber_engine/openmdao.py
@@ -1,6 +1,4 @@
-"""
-OpenMDAO wrapping of RubberEngine
-"""
+"""OpenMDAO wrapping of RubberEngine."""
 #  This file is part of FAST : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
@@ -29,8 +27,10 @@ from .rubber_engine import RubberEngine
 @RegisterPropulsion("fastoad.wrapper.propulsion.rubber_engine")
 class OMRubberEngineWrapper(IOMEngineWrapper):
     """
-    Wrapper class for allowing direct call of :class:`~.rubber_engine.RubberEngine` in an
-    OpenMDAO component.
+    Wrapper class of for rubber engine model.
+
+    It is made to allow a direct call to :class:`~.rubber_engine.RubberEngine` in an OpenMDAO
+    component.
 
     Example of usage of this class::
 

--- a/src/fastoad/models/propulsion/fuel_engine/rubber_engine/openmdao.py
+++ b/src/fastoad/models/propulsion/fuel_engine/rubber_engine/openmdao.py
@@ -25,7 +25,6 @@ from .rubber_engine import RubberEngine
 
 class DirectRubberEngine(DirectEngine):
     def setup(self, comp: Component):
-        super().setup(comp)
         comp.add_input("data:propulsion:rubber_engine:bypass_ratio", np.nan)
         comp.add_input("data:propulsion:rubber_engine:overall_pressure_ratio", np.nan)
         comp.add_input("data:propulsion:rubber_engine:turbine_inlet_temperature", np.nan, units="K")
@@ -97,6 +96,10 @@ class OMRubberEngine(OMIEngine):
 
     See :class:`RubberEngine` for more information.
     """
+
+    def setup(self):
+        super().setup()
+        self.get_engine().setup(self)
 
     @staticmethod
     def get_engine() -> DirectEngine:

--- a/src/fastoad/models/propulsion/fuel_engine/rubber_engine/openmdao.py
+++ b/src/fastoad/models/propulsion/fuel_engine/rubber_engine/openmdao.py
@@ -16,15 +16,17 @@ OpenMDAO wrapping of RubberEngine
 
 import numpy as np
 from fastoad.models.propulsion import IOMEngineWrapper, IEngine, BaseOMEngineComponent
+from fastoad.module_management.service_registry import RegisterPropulsion
 from fastoad.openmdao.validity_checker import ValidityDomainChecker
 from openmdao.core.component import Component
-from pelix.ipopo.decorators import ComponentFactory, Provides
 
 from .rubber_engine import RubberEngine
 
 
-@ComponentFactory("fastoad.wrapper.propulsion.rubber_engine")
-@Provides("fastoad.wrapper.propulsion")
+# Note: For the decorator to work, this module must be started as an iPOPO bundle,
+# which is automatically done because OMRubberEngineComponent is currently registered
+# as an OpenMDAO component with OpenMDAOSystemRegistry.register_system() in fastoad.register
+@RegisterPropulsion("fastoad.wrapper.propulsion.rubber_engine")
 class OMRubberEngineWrapper(IOMEngineWrapper):
     def setup(self, component: Component):
         component.add_input("data:propulsion:rubber_engine:bypass_ratio", np.nan)

--- a/src/fastoad/models/propulsion/fuel_engine/rubber_engine/openmdao.py
+++ b/src/fastoad/models/propulsion/fuel_engine/rubber_engine/openmdao.py
@@ -18,10 +18,13 @@ import numpy as np
 from fastoad.models.propulsion import IOMEngineWrapper, IEngine, BaseOMEngineComponent
 from fastoad.openmdao.validity_checker import ValidityDomainChecker
 from openmdao.core.component import Component
+from pelix.ipopo.decorators import ComponentFactory, Provides
 
 from .rubber_engine import RubberEngine
 
 
+@ComponentFactory("fastoad.wrapper.propulsion.rubber_engine")
+@Provides("fastoad.wrapper.propulsion")
 class OMRubberEngineWrapper(IOMEngineWrapper):
     def setup(self, component: Component):
         component.add_input("data:propulsion:rubber_engine:bypass_ratio", np.nan)

--- a/src/fastoad/models/propulsion/fuel_engine/rubber_engine/openmdao.py
+++ b/src/fastoad/models/propulsion/fuel_engine/rubber_engine/openmdao.py
@@ -15,29 +15,30 @@ OpenMDAO wrapping of RubberEngine
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import numpy as np
-from fastoad.models.propulsion import OMIEngine
-from fastoad.models.propulsion.engine import DirectEngine, IEngine
+from fastoad.models.propulsion import IOMEngineWrapper, IEngine, BaseOMEngineComponent
 from fastoad.openmdao.validity_checker import ValidityDomainChecker
 from openmdao.core.component import Component
 
 from .rubber_engine import RubberEngine
 
 
-class DirectRubberEngine(DirectEngine):
-    def setup(self, comp: Component):
-        comp.add_input("data:propulsion:rubber_engine:bypass_ratio", np.nan)
-        comp.add_input("data:propulsion:rubber_engine:overall_pressure_ratio", np.nan)
-        comp.add_input("data:propulsion:rubber_engine:turbine_inlet_temperature", np.nan, units="K")
-        comp.add_input("data:propulsion:MTO_thrust", np.nan, units="N")
-        comp.add_input("data:propulsion:rubber_engine:maximum_mach", np.nan)
-        comp.add_input("data:propulsion:rubber_engine:design_altitude", np.nan, units="m")
-        comp.add_input(
+class OMRubberEngineWrapper(IOMEngineWrapper):
+    def setup(self, component: Component):
+        component.add_input("data:propulsion:rubber_engine:bypass_ratio", np.nan)
+        component.add_input("data:propulsion:rubber_engine:overall_pressure_ratio", np.nan)
+        component.add_input(
+            "data:propulsion:rubber_engine:turbine_inlet_temperature", np.nan, units="K"
+        )
+        component.add_input("data:propulsion:MTO_thrust", np.nan, units="N")
+        component.add_input("data:propulsion:rubber_engine:maximum_mach", np.nan)
+        component.add_input("data:propulsion:rubber_engine:design_altitude", np.nan, units="m")
+        component.add_input(
             "data:propulsion:rubber_engine:delta_t4_climb",
             -50,
             desc="As it is a delta, unit is K or °C, but is not "
             "specified to avoid OpenMDAO making unwanted conversion",
         )
-        comp.add_input(
+        component.add_input(
             "data:propulsion:rubber_engine:delta_t4_cruise",
             -100,
             desc="As it is a delta, unit is K or °C, but is not "
@@ -90,7 +91,7 @@ class DirectRubberEngine(DirectEngine):
         ),  # limitation of max thrust model
     }
 )
-class OMRubberEngine(OMIEngine):
+class OMRubberEngineComponent(BaseOMEngineComponent):
     """
     Parametric engine model as OpenMDAO component
 
@@ -102,5 +103,5 @@ class OMRubberEngine(OMIEngine):
         self.get_engine().setup(self)
 
     @staticmethod
-    def get_engine() -> DirectEngine:
-        return DirectRubberEngine()
+    def get_engine() -> OMRubberEngineWrapper:
+        return OMRubberEngineWrapper()

--- a/src/fastoad/models/propulsion/fuel_engine/rubber_engine/rubber_engine.py
+++ b/src/fastoad/models/propulsion/fuel_engine/rubber_engine/rubber_engine.py
@@ -21,6 +21,7 @@ from typing import Union, Sequence, Tuple, Optional
 
 import numpy as np
 from fastoad.constants import FlightPhase
+from fastoad.exceptions import FastUnknownFlightPhaseError
 from fastoad.models.propulsion import IEngine
 from fastoad.models.propulsion.fuel_engine.rubber_engine.exceptions import (
     FastRubberEngineInconsistentInputParametersError,
@@ -99,7 +100,9 @@ class RubberEngine(IEngine):
         }
 
         # ... so check that all FlightPhase values are in dict
-        assert any([key in self.dt4_values.keys() for key in FlightPhase])
+        unknown_keys = [key for key in FlightPhase if key not in self.dt4_values.keys()]
+        if unknown_keys:
+            raise FastUnknownFlightPhaseError("Unknown flight phases: %s", unknown_keys)
 
     def compute_flight_points(
         self,

--- a/src/fastoad/models/propulsion/fuel_engine/rubber_engine/rubber_engine.py
+++ b/src/fastoad/models/propulsion/fuel_engine/rubber_engine/rubber_engine.py
@@ -1,7 +1,6 @@
 """
 Parametric turbofan engine
 """
-
 #  This file is part of FAST : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
@@ -190,8 +189,32 @@ class RubberEngine(IEngine):
         return sfc, out_thrust_rate, out_thrust
 
     @staticmethod
-    def _check_thrust_inputs(use_thrust_rate, thrust_rate, thrust):
-        """ Checks that inputs are consistent and return them in proper shape """
+    def _check_thrust_inputs(
+        use_thrust_rate: Optional[Union[float, Sequence]],
+        thrust_rate: Optional[Union[float, Sequence]],
+        thrust: Optional[Union[float, Sequence]],
+    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+        """
+        Checks that inputs are consistent and return them in proper shape.
+
+        Some of the inputs can be None, but outputs will be proper numpy arrays.
+
+        :param use_thrust_rate:
+        :param thrust_rate:
+        :param thrust:
+        :return: the inputs, but transformed in numpy arrays.
+        """
+        # Ensure they are numpy array
+        if use_thrust_rate is not None:
+            # As OpenMDAO may provide floats that could be slightly different
+            # from 0. or 1., a rounding operation is needed before converting
+            # to booleans
+            use_thrust_rate = np.asarray(np.round(use_thrust_rate, 0), dtype=bool)
+        if thrust_rate is not None:
+            thrust_rate = np.asarray(thrust_rate)
+        if thrust is not None:
+            thrust = np.asarray(thrust)
+
         # Check inputs: if use_thrust_rate is None, we will use the provided input between
         # thrust_rate and thrust
         if use_thrust_rate is None:
@@ -240,7 +263,9 @@ class RubberEngine(IEngine):
 
         return use_thrust_rate, thrust_rate, thrust
 
-    def sfc_at_max_thrust(self, atmosphere: Atmosphere, mach: Union[float, Sequence[float]]):
+    def sfc_at_max_thrust(
+        self, atmosphere: Atmosphere, mach: Union[float, Sequence[float]]
+    ) -> np.ndarray:
         """
         Computation of Specific Fuel Consumption at maximum thrust
 
@@ -280,7 +305,7 @@ class RubberEngine(IEngine):
         altitude: Union[float, Sequence[float]],
         thrust_rate: Union[float, Sequence[float]],
         mach: Union[float, Sequence[float]] = 0.8,
-    ) -> Union[float, Sequence[float]]:
+    ) -> np.ndarray:
         """
         Computation of ratio :math:`\\frac{SFC(F)}{SFC(Fmax)}`, given altitude
         and thrust_rate :math:`\\frac{F}{Fmax}`.
@@ -328,7 +353,7 @@ class RubberEngine(IEngine):
         atmosphere: Atmosphere,
         mach: Union[float, Sequence[float]],
         delta_t4: Union[float, Sequence[float]],
-    ) -> Union[float, Sequence[float]]:
+    ) -> np.ndarray:
         """
         Computation of maximum thrust
 
@@ -476,7 +501,7 @@ class RubberEngine(IEngine):
 
         return installed_weight
 
-    def length(self):
+    def length(self) -> float:
         # TODO: update model reference with last edition of Raymer
         """
         Computes engine length from MTO thrust and maximum Mach
@@ -489,7 +514,7 @@ class RubberEngine(IEngine):
 
         return length
 
-    def nacelle_diameter(self):
+    def nacelle_diameter(self) -> float:
         # TODO: update model reference with last edition of Raymer
         """
         Computes nacelle diameter from MTO thrust and bypass ratio

--- a/src/fastoad/models/propulsion/fuel_engine/rubber_engine/rubber_engine.py
+++ b/src/fastoad/models/propulsion/fuel_engine/rubber_engine/rubber_engine.py
@@ -82,7 +82,6 @@ class RubberEngine(IEngine):
         delta_t4_cruise: float = -100,
     ):
         # pylint: disable=too-many-arguments  # they define the engine
-        """ constructor """
 
         self.bypass_ratio = bypass_ratio
         self.overall_pressure_ratio = overall_pressure_ratio
@@ -145,11 +144,14 @@ class RubberEngine(IEngine):
         altitude = np.asarray(altitude)
         delta_t4 = np.asarray(delta_t4)
 
+        if use_thrust_rate is not None:
+            use_thrust_rate = np.asarray(np.round(use_thrust_rate, 0), dtype=bool)
+
         use_thrust_rate, thrust_rate, thrust = self._check_thrust_inputs(
             use_thrust_rate, thrust_rate, thrust
         )
 
-        use_thrust_rate = np.asarray(use_thrust_rate, dtype=bool)
+        use_thrust_rate = np.asarray(np.round(use_thrust_rate, 0), dtype=bool)
         thrust_rate = np.asarray(thrust_rate)
         thrust = np.asarray(thrust)
 

--- a/src/fastoad/models/propulsion/fuel_engine/rubber_engine/rubber_engine.py
+++ b/src/fastoad/models/propulsion/fuel_engine/rubber_engine/rubber_engine.py
@@ -111,18 +111,6 @@ class RubberEngine(IEngine):
         thrust: Optional[Union[float, Sequence]] = None,
     ) -> Tuple[Union[float, Sequence], Union[float, Sequence], Union[float, Sequence]]:
         # pylint: disable=too-many-arguments  # they define the trajectory
-        """
-        see :meth:`fastoad.modules.propulsion.engine.IEngine.compute_flight_points` for more info
-
-
-        :param mach: Mach number
-        :param altitude: (unit=m) altitude w.r.t. to sea level
-        :param phase: flight phase
-        :param use_thrust_rate: tells if thrust_rate or thrust should be used (works element-wise)
-        :param thrust_rate: thrust rate (unit=none)
-        :param thrust: required thrust (unit=N)
-        :return: SFC (in kg/s/N), thrust rate, thrust (in N)
-        """
         return self.compute_flight_points_from_dt4(
             mach, altitude, self._get_delta_t4(phase), use_thrust_rate, thrust_rate, thrust
         )

--- a/src/fastoad/models/propulsion/fuel_engine/rubber_engine/rubber_engine.py
+++ b/src/fastoad/models/propulsion/fuel_engine/rubber_engine/rubber_engine.py
@@ -1,6 +1,4 @@
-"""
-Parametric turbofan engine
-"""
+"""Parametric turbofan engine."""
 #  This file is part of FAST : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
@@ -50,25 +48,6 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class RubberEngine(IEngine):
-    """
-    Parametric turbofan engine
-
-    Computes engine characteristics using analytical model from following sources:
-
-    .. bibliography:: ../refs.bib
-       :filter: docname in docnames
-
-    :param bypass_ratio:
-    :param overall_pressure_ratio:
-    :param turbine_inlet_temperature: (unit=K) also noted T4
-    :param mto_thrust: (unit=N) Maximum TakeOff thrust, i.e. maximum thrust
-                       on ground at speed 0, also noted F0
-    :param maximum_mach:
-    :param design_altitude: (unit=m)
-    :param delta_t4_climb: (unit=K) difference between T4 during climb and design T4
-    :param delta_t4_cruise: (unit=K) difference between T4 during cruise and design T4
-    """
-
     def __init__(
         self,
         bypass_ratio: float,
@@ -80,6 +59,25 @@ class RubberEngine(IEngine):
         delta_t4_climb: float = -50,
         delta_t4_cruise: float = -100,
     ):
+        """
+        Parametric turbofan engine.
+
+        It computes engine characteristics using analytical model from following
+        sources:
+
+        .. bibliography:: ../refs.bib
+           :filter: docname in docnames
+
+        :param bypass_ratio:
+        :param overall_pressure_ratio:
+        :param turbine_inlet_temperature: (unit=K) also noted T4
+        :param mto_thrust: (unit=N) Maximum TakeOff thrust, i.e. maximum thrust
+                           on ground at speed 0, also noted F0
+        :param maximum_mach:
+        :param design_altitude: (unit=m)
+        :param delta_t4_climb: (unit=K) difference between T4 during climb and design T4
+        :param delta_t4_cruise: (unit=K) difference between T4 during cruise and design T4
+        """
         # pylint: disable=too-many-arguments  # they define the engine
 
         self.bypass_ratio = bypass_ratio
@@ -267,7 +265,7 @@ class RubberEngine(IEngine):
         self, atmosphere: Atmosphere, mach: Union[float, Sequence[float]]
     ) -> np.ndarray:
         """
-        Computation of Specific Fuel Consumption at maximum thrust
+        Computation of Specific Fuel Consumption at maximum thrust.
 
         Uses model described in :cite:`roux:2005`, p.41.
 
@@ -355,7 +353,7 @@ class RubberEngine(IEngine):
         delta_t4: Union[float, Sequence[float]],
     ) -> np.ndarray:
         """
-        Computation of maximum thrust
+        Computation of maximum thrust.
 
         Uses model described in :cite:`roux:2005`, p.57-58
 
@@ -371,7 +369,7 @@ class RubberEngine(IEngine):
         delta_t4 = np.asarray(delta_t4)
 
         def _mach_effect():
-            """ Computation of Mach effect """
+            """Computation of Mach effect."""
             vect = [
                 (self.overall_pressure_ratio - 30) ** 2,
                 (self.overall_pressure_ratio - 30),
@@ -429,7 +427,7 @@ class RubberEngine(IEngine):
             return alpha_mach_effect * (mach - m_s) ** 2 + f_m
 
         def _altitude_effect():
-            """ Computation of altitude effect """
+            """Computation of altitude effect."""
             # pylint: disable=invalid-name  # coefficients are named after model
             k = 1 + 1.2e-3 * delta_t4
             nf = 0.98 + 8e-4 * delta_t4
@@ -471,7 +469,7 @@ class RubberEngine(IEngine):
             return h
 
         def _residuals():
-            """ Computation of residuals """
+            """Computation of residuals."""
             return (
                 -4.51e-3 * self.bypass_ratio
                 + 2.19e-5 * self.t_4
@@ -483,7 +481,7 @@ class RubberEngine(IEngine):
 
     def installed_weight(self) -> float:
         """
-        Computes weight of installed engine, depending on MTO thrust (F0)
+        Computes weight of installed engine, depending on MTO thrust (F0).
 
         Uses model described in :cite:`roux:2005`, p.74
 
@@ -504,7 +502,7 @@ class RubberEngine(IEngine):
     def length(self) -> float:
         # TODO: update model reference with last edition of Raymer
         """
-        Computes engine length from MTO thrust and maximum Mach
+        Computes engine length from MTO thrust and maximum Mach.
 
         Model from :cite:`raymer:1999`, p.74
 
@@ -517,7 +515,7 @@ class RubberEngine(IEngine):
     def nacelle_diameter(self) -> float:
         # TODO: update model reference with last edition of Raymer
         """
-        Computes nacelle diameter from MTO thrust and bypass ratio
+        Computes nacelle diameter from MTO thrust and bypass ratio.
 
         Model of engine diameter from :cite:`raymer:1999`, p.235.
         Nacelle diameter is considered 10% greater (:cite:`kroo:2001`)

--- a/src/fastoad/models/propulsion/fuel_engine/rubber_engine/tests/test_openmdao_engine.py
+++ b/src/fastoad/models/propulsion/fuel_engine/rubber_engine/tests/test_openmdao_engine.py
@@ -19,13 +19,13 @@ import openmdao.api as om
 from fastoad.constants import FlightPhase
 
 from tests.testing_utilities import run_system
-from ..openmdao import OMRubberEngine
+from ..openmdao import OMRubberEngineComponent
 
 
-def test_OMRubberEngine():
+def test_OMRubberEngineComponent():
     """ Tests ManualRubberEngine component """
     # Same test as in test_rubber_engine.test_compute_flight_points
-    engine = OMRubberEngine(flight_point_count=(2, 5))
+    engine = OMRubberEngineComponent(flight_point_count=(2, 5))
 
     machs = [0, 0.3, 0.3, 0.8, 0.8]
     altitudes = [0, 0, 0, 10000, 13000]

--- a/src/fastoad/module_management/constants.py
+++ b/src/fastoad/module_management/constants.py
@@ -17,7 +17,7 @@ from enum import Enum
 
 # Services
 SERVICE_OPENMDAO_SYSTEM = "fast.openmdao.system"
-SERVICE_RESULT_FOLDER_PROVIDER = "fast.result.folder"
+SERVICE_PROPULSION_WRAPPER = "fastoad.wrapper.propulsion"
 
 # Properties for OpenMDAOSystemRegistry
 OPTION_PROPERTY_NAME = "OPTIONS"

--- a/src/fastoad/module_management/constants.py
+++ b/src/fastoad/module_management/constants.py
@@ -1,6 +1,4 @@
-"""
-The place for module-level constants
-"""
+"""The place for module-level constants."""
 #  This file is part of FAST : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
@@ -27,7 +25,9 @@ DOMAIN_PROPERTY_NAME = "DOMAIN"
 
 # Definition of model domains
 class ModelDomain(Enum):
-    """ Enumeration of model domains """
+    """
+    Enumeration of model domains.
+    """
 
     GEOMETRY = "Geometry"
     AERODYNAMICS = "Aerodynamics"

--- a/src/fastoad/module_management/exceptions.py
+++ b/src/fastoad/module_management/exceptions.py
@@ -1,6 +1,4 @@
-"""
-Exceptions for module_management package
-"""
+"""Exceptions for module_management package."""
 #  This file is part of FAST : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
@@ -18,21 +16,26 @@ from fastoad.exceptions import FastError
 
 
 class FastDuplicateFactoryError(FastError):
-    """
-    Raised when trying to register a factory with an already used name
-    """
-
     def __init__(self, factory_name):
+        """
+        Raised when trying to register a factory with an already used name.
+
+        :param factory_name:
+        """
         super().__init__('Name "%s" is already used.' % factory_name)
         self.factory_name = factory_name
 
 
 class FastDuplicateOMSystemIdentifierException(FastDuplicateFactoryError):
     """
-    Raised when trying to register an OpenMDAO System with an already used identifier
+    Raised when trying to register an OpenMDAO System with an already used identifier.
     """
 
     def __str__(self):
+        """
+
+        :return:
+        """
         return (
             "Tried to register an OpenMDAO system with an already used identifier : %s"
             % self.factory_name
@@ -40,31 +43,35 @@ class FastDuplicateOMSystemIdentifierException(FastDuplicateFactoryError):
 
 
 class FastNoOMSystemFoundError(FastError):
-    """
-    Raised when no registered OpenMDAO system could be found from asked properties
-    """
-
     def __init__(self, properties):
+        """
+        Raised when no registered OpenMDAO system could be found from asked properties.
+
+        :param properties:
+        """
         super().__init__("No OpenMDAO system found with these properties: %s" % properties)
         self.properties = properties
 
 
 class FastUnknownOMSystemIdentifierError(FastError):
-    """
-    Raised when no OpenMDAO system is registered with asked identifier
-    """
-
     def __init__(self, identifier):
+        """
+        Raised when no OpenMDAO system is registered with asked identifier.
+
+        :param identifier:
+        """
         super().__init__("No OpenMDAO system found with this identifier: %s" % identifier)
         self.identifier = identifier
 
 
 class FastBadSystemOptionError(FastError):
-    """
-    Raised when some option name is not conform to OpenMDAO system definition
-    """
-
     def __init__(self, identifier, option_names):
+        """
+        Raised when some option name is not conform to OpenMDAO system definition.
+
+        :param identifier: system identifier
+        :param option_names: incorrect option names
+        """
         super().__init__(
             "OpenMDAO system %s does not accept following option(s): %s"
             % (identifier, option_names)
@@ -75,11 +82,17 @@ class FastBadSystemOptionError(FastError):
 
 class FastIncompatibleServiceClass(FastError):
     """
-    Raised when trying to register as service a class that does not implement the specified
-    interface.
     """
 
     def __init__(self, registered_class: type, service_id: str, base_class: type):
+        """
+        Raised when trying to register as service a class that does not implement
+        the specified interface.
+
+        :param registered_class:
+        :param service_id:
+        :param base_class: the unmatched interface
+        """
         super().__init__(
             'Trying to register %s as service "%s" but it does not inherit from %s'
             % (str(registered_class), service_id, str(base_class))

--- a/src/fastoad/module_management/exceptions.py
+++ b/src/fastoad/module_management/exceptions.py
@@ -71,3 +71,19 @@ class FastBadSystemOptionError(FastError):
         )
         self.identifier = identifier
         self.option_names = option_names
+
+
+class FastIncompatibleServiceClass(FastError):
+    """
+    Raised when trying to register as service a class that does not implement the specified
+    interface.
+    """
+
+    def __init__(self, registered_class: type, service_id: str, base_class: type):
+        super().__init__(
+            'Trying to register %s as service "%s" but it does not inherit from %s'
+            % (str(registered_class), service_id, str(base_class))
+        )
+        self.registered_class = registered_class
+        self.service_id = service_id
+        self.base_class = base_class

--- a/src/fastoad/module_management/service_registry.py
+++ b/src/fastoad/module_management/service_registry.py
@@ -1,0 +1,57 @@
+"""
+Module for registering services
+"""
+#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  FAST is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+from fastoad.models.propulsion import IOMEngineWrapper
+from fastoad.module_management.constants import SERVICE_PROPULSION_WRAPPER
+from fastoad.module_management.exceptions import FastIncompatibleServiceClass
+from pelix.ipopo.decorators import ComponentFactory, Provides
+
+
+class RegisterService:
+    def __init__(self, provider_id: str, service_id: str, base_class: type = None):
+        """
+        Decorator class that allows to register a service.
+
+        The service can be associated to a base class (or interface). Then all registered
+        classes must inherit from this base class.
+
+        Warning: the module must be started as an iPOPO bundle for the decorator to work.
+
+        :param provider_id: the identifier of the service provider to register
+        :param service_id: the identifier of the service
+        :param base_class: the class that should be parent to the registered class
+        """
+
+        self._id = provider_id
+        self._service_id = service_id
+        self._base_class = base_class
+
+    def __call__(self, service_class: type) -> type:
+        if self._base_class and not issubclass(service_class, self._base_class):
+            raise FastIncompatibleServiceClass(service_class, self._service_id, self._base_class)
+
+        return ComponentFactory(self._id)(Provides(self._service_id)(service_class))
+
+
+class RegisterPropulsion(RegisterService):
+    def __init__(self, model_id):
+        """
+        Decorator class for registering a propulsion-dedicated model.
+
+        Warning: the module must be started as an iPOPO bundle for the decorator to work.
+
+        :param model_id: the identifier of the propulsion model
+        """
+        super().__init__(model_id, SERVICE_PROPULSION_WRAPPER, IOMEngineWrapper)

--- a/src/fastoad/module_management/service_registry.py
+++ b/src/fastoad/module_management/service_registry.py
@@ -33,7 +33,6 @@ class RegisterService:
         :param service_id: the identifier of the service
         :param base_class: the class that should be parent to the registered class
         """
-
         self._id = provider_id
         self._service_id = service_id
         self._base_class = base_class

--- a/src/fastoad/module_management/service_registry.py
+++ b/src/fastoad/module_management/service_registry.py
@@ -1,6 +1,6 @@
 """
 Module for registering services
-"""
+."""
 #  This file is part of FAST : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify

--- a/src/fastoad/module_management/service_registry.py
+++ b/src/fastoad/module_management/service_registry.py
@@ -1,6 +1,4 @@
-"""
-Module for registering services
-."""
+"""Module for registering services."""
 #  This file is part of FAST : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
@@ -13,6 +11,7 @@ Module for registering services
 #  GNU General Public License for more details.
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 from fastoad.models.propulsion import IOMEngineWrapper
 from fastoad.module_management.constants import SERVICE_PROPULSION_WRAPPER
 from fastoad.module_management.exceptions import FastIncompatibleServiceClass

--- a/src/fastoad/openmdao/validity_checker.py
+++ b/src/fastoad/openmdao/validity_checker.py
@@ -1,6 +1,4 @@
-"""
-For checking validity domain of OpenMDAO variables
-"""
+"""For checking validity domain of OpenMDAO variables."""
 #  This file is part of FAST : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
@@ -48,7 +46,7 @@ A namedtuple that contains result of one variable check
 
 class ValidityStatus(IntEnum):
     """
-    Simple enumeration for validity status
+    Simple enumeration for validity status.
     """
 
     OK = 0
@@ -138,16 +136,17 @@ class ValidityDomainChecker:
     - Units of limit values defined in ValidityDomainChecker are assumed to be the
       same as in add_input() and add_output() statements of decorated class
     - Validity check currently only applies to scalar values
-
-    :param limits: a dictionary where keys are variable names and values are two-values tuples
-                   that give lower and upper bound. One bound can be set to None.
-    :param logger_name: The named of the logger that will be used. If not provided, name of
-                        current module (i.e. "__name__"") will be used.
     """
 
     _limit_definitions: Dict[UUID, _LimitDefinitions] = {}
 
     def __init__(self, limits: Dict[str, tuple] = None, logger_name: str = None):
+        """
+        :param limits: a dictionary where keys are variable names and values are two-values tuples
+                   that give lower and upper bound. One bound can be set to None.
+        :param logger_name: The named of the logger that will be used. If not provided, name of
+                        current module (i.e. "__name__"") will be used.
+        """
         self._uuid = uuid.uuid4()
 
         # use given logger name for now. If it is None, it will be replaced by
@@ -186,8 +185,7 @@ class ValidityDomainChecker:
         checker_id = self._uuid
 
         def setup(self):
-            """ Will replace the original setup() method"""
-
+            """Will replace the original setup method."""
             # Ok kid, this is where it gets maybe too complicated...
             # We need to get variables of the current OpenMDAO instance.
             # This is done with VariableList.from_system() which we know does

--- a/src/fastoad/openmdao/validity_checker.py
+++ b/src/fastoad/openmdao/validity_checker.py
@@ -177,7 +177,7 @@ class ValidityDomainChecker:
         # added, that will call the original setup() and do what we need.
 
         # original setup will be renamed with a name that will be unique
-        setup_new_name = "setup_before_validity_domain_checker_%i" % int(self._uuid)
+        setup_new_name = "__setup_before_validity_domain_checker_%i" % int(self._uuid)
 
         # Copy the original method "setup" to "__setup_before_option_decorator_<uuid>"
         setattr(om_class, setup_new_name, om_class.setup)

--- a/src/fastoad/register.py
+++ b/src/fastoad/register.py
@@ -22,7 +22,7 @@ from fastoad.models.handling_qualities.compute_static_margin import ComputeStati
 from fastoad.models.handling_qualities.tail_sizing.compute_tail_areas import ComputeTailAreas
 from fastoad.models.loops.compute_wing_area import ComputeWingArea
 from fastoad.models.performances import BreguetFromOWE
-from fastoad.models.propulsion.fuel_engine.rubber_engine import OMRubberEngine
+from fastoad.models.propulsion.fuel_engine.rubber_engine import OMRubberEngineComponent
 from fastoad.models.weight.weight import Weight
 from fastoad.module_management import OpenMDAOSystemRegistry
 from fastoad.module_management.constants import ModelDomain
@@ -85,7 +85,7 @@ def register_openmdao_systems():
     """
 
     OpenMDAOSystemRegistry.register_system(
-        OMRubberEngine,
+        OMRubberEngineComponent,
         "fastoad.propulsion.rubber_engine",
         domain=ModelDomain.PROPULSION,
         desc=rubber_engine_description,

--- a/tests/integration_tests/oad_process/data/oad_process.toml
+++ b/tests/integration_tests/oad_process/data/oad_process.toml
@@ -9,7 +9,7 @@ output_file = "../results/oad_process_outputs.xml"
 
 [model]
     nonlinear_solver = "om.NonlinearBlockGS(maxiter=100)"
-    linear_solver = "om.ScipyKrylov()"
+    linear_solver = "om.DirectSolver()"
     [model.geometry]
         id = "fastoad.geometry.legacy"
     [model.weight]

--- a/tests/testing_utilities.py
+++ b/tests/testing_utilities.py
@@ -33,7 +33,7 @@ def run_system(
     model.add_subsystem("inputs", input_vars, promotes=["*"])
     model.add_subsystem("component", component, promotes=["*"])
     if add_solvers:
-        model.nonlinear_solver = om.NewtonSolver()
+        model.nonlinear_solver = om.NewtonSolver(solve_subsystems=False)
         model.linear_solver = om.DirectSolver()
 
     problem.setup(mode=setup_mode)


### PR DESCRIPTION
This PR reworks the engine model definition for preparing the upcoming development of a time-dependent performance module.

The engine model can now be put in a wrapper that should ease its usage in an OpenMDAO component and allow easy switching between propulsion models.

Additionally, Sphinx settings have been changed so that a class documentation is now the concatenation of the class docstring and the `__init__` docstring. This allows to put docstrings in `__init__` so we can get PEP257-compliant.