### PR TITLE
Avoiding to have _auto_ivc variables in list_variables output

### DIFF
--- a/src/fastoad/openmdao/variables.py
+++ b/src/fastoad/openmdao/variables.py
@@ -451,11 +451,7 @@ class VariableList(list):
 
     @classmethod
     def from_problem(
-        cls,
-        problem: om.Problem,
-        use_initial_values: bool = False,
-        get_promoted_names=True,
-        get_auto_ivc_vars=False,
+        cls, problem: om.Problem, use_initial_values: bool = False, get_promoted_names=True,
     ) -> "VariableList":
         """
         Creates a VariableList instance containing inputs and outputs of a an OpenMDAO Problem.
@@ -470,10 +466,13 @@ class VariableList(list):
         If variables are promoted, the promoted name will be used. Otherwise (and if
         promoted_only is False), the absolute name will be used.
 
+        .. note::
+
+            Variables from _auto_ivc are ignored.
+
         :param problem: OpenMDAO Problem instance to inspect
         :param use_initial_values: if True, returned instance will contain values before computation
         :param get_promoted_names: if True, only promoted variable names will be returned
-        :param get_auto_ivc_vars:
         :return: VariableList instance
         """
         variables = VariableList()
@@ -492,7 +491,7 @@ class VariableList(list):
         ivc_inputs = []
         for subsystem in model.system_iter():
             if isinstance(subsystem, om.IndepVarComp):
-                if get_auto_ivc_vars or subsystem.name != "_auto_ivc":
+                if subsystem.name != "_auto_ivc":  # Exclude vars from _auto_ivc
                     input_variables = cls.from_ivc(subsystem)
                     for var in input_variables:
                         ivc_inputs.append(var.name)
@@ -503,8 +502,8 @@ class VariableList(list):
             metadata_keys=["value", "units", "upper", "lower"], return_rel_names=False
         ).items():
 
-            # Exclude vars from _auto_ivc unless they are required
-            if not get_auto_ivc_vars and abs_name.startswith("_auto_ivc"):
+            # Exclude vars from _auto_ivc
+            if abs_name.startswith("_auto_ivc."):
                 continue
 
             prom_name = metadata["prom_name"]


### PR DESCRIPTION
Variables from _auto_ivc are no more in outputs from VariableList.from_problem, unless they are asked for.

Fixes #225