### PR TITLE
release v0.4.2b because v0.4.1b is not what is should be.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,7 +2,7 @@
 Changelog
 =========
 
-Version 0.4.1-beta
+Version 0.4.2-beta
 ==================
 
 - Prevents installation of OpenMDAO 3.2 and above for incompatibility reasons.


### PR DESCRIPTION
Due to a tag error, the 0.4.1b release is the same as the 0.4.0b.
So we make a [0.4.2b](https://github.com/fast-aircraft-design/FAST-OAD/releases/tag/untagged-a3cdffdf8b6655e03aa5) and remove the 0.4.1b from history.