### PR TITLE
Added "watchman" tests

### DIFF
--- a/.github/workflows/watchman_tests.yml
+++ b/.github/workflows/watchman_tests.yml
@@ -1,0 +1,52 @@
+name: Watchman Tests
+# This workflow will run tests with an up-to-date production environment instead
+# of the locked one.
+# It will warn developers if the update of a dependency broke something.
+
+on: [push]
+
+jobs:
+
+  tests:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python-version: [3.8]
+        os: [ubuntu-latest, windows-latest, macos-latest]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install Poetry
+        run: curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
+        shell: bash
+
+      - name: Poetry path
+        run: echo "::add-path::$HOME/.poetry/bin"
+        shell: bash
+
+      - name: Update production dependencies
+        run: poetry update --no-dev
+        shell: bash
+
+      - name: Install dependencies
+        run: poetry install
+        shell: bash
+
+      - name: Unit tests
+        run: |
+          poetry run pytest src
+        shell: bash
+
+      - name: Integration tests
+        run: poetry run pytest --no-cov tests/integration_tests
+        shell: bash
+
+      - name: Notebook tests
+        run: poetry run pytest --no-cov --nbval-lax -p no:python src
+        shell: bash

--- a/.github/workflows/watchman_tests.yml
+++ b/.github/workflows/watchman_tests.yml
@@ -30,6 +30,30 @@ jobs:
         run: echo "::add-path::$HOME/.poetry/bin"
         shell: bash
 
+      - uses: actions/cache@v2
+        if: startsWith(runner.os, 'Linux')
+        with:
+          path: ~/.cache/pypoetry
+          key: ${{ runner.os }}-Py${{ matrix.python-version }}-watchman
+          restore-keys: |
+            ${{ runner.os }}-Py${{ matrix.python-version }}-watchman
+
+      - uses: actions/cache@v2
+        if: startsWith(runner.os, 'macOS')
+        with:
+          path: /Users/runner/Library/Caches/pypoetry
+          key: ${{ runner.os }}-Py${{ matrix.python-version }}-watchman
+          restore-keys: |
+            ${{ runner.os }}-Py${{ matrix.python-version }}-watchman
+
+      - uses: actions/cache@v2
+        if: startsWith(runner.os, 'Windows')
+        with:
+          path: ~\AppData\Local\pypoetry\Cache
+          key: ${{ runner.os }}-Py${{ matrix.python-version }}-watchman
+          restore-keys: |
+            ${{ runner.os }}-Py${{ matrix.python-version }}-watchman
+
       - name: Update production dependencies
         run: poetry update --no-dev
         shell: bash


### PR DESCRIPTION
The added workflow will run tests with an up-to-date production environment instead
of the locked one.
It will warn developers if the update of a dependency broke something.