### PR TITLE
Release 0.5.1 beta

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+Version 0.5.1-beta
+==================
+
+- Now avoids apparition of numerous deprecation warnings from OpenMDAO.
+
 Version 0.5.0-beta
 ==================
 
@@ -9,7 +14,6 @@ Version 0.5.0-beta
 - Added the mission performance module (currently computes a fixed standard mission).
 - Propulsion models are now declared in a specific way so that another
   module can do a direct call to the needed propulsion model.
-
 
 Version 0.4.2-beta
 ==================

--- a/src/fastoad/openmdao/variables.py
+++ b/src/fastoad/openmdao/variables.py
@@ -33,7 +33,21 @@ _LOGGER = logging.getLogger(__name__)
 DESCRIPTION_FILENAME = "variable_descriptions.txt"
 # Metadata that will be ignore when checking variable equality and when adding variable
 # to an OpenMDAO component
-METADATA_TO_IGNORE = ["is_input", "tags", "size", "src_indices", "flat_src_indices", "distributed"]
+METADATA_TO_IGNORE = [
+    "is_input",
+    "tags",
+    "size",
+    "src_indices",
+    "flat_src_indices",
+    "distributed",
+    "res_units",  # deprecated in IndepVarComp.add_output() since OpenMDAO 3.2
+    "lower",  # deprecated in IndepVarComp.add_output() since OpenMDAO 3.2
+    "upper",  # deprecated in IndepVarComp.add_output() since OpenMDAO 3.2
+    "ref",  # deprecated in IndepVarComp.add_output() since OpenMDAO 3.2
+    "ref0",  # deprecated in IndepVarComp.add_output() since OpenMDAO 3.2
+    "res_ref",  # deprecated in IndepVarComp.add_output() since OpenMDAO 3.2
+    "ref",  # deprecated in IndepVarComp.add_output() since OpenMDAO 3.2
+]
 
 
 class Variable(Hashable):


### PR DESCRIPTION
Numerous deprecation warnings were displayed in notebooks.

This is now fixed and a new release is proposed:
https://github.com/fast-aircraft-design/FAST-OAD/releases/tag/untagged-78ed6ca7419acbdfea21