### PR TITLE
Now list_systems() also lists propulsion wrappers.

### DIFF
--- a/src/fastoad/models/propulsion/fuel_propulsion/rubber_engine/openmdao.py
+++ b/src/fastoad/models/propulsion/fuel_propulsion/rubber_engine/openmdao.py
@@ -1,6 +1,6 @@
 """OpenMDAO wrapping of RubberEngine."""
 #  This file is part of FAST : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA/ISAE
+#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -21,7 +21,15 @@ from fastoad.openmdao.validity_checker import ValidityDomainChecker
 from .rubber_engine import RubberEngine
 
 
-@RegisterPropulsion("fastoad.wrapper.propulsion.rubber_engine")
+@RegisterPropulsion(
+    "fastoad.wrapper.propulsion.rubber_engine",
+    desc="""
+Parametric engine model as OpenMDAO component.
+
+Implementation of E. Roux models for fuel consumption of low bypass ratio engines
+For more information, see RubberEngine class in FAST-OAD developer documentation.
+""",
+)
 class OMRubberEngineWrapper(IOMPropulsionWrapper):
     """
     Wrapper class of for rubber engine model.

--- a/src/fastoad/module_management/openmdao_system_registry.py
+++ b/src/fastoad/module_management/openmdao_system_registry.py
@@ -19,7 +19,6 @@ from types import MethodType
 from typing import List, Union, Any
 
 from fastoad.openmdao.types import SystemSubclass
-
 from .bundle_loader import BundleLoader
 from .constants import (
     SERVICE_OPENMDAO_SYSTEM,
@@ -143,7 +142,7 @@ class OpenMDAOSystemRegistry:
         return cls._get_system_property(system_or_id, DOMAIN_PROPERTY_NAME)
 
     @classmethod
-    def get_system_description(cls, system_or_id: Union[str, SystemSubclass]) -> ModelDomain:
+    def get_system_description(cls, system_or_id: Union[str, SystemSubclass]) -> str:
         """
 
         :param system_or_id: an identifier of a registered OpenMDAO System class or


### PR DESCRIPTION
Since the new wrapper system for propulsion models, the registered wrapper were not listed when asking for system list. This is fixed by this PR.

The `RegisterService` class has got a bit larger and begins to smell like `OpenMDAOSystemRegistry` class. This is left as is for now, but a future PR may put that in order.