### PR TITLE
Updated copyright texts in whole project

### DIFF
--- a/devutils/__init__.py
+++ b/devutils/__init__.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/devutils/rename_vars.py
+++ b/devutils/rename_vars.py
@@ -3,7 +3,7 @@ This script reads the 2 column files 'rename_vars.txt' where the the first
 column contains old OpenMDAO variable names and the new names.
 Replaces old names by new ones in all files of ./src and ./tests.
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -22,6 +22,7 @@ import os.path as pth
 import re
 
 import numpy as np
+
 from fastoad.io import VariableIO
 from fastoad.io.xml import VariableXmlBaseFormatter
 from fastoad.io.xml.exceptions import (
@@ -30,7 +31,6 @@ from fastoad.io.xml.exceptions import (
 )
 from fastoad.io.xml.translator import VarXpathTranslator
 from fastoad.io.xml.variable_io_standard import BasicVarXpathTranslator
-
 from tests import root_folder_path
 
 SRC_PATH = pth.join(root_folder_path, "src")

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/__init__.py
+++ b/src/fastoad/__init__.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/activator.py
+++ b/src/fastoad/activator.py
@@ -1,7 +1,7 @@
 """
 Where initialization operations can be done
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -14,8 +14,9 @@ Where initialization operations can be done
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from fastoad.register import register_openmdao_systems
 from pelix.constants import BundleActivator
+
+from fastoad.register import register_openmdao_systems
 
 
 @BundleActivator

--- a/src/fastoad/base/__init__.py
+++ b/src/fastoad/base/__init__.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/base/dict.py
+++ b/src/fastoad/base/dict.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/base/flight_point.py
+++ b/src/fastoad/base/flight_point.py
@@ -1,5 +1,5 @@
 """Structure for managing flight point data."""
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/base/tests/__init__.py
+++ b/src/fastoad/base/tests/__init__.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/base/tests/test_flight_point.py
+++ b/src/fastoad/base/tests/test_flight_point.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/cmd/__init__.py
+++ b/src/fastoad/cmd/__init__.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/cmd/api.py
+++ b/src/fastoad/cmd/api.py
@@ -1,7 +1,7 @@
 """
 API
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -33,17 +33,16 @@ from whatsopt.whatsopt_client import WhatsOpt, PROD_URL
 
 from fastoad.cmd.exceptions import FastFileExistsError
 from fastoad.io import IVariableIOFormatter, VariableIO
-from fastoad.io.configuration import FASTOADProblem
-from fastoad.io.configuration.configuration import FASTOADProblemConfigurator
+from fastoad.io.configuration import FASTOADProblemConfigurator
 from fastoad.io.xml import VariableLegacy1XmlFormatter
-from fastoad.module_management import BundleLoader
-from fastoad.module_management import OpenMDAOSystemRegistry
+from fastoad.module_management import BundleLoader, OpenMDAOSystemRegistry
+from fastoad.module_management.service_registry import RegisterPropulsion
+from fastoad.openmdao.problem import FASTOADProblem
 from fastoad.openmdao.variables import VariableList
 from fastoad.utils.files import make_parent_dir
 from fastoad.utils.postprocessing import OptimizationViewer, VariableViewer
 from fastoad.utils.resource_management.copy import copy_resource
 from . import resources
-from ..module_management.service_registry import RegisterPropulsion
 
 DEFAULT_WOP_URL = "https://ether.onera.fr/whatsopt"
 _LOGGER = logging.getLogger(__name__)

--- a/src/fastoad/cmd/exceptions.py
+++ b/src/fastoad/cmd/exceptions.py
@@ -1,7 +1,7 @@
 """
 Exception for cmd package
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/cmd/fast.py
+++ b/src/fastoad/cmd/fast.py
@@ -1,5 +1,5 @@
 """Command Line Interface."""
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/cmd/resources/__init__.py
+++ b/src/fastoad/cmd/resources/__init__.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/cmd/tests/__init__.py
+++ b/src/fastoad/cmd/tests/__init__.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/cmd/tests/data/inputs.xml
+++ b/src/fastoad/cmd/tests/data/inputs.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ This file is part of FAST : A framework for rapid Overall Aircraft Design
+  ~ This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
   ~ Copyright (C) 2020  ONERA & ISAE-SUPAERO
   ~ FAST is free software: you can redistribute it and/or modify
   ~ it under the terms of the GNU General Public License as published by

--- a/src/fastoad/cmd/tests/data/sellar_example/disc1.py
+++ b/src/fastoad/cmd/tests/data/sellar_example/disc1.py
@@ -3,7 +3,7 @@
     Sellar discipline 1
 """
 
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/cmd/tests/data/sellar_example/disc1_base.py
+++ b/src/fastoad/cmd/tests/data/sellar_example/disc1_base.py
@@ -2,7 +2,7 @@
 """
     Sellar discipline 1
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/cmd/tests/data/sellar_example/disc2.py
+++ b/src/fastoad/cmd/tests/data/sellar_example/disc2.py
@@ -2,7 +2,7 @@
 """
     Sellar discipline 2
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/cmd/tests/data/sellar_example/disc2_base.py
+++ b/src/fastoad/cmd/tests/data/sellar_example/disc2_base.py
@@ -2,7 +2,7 @@
 """
     Sellar discipline 2
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/cmd/tests/data/sellar_example/functions.py
+++ b/src/fastoad/cmd/tests/data/sellar_example/functions.py
@@ -2,7 +2,7 @@
 """
   Sellar functions
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/cmd/tests/data/sellar_example/functions_base.py
+++ b/src/fastoad/cmd/tests/data/sellar_example/functions_base.py
@@ -2,7 +2,7 @@
 """
   Sellar functions
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/cmd/tests/data/sellar_example/register_components.py
+++ b/src/fastoad/cmd/tests/data/sellar_example/register_components.py
@@ -1,7 +1,7 @@
 """
 Demonstrates how to register components in OpenMDAOSystemRegistry
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/cmd/tests/data/sellar_example/sellar.py
+++ b/src/fastoad/cmd/tests/data/sellar_example/sellar.py
@@ -2,7 +2,7 @@
 """
   Sellar openMDAO group
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/cmd/tests/data/short_inputs.xml
+++ b/src/fastoad/cmd/tests/data/short_inputs.xml
@@ -1,3 +1,18 @@
+<!--
+  ~ This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
+  ~ Copyright (C) 2020  ONERA & ISAE-SUPAERO
+  ~ FAST is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  -->
+
 <FASTOAD_model>
   <data>
     <TLAR>

--- a/src/fastoad/cmd/tests/test_api.py
+++ b/src/fastoad/cmd/tests/test_api.py
@@ -1,7 +1,7 @@
 """
 Tests for basic API
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/constants.py
+++ b/src/fastoad/constants.py
@@ -1,5 +1,5 @@
 """Definition of globally used constants."""
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/exceptions.py
+++ b/src/fastoad/exceptions.py
@@ -3,7 +3,7 @@ Module for custom Exception classes
 """
 
 
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/io/__init__.py
+++ b/src/fastoad/io/__init__.py
@@ -1,7 +1,7 @@
 """
 Package for handling input/output streams
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/io/configuration/__init__.py
+++ b/src/fastoad/io/configuration/__init__.py
@@ -1,7 +1,7 @@
 """
 Package for building OpenMDAO problem from configuration file
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -14,7 +14,8 @@ Package for building OpenMDAO problem from configuration file
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from .configuration import FASTOADProblem
+from .configuration import FASTOADProblemConfigurator
+
 from .exceptions import (
     FASTConfigurationError,
     FASTConfigurationBadOpenMDAOInstructionError,

--- a/src/fastoad/io/configuration/configuration.py
+++ b/src/fastoad/io/configuration/configuration.py
@@ -2,7 +2,7 @@
 Module for building OpenMDAO problem from configuration file
 """
 
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/io/configuration/exceptions.py
+++ b/src/fastoad/io/configuration/exceptions.py
@@ -1,7 +1,7 @@
 """
 Exceptions for package configuration
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/io/configuration/tests/__init__.py
+++ b/src/fastoad/io/configuration/tests/__init__.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/io/configuration/tests/data/ref_inputs.xml
+++ b/src/fastoad/io/configuration/tests/data/ref_inputs.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ This file is part of FAST : A framework for rapid Overall Aircraft Design
+  ~ This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
   ~ Copyright (C) 2020  ONERA & ISAE-SUPAERO
   ~ FAST is free software: you can redistribute it and/or modify
   ~ it under the terms of the GNU General Public License as published by

--- a/src/fastoad/io/configuration/tests/data/sellar_example/disc1.py
+++ b/src/fastoad/io/configuration/tests/data/sellar_example/disc1.py
@@ -3,7 +3,7 @@
     Sellar discipline 1
 """
 
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/io/configuration/tests/data/sellar_example/disc1_base.py
+++ b/src/fastoad/io/configuration/tests/data/sellar_example/disc1_base.py
@@ -2,7 +2,7 @@
 """
     Sellar discipline 1
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/io/configuration/tests/data/sellar_example/disc2.py
+++ b/src/fastoad/io/configuration/tests/data/sellar_example/disc2.py
@@ -2,7 +2,7 @@
 """
     Sellar discipline 2
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/io/configuration/tests/data/sellar_example/disc2_base.py
+++ b/src/fastoad/io/configuration/tests/data/sellar_example/disc2_base.py
@@ -2,7 +2,7 @@
 """
     Sellar discipline 2
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/io/configuration/tests/data/sellar_example/functions.py
+++ b/src/fastoad/io/configuration/tests/data/sellar_example/functions.py
@@ -2,7 +2,7 @@
 """
   Sellar functions
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/io/configuration/tests/data/sellar_example/functions_base.py
+++ b/src/fastoad/io/configuration/tests/data/sellar_example/functions_base.py
@@ -2,7 +2,7 @@
 """
   Sellar functions
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/io/configuration/tests/data/sellar_example/register_components.py
+++ b/src/fastoad/io/configuration/tests/data/sellar_example/register_components.py
@@ -1,7 +1,7 @@
 """
 Demonstrates how to register components in OpenMDAOSystemRegistry
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/io/configuration/tests/data/sellar_example/sellar.py
+++ b/src/fastoad/io/configuration/tests/data/sellar_example/sellar.py
@@ -2,7 +2,7 @@
 """
   Sellar openMDAO group
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/io/configuration/tests/test_configuration.py
+++ b/src/fastoad/io/configuration/tests/test_configuration.py
@@ -1,7 +1,7 @@
 """
 Test module for configuration.py
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -21,13 +21,13 @@ import numpy as np
 import openmdao.api as om
 import pytest
 import tomlkit
+
 from fastoad.io.configuration.configuration import (
     FASTOADProblemConfigurator,
     KEY_INPUT_FILE,
     KEY_OUTPUT_FILE,
     TABLE_MODEL,
 )
-
 from ..exceptions import (
     FASTConfigurationError,
     FASTConfigurationBadOpenMDAOInstructionError,

--- a/src/fastoad/io/formatter.py
+++ b/src/fastoad/io/formatter.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/io/variable_io.py
+++ b/src/fastoad/io/variable_io.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/io/xml/__init__.py
+++ b/src/fastoad/io/xml/__init__.py
@@ -1,7 +1,7 @@
 """
 Package for handling XML files
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/io/xml/constants.py
+++ b/src/fastoad/io/xml/constants.py
@@ -1,7 +1,7 @@
 """
 Constants for the XML module
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/io/xml/exceptions.py
+++ b/src/fastoad/io/xml/exceptions.py
@@ -1,6 +1,6 @@
 """ Exceptions for io.xml module """
 
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/io/xml/resources/__init__.py
+++ b/src/fastoad/io/xml/resources/__init__.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/io/xml/resources/remove_duplicate_variables.py
+++ b/src/fastoad/io/xml/resources/remove_duplicate_variables.py
@@ -1,7 +1,7 @@
 """
 Enables to remove duplicate variables from text file
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/io/xml/tests/__init__.py
+++ b/src/fastoad/io/xml/tests/__init__.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/io/xml/tests/data/CeRAS01_baseline.xml
+++ b/src/fastoad/io/xml/tests/data/CeRAS01_baseline.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet type="text/xsl" href="fastDataModel.xsl"?>
 <!--
-  ~ This file is part of FAST : A framework for rapid Overall Aircraft Design
+  ~ This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
   ~ Copyright (C) 2020  ONERA & ISAE-SUPAERO
   ~ FAST is free software: you can redistribute it and/or modify
   ~ it under the terms of the GNU General Public License as published by

--- a/src/fastoad/io/xml/tests/data/basic.xml
+++ b/src/fastoad/io/xml/tests/data/basic.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
-  ~ This file is part of FAST : A framework for rapid Overall Aircraft Design
+  ~ This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
   ~ Copyright (C) 2020  ONERA & ISAE-SUPAERO
   ~ FAST is free software: you can redistribute it and/or modify
   ~ it under the terms of the GNU General Public License as published by

--- a/src/fastoad/io/xml/tests/data/custom.xml
+++ b/src/fastoad/io/xml/tests/data/custom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
-  ~ This file is part of FAST : A framework for rapid Overall Aircraft Design
+  ~ This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
   ~ Copyright (C) 2020  ONERA & ISAE-SUPAERO
   ~ FAST is free software: you can redistribute it and/or modify
   ~ it under the terms of the GNU General Public License as published by

--- a/src/fastoad/io/xml/tests/data/custom_additional_var.xml
+++ b/src/fastoad/io/xml/tests/data/custom_additional_var.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
-  ~ This file is part of FAST : A framework for rapid Overall Aircraft Design
+  ~ This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
   ~ Copyright (C) 2020  ONERA & ISAE-SUPAERO
   ~ FAST is free software: you can redistribute it and/or modify
   ~ it under the terms of the GNU General Public License as published by

--- a/src/fastoad/io/xml/tests/data/custom_ref.xml
+++ b/src/fastoad/io/xml/tests/data/custom_ref.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ This file is part of FAST : A framework for rapid Overall Aircraft Design
+  ~ This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
   ~ Copyright (C) 2020  ONERA & ISAE-SUPAERO
   ~ FAST is free software: you can redistribute it and/or modify
   ~ it under the terms of the GNU General Public License as published by

--- a/src/fastoad/io/xml/tests/data/foobar.xml
+++ b/src/fastoad/io/xml/tests/data/foobar.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
-  ~ This file is part of FAST : A framework for rapid Overall Aircraft Design
+  ~ This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
   ~ Copyright (C) 2020  ONERA & ISAE-SUPAERO
   ~ FAST is free software: you can redistribute it and/or modify
   ~ it under the terms of the GNU General Public License as published by

--- a/src/fastoad/io/xml/tests/data/xml_update_original.xml
+++ b/src/fastoad/io/xml/tests/data/xml_update_original.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
-  ~ This file is part of FAST : A framework for rapid Overall Aircraft Design
+  ~ This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
   ~ Copyright (C) 2020  ONERA & ISAE-SUPAERO
   ~ FAST is free software: you can redistribute it and/or modify
   ~ it under the terms of the GNU General Public License as published by

--- a/src/fastoad/io/xml/tests/data/xml_update_reference.xml
+++ b/src/fastoad/io/xml/tests/data/xml_update_reference.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
-  ~ This file is part of FAST : A framework for rapid Overall Aircraft Design
+  ~ This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
   ~ Copyright (C) 2020  ONERA & ISAE-SUPAERO
   ~ FAST is free software: you can redistribute it and/or modify
   ~ it under the terms of the GNU General Public License as published by

--- a/src/fastoad/io/xml/tests/test_translator.py
+++ b/src/fastoad/io/xml/tests/test_translator.py
@@ -1,7 +1,7 @@
 """
 Test module for translator.py
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/io/xml/tests/test_variable_io_base.py
+++ b/src/fastoad/io/xml/tests/test_variable_io_base.py
@@ -1,7 +1,7 @@
 """
 Tests custom XML serializer for OpenMDAO variables
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -18,9 +18,9 @@ import os.path as pth
 from shutil import rmtree
 
 import pytest
-from fastoad.openmdao.variables import VariableList
 from pytest import approx
 
+from fastoad.openmdao.variables import VariableList
 from .. import VariableXmlBaseFormatter
 from ..translator import VarXpathTranslator
 from ...variable_io import VariableIO

--- a/src/fastoad/io/xml/tests/test_variable_io_legacy.py
+++ b/src/fastoad/io/xml/tests/test_variable_io_legacy.py
@@ -1,7 +1,7 @@
 """
 Test module for variable_io_legacy.py
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/io/xml/tests/test_variable_io_standard.py
+++ b/src/fastoad/io/xml/tests/test_variable_io_standard.py
@@ -1,7 +1,7 @@
 """
 Tests basic XML serializer for OpenMDAO variables
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -19,12 +19,12 @@ from shutil import rmtree
 
 import numpy as np
 import pytest
-from fastoad.io import VariableIO
-from fastoad.io.xml import VariableXmlStandardFormatter
-from fastoad.openmdao.variables import VariableList
 from lxml import etree
 from numpy.testing import assert_allclose
 
+from fastoad.io import VariableIO
+from fastoad.io.xml import VariableXmlStandardFormatter
+from fastoad.openmdao.variables import VariableList
 from ..exceptions import FastXPathEvalError
 
 DATA_FOLDER_PATH = pth.join(pth.dirname(__file__), "data")

--- a/src/fastoad/io/xml/translator.py
+++ b/src/fastoad/io/xml/translator.py
@@ -2,7 +2,7 @@
 Conversion from OpenMDAO variables to XPath
 """
 
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/io/xml/variable_io_base.py
+++ b/src/fastoad/io/xml/variable_io_base.py
@@ -1,7 +1,7 @@
 """
 Defines how OpenMDAO variables are serialized to XML using a conversion table
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -21,6 +21,11 @@ import warnings
 from typing import IO, Union
 
 import numpy as np
+from lxml import etree
+from lxml.etree import XPathEvalError
+from lxml.etree import _Element  # pylint: disable=protected-access  # Useful for type hinting
+from openmdao.vectors.vector import Vector
+
 from fastoad.io.formatter import IVariableIOFormatter
 from fastoad.io.xml.exceptions import (
     FastXPathEvalError,
@@ -32,11 +37,6 @@ from fastoad.io.xml.translator import VarXpathTranslator
 from fastoad.openmdao.variables import VariableList
 from fastoad.utils.files import make_parent_dir
 from fastoad.utils.strings import get_float_list_from_string
-from lxml import etree
-from lxml.etree import XPathEvalError
-from lxml.etree import _Element  # pylint: disable=protected-access  # Useful for type hinting
-from openmdao.vectors.vector import Vector
-
 from .constants import DEFAULT_UNIT_ATTRIBUTE, DEFAULT_IO_ATTRIBUTE, ROOT_TAG
 
 _LOGGER = logging.getLogger(__name__)  # Logger for this module

--- a/src/fastoad/io/xml/variable_io_legacy.py
+++ b/src/fastoad/io/xml/variable_io_legacy.py
@@ -1,7 +1,7 @@
 """
 Readers for legacy XML format
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -14,10 +14,10 @@ Readers for legacy XML format
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from fastoad.io.xml import VariableXmlBaseFormatter
-from fastoad.io.xml.translator import VarXpathTranslator
 from importlib_resources import open_text
 
+from fastoad.io.xml import VariableXmlBaseFormatter
+from fastoad.io.xml.translator import VarXpathTranslator
 from . import resources
 
 CONVERSION_FILENAME_1 = "legacy1.txt"

--- a/src/fastoad/io/xml/variable_io_standard.py
+++ b/src/fastoad/io/xml/variable_io_standard.py
@@ -1,7 +1,7 @@
 """
 Defines how OpenMDAO variables are serialized to XML
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -17,7 +17,6 @@ import logging
 from typing import Union, IO
 
 from fastoad.openmdao.variables import VariableList
-
 from .exceptions import FastXPathEvalError
 from .translator import VarXpathTranslator
 from .variable_io_base import VariableXmlBaseFormatter

--- a/src/fastoad/models/__init__.py
+++ b/src/fastoad/models/__init__.py
@@ -6,7 +6,7 @@ These models are based on following references:
  .. bibliography:: ../refs.bib
     :all:
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/aerodynamics/__init__.py
+++ b/src/fastoad/models/aerodynamics/__init__.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/aerodynamics/aerodynamics.py
+++ b/src/fastoad/models/aerodynamics/aerodynamics.py
@@ -2,7 +2,7 @@
     FAST - Copyright (c) 2016 ONERA ISAE
 """
 
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -15,10 +15,11 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from openmdao.api import Group
+
 from fastoad.models.aerodynamics.aerodynamics_high_speed import AerodynamicsHighSpeed
 from fastoad.models.aerodynamics.aerodynamics_landing import AerodynamicsLanding
 from fastoad.models.aerodynamics.aerodynamics_low_speed import AerodynamicsLowSpeed
-from openmdao.api import Group
 
 
 class Aerodynamics(Group):

--- a/src/fastoad/models/aerodynamics/aerodynamics_high_speed.py
+++ b/src/fastoad/models/aerodynamics/aerodynamics_high_speed.py
@@ -1,7 +1,7 @@
 """
     FAST - Copyright (c) 2016 ONERA ISAE
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -13,6 +13,8 @@
 #  GNU General Public License for more details.
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from openmdao.core.group import Group
 
 from fastoad.models.aerodynamics.components.cd0_fuselage import Cd0Fuselage
 from fastoad.models.aerodynamics.components.cd0_ht import Cd0HorizontalTail
@@ -26,7 +28,6 @@ from fastoad.models.aerodynamics.components.compute_polar import ComputePolar
 from fastoad.models.aerodynamics.components.compute_reynolds import ComputeReynolds
 from fastoad.models.aerodynamics.components.initialize_cl import InitializeClPolar
 from fastoad.models.aerodynamics.components.oswald import OswaldCoefficient
-from openmdao.core.group import Group
 
 
 class AerodynamicsHighSpeed(Group):

--- a/src/fastoad/models/aerodynamics/aerodynamics_landing.py
+++ b/src/fastoad/models/aerodynamics/aerodynamics_landing.py
@@ -1,7 +1,7 @@
 """
 Aero computation for landing phase
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -16,9 +16,9 @@ Aero computation for landing phase
 
 import numpy as np
 import openmdao.api as om
+
 from fastoad.models.options import OpenMdaoOptionDispatcherGroup
 from fastoad.utils.physics import Atmosphere
-
 from .components.compute_max_cl_landing import ComputeMaxClLanding
 from .components.high_lift_aero import ComputeDeltaHighLift
 from .external.xfoil import XfoilPolar

--- a/src/fastoad/models/aerodynamics/aerodynamics_low_speed.py
+++ b/src/fastoad/models/aerodynamics/aerodynamics_low_speed.py
@@ -2,7 +2,7 @@
     FAST - Copyright (c) 2016 ONERA ISAE
 """
 
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -14,6 +14,9 @@
 #  GNU General Public License for more details.
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from openmdao.core.group import Group
+from openmdao.core.indepvarcomp import IndepVarComp
 
 from fastoad.models.aerodynamics.components.cd0_fuselage import Cd0Fuselage
 from fastoad.models.aerodynamics.components.cd0_ht import Cd0HorizontalTail
@@ -29,8 +32,6 @@ from fastoad.models.aerodynamics.components.compute_polar import ComputePolar, P
 from fastoad.models.aerodynamics.components.compute_reynolds import ComputeReynolds
 from fastoad.models.aerodynamics.components.initialize_cl import InitializeClPolar
 from fastoad.models.aerodynamics.components.oswald import OswaldCoefficient
-from openmdao.core.group import Group
-from openmdao.core.indepvarcomp import IndepVarComp
 
 
 class AerodynamicsLowSpeed(Group):

--- a/src/fastoad/models/aerodynamics/aerodynamics_takeoff.py
+++ b/src/fastoad/models/aerodynamics/aerodynamics_takeoff.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -12,8 +12,8 @@
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import openmdao.api as om
-from fastoad.models.aerodynamics.components.compute_polar import ComputePolar, PolarType
 
+from fastoad.models.aerodynamics.components.compute_polar import ComputePolar, PolarType
 from .components.high_lift_aero import ComputeDeltaHighLift
 
 

--- a/src/fastoad/models/aerodynamics/components/__init__.py
+++ b/src/fastoad/models/aerodynamics/components/__init__.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/aerodynamics/components/cd0.py
+++ b/src/fastoad/models/aerodynamics/components/cd0.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/aerodynamics/components/cd0_fuselage.py
+++ b/src/fastoad/models/aerodynamics/components/cd0_fuselage.py
@@ -1,7 +1,7 @@
 """
     FAST - Copyright (c) 2016 ONERA ISAE
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/aerodynamics/components/cd0_ht.py
+++ b/src/fastoad/models/aerodynamics/components/cd0_ht.py
@@ -2,7 +2,7 @@
     FAST - Copyright (c) 2016 ONERA ISAE
 """
 
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/aerodynamics/components/cd0_nacelle_pylons.py
+++ b/src/fastoad/models/aerodynamics/components/cd0_nacelle_pylons.py
@@ -2,7 +2,7 @@
     FAST - Copyright (c) 2016 ONERA ISAE
 """
 
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/aerodynamics/components/cd0_total.py
+++ b/src/fastoad/models/aerodynamics/components/cd0_total.py
@@ -1,7 +1,7 @@
 """
     FAST - Copyright (c) 2016 ONERA ISAE
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/aerodynamics/components/cd0_vt.py
+++ b/src/fastoad/models/aerodynamics/components/cd0_vt.py
@@ -2,7 +2,7 @@
     FAST - Copyrigvt (c) 2016 ONERA ISAE
 """
 
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/aerodynamics/components/cd0_wing.py
+++ b/src/fastoad/models/aerodynamics/components/cd0_wing.py
@@ -1,7 +1,7 @@
 """
     FAST - Copyright (c) 2016 ONERA ISAE
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/aerodynamics/components/cd_compressibility.py
+++ b/src/fastoad/models/aerodynamics/components/cd_compressibility.py
@@ -2,7 +2,7 @@
 Compressibility drag computation.
 """
 
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/aerodynamics/components/cd_trim.py
+++ b/src/fastoad/models/aerodynamics/components/cd_trim.py
@@ -2,7 +2,7 @@
     FAST - Copyright (c) 2016 ONERA ISAE
 """
 
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/aerodynamics/components/compute_low_speed_aero.py
+++ b/src/fastoad/models/aerodynamics/components/compute_low_speed_aero.py
@@ -1,7 +1,7 @@
 """
     FAST - Copyright (c) 2016 ONERA ISAE
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/aerodynamics/components/compute_max_cl_landing.py
+++ b/src/fastoad/models/aerodynamics/components/compute_max_cl_landing.py
@@ -2,7 +2,7 @@
     FAST - Copyright (c) 2016 ONERA ISAE
 """
 
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/aerodynamics/components/compute_polar.py
+++ b/src/fastoad/models/aerodynamics/components/compute_polar.py
@@ -1,7 +1,7 @@
 """
     FAST - Copyright (c) 2016 ONERA ISAE
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/aerodynamics/components/compute_reynolds.py
+++ b/src/fastoad/models/aerodynamics/components/compute_reynolds.py
@@ -2,7 +2,7 @@
     FAST - Copyright (c) 2016 ONERA ISAE
 """
 
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -17,8 +17,9 @@
 
 
 import numpy as np
-from fastoad.utils.physics import AtmosphereSI
 from openmdao.core.explicitcomponent import ExplicitComponent
+
+from fastoad.utils.physics import AtmosphereSI
 
 
 class ComputeReynolds(ExplicitComponent):

--- a/src/fastoad/models/aerodynamics/components/high_lift_aero.py
+++ b/src/fastoad/models/aerodynamics/components/high_lift_aero.py
@@ -1,7 +1,7 @@
 """
 Computation of lift and drag increment due to high-lift devices
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/aerodynamics/components/initialize_cl.py
+++ b/src/fastoad/models/aerodynamics/components/initialize_cl.py
@@ -1,7 +1,7 @@
 """
     FAST - Copyright (c) 2016 ONERA ISAE
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/aerodynamics/components/oswald.py
+++ b/src/fastoad/models/aerodynamics/components/oswald.py
@@ -2,7 +2,7 @@
 Computation of Oswald coefficient
 """
 
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/aerodynamics/components/resources/__init__.py
+++ b/src/fastoad/models/aerodynamics/components/resources/__init__.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/aerodynamics/components/tests/__init__.py
+++ b/src/fastoad/models/aerodynamics/components/tests/__init__.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/aerodynamics/components/tests/data/aerodynamics_inputs.xml
+++ b/src/fastoad/models/aerodynamics/components/tests/data/aerodynamics_inputs.xml
@@ -1,6 +1,6 @@
 <!--
-  ~ This file is part of FAST : A framework for rapid Overall Aircraft Design
-  ~ Copyright (C) 2020  ONERA/ISAE
+  ~ This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
+  ~ Copyright (C) 2020  ONERA & ISAE-SUPAERO
   ~ FAST is free software: you can redistribute it and/or modify
   ~ it under the terms of the GNU General Public License as published by
   ~ the Free Software Foundation, either version 3 of the License, or

--- a/src/fastoad/models/aerodynamics/components/tests/test_components.py
+++ b/src/fastoad/models/aerodynamics/components/tests/test_components.py
@@ -2,7 +2,7 @@
 test module for modules in aerodynamics/components
 """
 
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/aerodynamics/constants.py
+++ b/src/fastoad/models/aerodynamics/constants.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/aerodynamics/external/__init__.py
+++ b/src/fastoad/models/aerodynamics/external/__init__.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/aerodynamics/external/xfoil/__init__.py
+++ b/src/fastoad/models/aerodynamics/external/xfoil/__init__.py
@@ -1,5 +1,5 @@
 """ Module for OpenMDAO-embedded XFOIL """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/aerodynamics/external/xfoil/resources/__init__.py
+++ b/src/fastoad/models/aerodynamics/external/xfoil/resources/__init__.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/aerodynamics/external/xfoil/tests/__init__.py
+++ b/src/fastoad/models/aerodynamics/external/xfoil/tests/__init__.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/aerodynamics/external/xfoil/tests/test_xfoil.py
+++ b/src/fastoad/models/aerodynamics/external/xfoil/tests/test_xfoil.py
@@ -1,7 +1,7 @@
 """
 Test module for XFOIL component
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/aerodynamics/external/xfoil/xfoil699/__init__.py
+++ b/src/fastoad/models/aerodynamics/external/xfoil/xfoil699/__init__.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/aerodynamics/external/xfoil/xfoil_polar.py
+++ b/src/fastoad/models/aerodynamics/external/xfoil/xfoil_polar.py
@@ -1,7 +1,7 @@
 """
 This module launches XFOIL computations
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/aerodynamics/tests/__init__.py
+++ b/src/fastoad/models/aerodynamics/tests/__init__.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/aerodynamics/tests/data/aerodynamics_inputs.xml
+++ b/src/fastoad/models/aerodynamics/tests/data/aerodynamics_inputs.xml
@@ -1,3 +1,18 @@
+<!--
+  ~ This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
+  ~ Copyright (C) 2020  ONERA & ISAE-SUPAERO
+  ~ FAST is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  -->
+
 <FASTOAD_model>
   <geometry>
     <useless>0.9</useless>

--- a/src/fastoad/models/aerodynamics/tests/test_aerodynamics.py
+++ b/src/fastoad/models/aerodynamics/tests/test_aerodynamics.py
@@ -1,7 +1,7 @@
 """
 Test module for aerodynamics groups
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/defaults.py
+++ b/src/fastoad/models/defaults.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/geometry/__init__.py
+++ b/src/fastoad/models/geometry/__init__.py
@@ -1,7 +1,7 @@
 """
 Estimation of global geometry components
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/geometry/compute_aero_center.py
+++ b/src/fastoad/models/geometry/compute_aero_center.py
@@ -2,7 +2,7 @@
     Estimation of aerodynamic center
 """
 
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/geometry/geom_components/__init__.py
+++ b/src/fastoad/models/geometry/geom_components/__init__.py
@@ -1,7 +1,7 @@
 """
 Estimation of geometry components
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/geometry/geom_components/compute_total_area.py
+++ b/src/fastoad/models/geometry/geom_components/compute_total_area.py
@@ -2,7 +2,7 @@
     Estimation of total aircraft wet area
 """
 
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/geometry/geom_components/fuselage/__init__.py
+++ b/src/fastoad/models/geometry/geom_components/fuselage/__init__.py
@@ -1,7 +1,7 @@
 """
 Estimation of fuselage geometry
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/geometry/geom_components/fuselage/compute_cnbeta_fuselage.py
+++ b/src/fastoad/models/geometry/geom_components/fuselage/compute_cnbeta_fuselage.py
@@ -2,7 +2,7 @@
     Estimation of yawing moment due to sideslip
 """
 
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/geometry/geom_components/fuselage/compute_fuselage.py
+++ b/src/fastoad/models/geometry/geom_components/fuselage/compute_fuselage.py
@@ -2,7 +2,7 @@
     Estimation of geometry of fuselase part A - Cabin (Commercial)
 """
 
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/geometry/geom_components/ht/__init__.py
+++ b/src/fastoad/models/geometry/geom_components/ht/__init__.py
@@ -1,7 +1,7 @@
 """
 Estimation of horizontal tail geometry (global)
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/geometry/geom_components/ht/components/__init__.py
+++ b/src/fastoad/models/geometry/geom_components/ht/components/__init__.py
@@ -1,7 +1,7 @@
 """
 Estimation of horizontal tail geometry (components)
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/geometry/geom_components/ht/components/compute_ht_chords.py
+++ b/src/fastoad/models/geometry/geom_components/ht/components/compute_ht_chords.py
@@ -1,7 +1,7 @@
 """
     Estimation of horizontal tail chords and span
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/geometry/geom_components/ht/components/compute_ht_cl_alpha.py
+++ b/src/fastoad/models/geometry/geom_components/ht/components/compute_ht_cl_alpha.py
@@ -2,7 +2,7 @@
     Estimation of horizontal tail lift coefficient
 """
 
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/geometry/geom_components/ht/components/compute_ht_mac.py
+++ b/src/fastoad/models/geometry/geom_components/ht/components/compute_ht_mac.py
@@ -2,7 +2,7 @@
     Estimation of horizontal tail mean aerodynamic chords
 """
 
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/geometry/geom_components/ht/components/compute_ht_sweep.py
+++ b/src/fastoad/models/geometry/geom_components/ht/components/compute_ht_sweep.py
@@ -2,7 +2,7 @@
     Estimation of horizontal tail sweeps
 """
 
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/geometry/geom_components/ht/compute_horizontal_tail.py
+++ b/src/fastoad/models/geometry/geom_components/ht/compute_horizontal_tail.py
@@ -1,7 +1,7 @@
 """
     Estimation of geometry of horizontal tail
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/geometry/geom_components/nacelle_pylons/__init__.py
+++ b/src/fastoad/models/geometry/geom_components/nacelle_pylons/__init__.py
@@ -1,7 +1,7 @@
 """
 Estimation of nacelle and pylons
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/geometry/geom_components/nacelle_pylons/compute_nacelle_pylons.py
+++ b/src/fastoad/models/geometry/geom_components/nacelle_pylons/compute_nacelle_pylons.py
@@ -1,7 +1,7 @@
 """
     Estimation of nacelle and pylon geometry
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/geometry/geom_components/vt/__init__.py
+++ b/src/fastoad/models/geometry/geom_components/vt/__init__.py
@@ -1,7 +1,7 @@
 """
 Estimation of vertical tail geometry (global)
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/geometry/geom_components/vt/components/__init__.py
+++ b/src/fastoad/models/geometry/geom_components/vt/components/__init__.py
@@ -1,7 +1,7 @@
 """
 Estimation of vertical tail geometry (components)
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/geometry/geom_components/vt/components/compute_vt_chords.py
+++ b/src/fastoad/models/geometry/geom_components/vt/components/compute_vt_chords.py
@@ -1,7 +1,7 @@
 """
     Estimation of vertical tail chords and span
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/geometry/geom_components/vt/components/compute_vt_clalpha.py
+++ b/src/fastoad/models/geometry/geom_components/vt/components/compute_vt_clalpha.py
@@ -1,7 +1,7 @@
 """
     Estimation of vertical tail lift coefficient
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/geometry/geom_components/vt/components/compute_vt_distance.py
+++ b/src/fastoad/models/geometry/geom_components/vt/components/compute_vt_distance.py
@@ -2,7 +2,7 @@
     Estimation of vertical tail distance
 """
 
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/geometry/geom_components/vt/components/compute_vt_mac.py
+++ b/src/fastoad/models/geometry/geom_components/vt/components/compute_vt_mac.py
@@ -2,7 +2,7 @@
     Estimation of vertical tail mean aerodynamic chords
 """
 
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/geometry/geom_components/vt/components/compute_vt_sweep.py
+++ b/src/fastoad/models/geometry/geom_components/vt/components/compute_vt_sweep.py
@@ -2,7 +2,7 @@
     Estimation of vertical tail sweeps
 """
 
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/geometry/geom_components/vt/compute_vertical_tail.py
+++ b/src/fastoad/models/geometry/geom_components/vt/compute_vertical_tail.py
@@ -1,7 +1,7 @@
 """
     Estimation of geometry of vertical tail
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/geometry/geom_components/wing/__init__.py
+++ b/src/fastoad/models/geometry/geom_components/wing/__init__.py
@@ -1,7 +1,7 @@
 """
 Estimation of wing (global)
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/geometry/geom_components/wing/components/__init__.py
+++ b/src/fastoad/models/geometry/geom_components/wing/components/__init__.py
@@ -1,7 +1,7 @@
 """
 Estimation of wing geometry (components)
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/geometry/geom_components/wing/components/compute_b_50.py
+++ b/src/fastoad/models/geometry/geom_components/wing/components/compute_b_50.py
@@ -2,7 +2,7 @@
     Estimation of wing B50
 """
 
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/geometry/geom_components/wing/components/compute_cl_alpha.py
+++ b/src/fastoad/models/geometry/geom_components/wing/components/compute_cl_alpha.py
@@ -2,7 +2,7 @@
     Estimation of wing lift coefficient
 """
 
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/geometry/geom_components/wing/components/compute_l1_l4.py
+++ b/src/fastoad/models/geometry/geom_components/wing/components/compute_l1_l4.py
@@ -2,7 +2,7 @@
     Estimation of wing chords (l1 and l4)
 """
 
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/geometry/geom_components/wing/components/compute_l2_l3.py
+++ b/src/fastoad/models/geometry/geom_components/wing/components/compute_l2_l3.py
@@ -2,7 +2,7 @@
     Estimation of wing chords (l2 and l3)
 """
 
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/geometry/geom_components/wing/components/compute_mac_wing.py
+++ b/src/fastoad/models/geometry/geom_components/wing/components/compute_mac_wing.py
@@ -2,7 +2,7 @@
     Estimation of wing mean aerodynamic chord
 """
 
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/geometry/geom_components/wing/components/compute_mfw.py
+++ b/src/fastoad/models/geometry/geom_components/wing/components/compute_mfw.py
@@ -2,7 +2,7 @@
     Estimation of max fuel weight
 """
 
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/geometry/geom_components/wing/components/compute_sweep_wing.py
+++ b/src/fastoad/models/geometry/geom_components/wing/components/compute_sweep_wing.py
@@ -2,7 +2,7 @@
     Estimation of wing sweeps
 """
 
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/geometry/geom_components/wing/components/compute_toc_wing.py
+++ b/src/fastoad/models/geometry/geom_components/wing/components/compute_toc_wing.py
@@ -2,7 +2,7 @@
     Estimation of wing ToC
 """
 
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/geometry/geom_components/wing/components/compute_wet_area_wing.py
+++ b/src/fastoad/models/geometry/geom_components/wing/components/compute_wet_area_wing.py
@@ -2,7 +2,7 @@
     Estimation of wing wet area
 """
 
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/geometry/geom_components/wing/components/compute_x_wing.py
+++ b/src/fastoad/models/geometry/geom_components/wing/components/compute_x_wing.py
@@ -2,7 +2,7 @@
     Estimation of wing Xs
 """
 
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/geometry/geom_components/wing/components/compute_y_wing.py
+++ b/src/fastoad/models/geometry/geom_components/wing/components/compute_y_wing.py
@@ -2,7 +2,7 @@
     Estimation of wing Ys (sections span)
 """
 
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/geometry/geom_components/wing/compute_wing.py
+++ b/src/fastoad/models/geometry/geom_components/wing/compute_wing.py
@@ -2,7 +2,7 @@
     Estimation of wing geometry
 """
 
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -14,6 +14,8 @@
 #  GNU General Public License for more details.
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from openmdao.api import Group
 
 from fastoad.models.geometry.geom_components.wing.components.compute_b_50 import ComputeB50
 from fastoad.models.geometry.geom_components.wing.components.compute_cl_alpha import ComputeCLalpha
@@ -30,8 +32,6 @@ from fastoad.models.geometry.geom_components.wing.components.compute_wet_area_wi
 )
 from fastoad.models.geometry.geom_components.wing.components.compute_x_wing import ComputeXWing
 from fastoad.models.geometry.geom_components.wing.components.compute_y_wing import ComputeYWing
-
-from openmdao.api import Group
 
 
 class ComputeWingGeometry(Group):

--- a/src/fastoad/models/geometry/geometry.py
+++ b/src/fastoad/models/geometry/geometry.py
@@ -2,7 +2,7 @@
     FAST - Copyright (c) 2016 ONERA ISAE
 """
 
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/geometry/profiles/__init__.py
+++ b/src/fastoad/models/geometry/profiles/__init__.py
@@ -1,7 +1,7 @@
 """
 Different functions available
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/geometry/profiles/get_profile.py
+++ b/src/fastoad/models/geometry/profiles/get_profile.py
@@ -1,7 +1,7 @@
 """
 Airfoil reshape function
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/geometry/profiles/profile.py
+++ b/src/fastoad/models/geometry/profiles/profile.py
@@ -1,7 +1,7 @@
 """
 Management of 2D wing profiles
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/geometry/resources/__init__.py
+++ b/src/fastoad/models/geometry/resources/__init__.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/geometry/tests/__init__.py
+++ b/src/fastoad/models/geometry/tests/__init__.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/geometry/tests/data/geometry_inputs_full.xml
+++ b/src/fastoad/models/geometry/tests/data/geometry_inputs_full.xml
@@ -1,3 +1,18 @@
+<!--
+  ~ This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
+  ~ Copyright (C) 2020  ONERA & ISAE-SUPAERO
+  ~ FAST is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  -->
+
 <FASTOAD_model>
   <TLAR>
     <AC_family>1.0</AC_family>

--- a/src/fastoad/models/geometry/tests/test_aero_center.py
+++ b/src/fastoad/models/geometry/tests/test_aero_center.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -14,8 +14,8 @@
 import os.path as pth
 
 import pytest
-from fastoad.io import VariableIO
 
+from fastoad.io import VariableIO
 from tests.testing_utilities import run_system
 from ..compute_aero_center import ComputeAeroCenter
 

--- a/src/fastoad/models/geometry/tests/test_geometry_geom_comps.py
+++ b/src/fastoad/models/geometry/tests/test_geometry_geom_comps.py
@@ -1,7 +1,7 @@
 """
 Test module for geometry functions of cg components
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -17,9 +17,9 @@ Test module for geometry functions of cg components
 import os.path as pth
 
 import pytest
+
 from fastoad.io import VariableIO
 from fastoad.models.weight.cg.cg_components import ComputeHTcg, ComputeVTcg, UpdateMLG
-
 from tests.testing_utilities import run_system
 from ..geom_components import ComputeTotalArea
 from ..geom_components.fuselage import (

--- a/src/fastoad/models/geometry/tests/test_profile.py
+++ b/src/fastoad/models/geometry/tests/test_profile.py
@@ -1,5 +1,5 @@
 """ Test module for profile.py """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/handling_qualities/__init__.py
+++ b/src/fastoad/models/handling_qualities/__init__.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/handling_qualities/compute_static_margin.py
+++ b/src/fastoad/models/handling_qualities/compute_static_margin.py
@@ -2,7 +2,7 @@
 Estimation of static margin
 """
 
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/handling_qualities/tail_sizing/__init__.py
+++ b/src/fastoad/models/handling_qualities/tail_sizing/__init__.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/handling_qualities/tail_sizing/compute_ht_area.py
+++ b/src/fastoad/models/handling_qualities/tail_sizing/compute_ht_area.py
@@ -1,7 +1,7 @@
 """
 Estimation of horizontal tail area
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -16,8 +16,9 @@ Estimation of horizontal tail area
 
 import numpy as np
 import openmdao.api as om
-from fastoad.utils.physics import Atmosphere
 from scipy.constants import g
+
+from fastoad.utils.physics import Atmosphere
 
 
 class ComputeHTArea(om.ExplicitComponent):

--- a/src/fastoad/models/handling_qualities/tail_sizing/compute_tail_areas.py
+++ b/src/fastoad/models/handling_qualities/tail_sizing/compute_tail_areas.py
@@ -1,7 +1,7 @@
 """
 Computation of tail areas w.r.t. HQ criteria
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/handling_qualities/tail_sizing/compute_vt_area.py
+++ b/src/fastoad/models/handling_qualities/tail_sizing/compute_vt_area.py
@@ -1,7 +1,7 @@
 """
 Estimation of vertical tail area
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/handling_qualities/tests/__init__.py
+++ b/src/fastoad/models/handling_qualities/tests/__init__.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/handling_qualities/tests/data/hq_inputs.xml
+++ b/src/fastoad/models/handling_qualities/tests/data/hq_inputs.xml
@@ -1,3 +1,18 @@
+<!--
+  ~ This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
+  ~ Copyright (C) 2020  ONERA & ISAE-SUPAERO
+  ~ FAST is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  -->
+
 <FASTOAD_model>
   <data>
     <TLAR>

--- a/src/fastoad/models/handling_qualities/tests/test_static_margin.py
+++ b/src/fastoad/models/handling_qualities/tests/test_static_margin.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -15,8 +15,8 @@ import os.path as pth
 
 import openmdao.api as om
 import pytest
-from fastoad.io import VariableIO
 
+from fastoad.io import VariableIO
 from tests.testing_utilities import run_system
 from ..compute_static_margin import ComputeStaticMargin
 

--- a/src/fastoad/models/handling_qualities/tests/test_tail_areas.py
+++ b/src/fastoad/models/handling_qualities/tests/test_tail_areas.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -14,8 +14,8 @@
 import os.path as pth
 
 import pytest
-from fastoad.io import VariableIO
 
+from fastoad.io import VariableIO
 from tests.testing_utilities import run_system
 from ..tail_sizing.compute_ht_area import ComputeHTArea
 from ..tail_sizing.compute_vt_area import ComputeVTArea

--- a/src/fastoad/models/loops/__init__.py
+++ b/src/fastoad/models/loops/__init__.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/loops/compute_wing_area.py
+++ b/src/fastoad/models/loops/compute_wing_area.py
@@ -1,7 +1,7 @@
 """
 Computation of wing area
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/loops/tests/__init__.py
+++ b/src/fastoad/models/loops/tests/__init__.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/loops/tests/test_compute_wing_area.py
+++ b/src/fastoad/models/loops/tests/test_compute_wing_area.py
@@ -1,7 +1,7 @@
 """
 test module for wing area computation
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/options.py
+++ b/src/fastoad/models/options.py
@@ -1,7 +1,7 @@
 """
 Module for management of options and factorizing their definition.
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/performances/__init__.py
+++ b/src/fastoad/models/performances/__init__.py
@@ -1,5 +1,5 @@
 """Package for performance modules."""
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/performances/breguet/__init__.py
+++ b/src/fastoad/models/performances/breguet/__init__.py
@@ -1,5 +1,5 @@
 """Package for performance computation using Breguet formula."""
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/performances/breguet/breguet.py
+++ b/src/fastoad/models/performances/breguet/breguet.py
@@ -1,5 +1,5 @@
 """Implementation of the Breguet Formula."""
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -13,11 +13,12 @@
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import numpy as np
+from scipy.constants import g
+
 from fastoad.base.flight_point import FlightPoint
 from fastoad.constants import EngineSetting
 from fastoad.models.propulsion import IPropulsion
 from fastoad.utils.physics import AtmosphereSI
-from scipy.constants import g
 
 
 class Breguet:

--- a/src/fastoad/models/performances/breguet/openmdao.py
+++ b/src/fastoad/models/performances/breguet/openmdao.py
@@ -1,5 +1,5 @@
 """Simple Breguet-based module for performances."""
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/performances/breguet/tests/__init__.py
+++ b/src/fastoad/models/performances/breguet/tests/__init__.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/performances/breguet/tests/test_breguet_openmdao.py
+++ b/src/fastoad/models/performances/breguet/tests/test_breguet_openmdao.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -12,15 +12,15 @@
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import openmdao.api as om
+from numpy.testing import assert_allclose
+from scipy.constants import foot
+
 from fastoad.base.flight_point import FlightPoint
 from fastoad.constants import EngineSetting
 from fastoad.models.propulsion.fuel_propulsion.rubber_engine import (
     OMRubberEngineComponent,
     RubberEngine,
 )
-from numpy.testing import assert_allclose
-from scipy.constants import foot
-
 from tests.testing_utilities import run_system
 from ..openmdao import OMBreguet
 

--- a/src/fastoad/models/performances/mission/__init__.py
+++ b/src/fastoad/models/performances/mission/__init__.py
@@ -1,5 +1,5 @@
 """Performance module for mission simulation."""
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/performances/mission/base.py
+++ b/src/fastoad/models/performances/mission/base.py
@@ -1,5 +1,5 @@
 """Base classes for mission computation."""
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/performances/mission/exceptions.py
+++ b/src/fastoad/models/performances/mission/exceptions.py
@@ -1,5 +1,5 @@
 """Exceptions for mission package."""
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/performances/mission/mission_definition/__init__.py
+++ b/src/fastoad/models/performances/mission/mission_definition/__init__.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/performances/mission/mission_definition/mission_builder.py
+++ b/src/fastoad/models/performances/mission/mission_definition/mission_builder.py
@@ -1,7 +1,7 @@
 """
 Mission generator.
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/performances/mission/mission_definition/schema.py
+++ b/src/fastoad/models/performances/mission/mission_definition/schema.py
@@ -1,7 +1,7 @@
 """
 Schema for mission definition files.
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/performances/mission/mission_definition/tests/__init__.py
+++ b/src/fastoad/models/performances/mission/mission_definition/tests/__init__.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/performances/mission/mission_definition/tests/test_mission_builder.py
+++ b/src/fastoad/models/performances/mission/mission_definition/tests/test_mission_builder.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/performances/mission/mission_definition/tests/test_schema.py
+++ b/src/fastoad/models/performances/mission/mission_definition/tests/test_schema.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/performances/mission/openmdao/__init__.py
+++ b/src/fastoad/models/performances/mission/openmdao/__init__.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/performances/mission/openmdao/mission_wrapper.py
+++ b/src/fastoad/models/performances/mission/openmdao/mission_wrapper.py
@@ -1,7 +1,7 @@
 """
 Mission wrapper.
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/performances/mission/openmdao/resources/__init__.py
+++ b/src/fastoad/models/performances/mission/openmdao/resources/__init__.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/performances/mission/openmdao/sizing_mission.py
+++ b/src/fastoad/models/performances/mission/openmdao/sizing_mission.py
@@ -1,7 +1,7 @@
 """
 OpenMDAO component for computation of sizing mission.
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/performances/mission/openmdao/tests/__init__.py
+++ b/src/fastoad/models/performances/mission/openmdao/tests/__init__.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/performances/mission/openmdao/tests/data/mission_inputs.xml
+++ b/src/fastoad/models/performances/mission/openmdao/tests/data/mission_inputs.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ This file is part of FAST : A framework for rapid Overall Aircraft Design
+  ~ This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
   ~ Copyright (C) 2020  ONERA & ISAE-SUPAERO
   ~ FAST is free software: you can redistribute it and/or modify
   ~ it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/performances/mission/openmdao/tests/test_sizing_mission.py
+++ b/src/fastoad/models/performances/mission/openmdao/tests/test_sizing_mission.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/performances/mission/polar.py
+++ b/src/fastoad/models/performances/mission/polar.py
@@ -1,5 +1,5 @@
 """Aerodynamic polar data."""
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/performances/mission/routes.py
+++ b/src/fastoad/models/performances/mission/routes.py
@@ -1,7 +1,7 @@
 """
 Classes for computation of routes (i.e. assemblies of climb, cruise and descent phases).
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/performances/mission/segments/__init__.py
+++ b/src/fastoad/models/performances/mission/segments/__init__.py
@@ -1,5 +1,5 @@
 """Classes for simulating flight segments."""
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/performances/mission/segments/altitude_change.py
+++ b/src/fastoad/models/performances/mission/segments/altitude_change.py
@@ -1,5 +1,5 @@
 """Classes for climb/descent segments."""
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/performances/mission/segments/base.py
+++ b/src/fastoad/models/performances/mission/segments/base.py
@@ -1,5 +1,5 @@
 """Base classes for simulating flight segments."""
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/performances/mission/segments/cruise.py
+++ b/src/fastoad/models/performances/mission/segments/cruise.py
@@ -1,5 +1,5 @@
 """Classes for simulating cruise segments."""
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/performances/mission/segments/hold.py
+++ b/src/fastoad/models/performances/mission/segments/hold.py
@@ -1,5 +1,5 @@
 """Class for simulating hold segment."""
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/performances/mission/segments/speed_change.py
+++ b/src/fastoad/models/performances/mission/segments/speed_change.py
@@ -1,5 +1,5 @@
 """Classes for acceleration/deceleration segments."""
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/performances/mission/segments/taxi.py
+++ b/src/fastoad/models/performances/mission/segments/taxi.py
@@ -1,5 +1,5 @@
 """Classes for Taxi sequences."""
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -15,7 +15,6 @@
 from typing import Tuple
 
 from fastoad.models.performances.mission.segments.base import FixedDurationSegment
-
 from .base import ManualThrustSegment
 
 

--- a/src/fastoad/models/performances/mission/segments/tests/__init__.py
+++ b/src/fastoad/models/performances/mission/segments/tests/__init__.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/performances/mission/segments/tests/test_segments.py
+++ b/src/fastoad/models/performances/mission/segments/tests/test_segments.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/performances/mission/tests/__init__.py
+++ b/src/fastoad/models/performances/mission/tests/__init__.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/performances/mission/tests/test_routes.py
+++ b/src/fastoad/models/performances/mission/tests/test_routes.py
@@ -7,7 +7,7 @@ Therefore, obtained numerical results depend mainly on other classes, so this is
 why almost no numerical check is done here (such checks will be done in the
 non-regression tests).
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/performances/mission/tests/test_util.py
+++ b/src/fastoad/models/performances/mission/tests/test_util.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/performances/mission/util.py
+++ b/src/fastoad/models/performances/mission/util.py
@@ -1,7 +1,7 @@
 """
 Utilities for mission computation.
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/propulsion/__init__.py
+++ b/src/fastoad/models/propulsion/__init__.py
@@ -1,7 +1,7 @@
 """
 Package for propulsion modules
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/propulsion/fuel_propulsion/__init__.py
+++ b/src/fastoad/models/propulsion/fuel_propulsion/__init__.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/propulsion/fuel_propulsion/base.py
+++ b/src/fastoad/models/propulsion/fuel_propulsion/base.py
@@ -1,5 +1,5 @@
 """Base classes for fuel-consuming propulsion models."""
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/propulsion/fuel_propulsion/rubber_engine/__init__.py
+++ b/src/fastoad/models/propulsion/fuel_propulsion/rubber_engine/__init__.py
@@ -5,7 +5,7 @@ Provides a parametric model for turbofan:
 - as OpenMDAO modules
 """
 
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/propulsion/fuel_propulsion/rubber_engine/constants.py
+++ b/src/fastoad/models/propulsion/fuel_propulsion/rubber_engine/constants.py
@@ -2,7 +2,7 @@
 Constants for rubber engine analytical models
 """
 
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/propulsion/fuel_propulsion/rubber_engine/exceptions.py
+++ b/src/fastoad/models/propulsion/fuel_propulsion/rubber_engine/exceptions.py
@@ -1,7 +1,7 @@
 """Exceptions for rubber_engine package."""
 
 
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/propulsion/fuel_propulsion/rubber_engine/openmdao.py
+++ b/src/fastoad/models/propulsion/fuel_propulsion/rubber_engine/openmdao.py
@@ -1,5 +1,5 @@
 """OpenMDAO wrapping of RubberEngine."""
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/propulsion/fuel_propulsion/rubber_engine/rubber_engine.py
+++ b/src/fastoad/models/propulsion/fuel_propulsion/rubber_engine/rubber_engine.py
@@ -1,5 +1,5 @@
 """Parametric turbofan engine."""
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/propulsion/fuel_propulsion/rubber_engine/tests/__init__.py
+++ b/src/fastoad/models/propulsion/fuel_propulsion/rubber_engine/tests/__init__.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/propulsion/fuel_propulsion/rubber_engine/tests/test_openmdao_engine.py
+++ b/src/fastoad/models/propulsion/fuel_propulsion/rubber_engine/tests/test_openmdao_engine.py
@@ -1,7 +1,7 @@
 """
 Test module for OpenMDAO versions of RubberEngine
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -16,8 +16,8 @@ Test module for OpenMDAO versions of RubberEngine
 
 import numpy as np
 import openmdao.api as om
-from fastoad.constants import EngineSetting
 
+from fastoad.constants import EngineSetting
 from tests.testing_utilities import run_system
 from ..openmdao import OMRubberEngineComponent
 

--- a/src/fastoad/models/propulsion/fuel_propulsion/rubber_engine/tests/test_rubber_engine.py
+++ b/src/fastoad/models/propulsion/fuel_propulsion/rubber_engine/tests/test_rubber_engine.py
@@ -2,7 +2,7 @@
 Test module for rubber_engine.py
 """
 
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -18,10 +18,10 @@ Test module for rubber_engine.py
 import numpy as np
 import pandas as pd
 import pytest
+
 from fastoad.base.flight_point import FlightPoint
 from fastoad.constants import EngineSetting
 from fastoad.utils.physics import Atmosphere
-
 from ..rubber_engine import RubberEngine
 
 

--- a/src/fastoad/models/propulsion/fuel_propulsion/tests/__init__.py
+++ b/src/fastoad/models/propulsion/fuel_propulsion/tests/__init__.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/propulsion/fuel_propulsion/tests/test_propulsion.py
+++ b/src/fastoad/models/propulsion/fuel_propulsion/tests/test_propulsion.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/propulsion/propulsion.py
+++ b/src/fastoad/models/propulsion/propulsion.py
@@ -1,6 +1,6 @@
 """Base module for propulsion models."""
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA/ISAE
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
+#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or

--- a/src/fastoad/models/weight/__init__.py
+++ b/src/fastoad/models/weight/__init__.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/weight/cg/__init__.py
+++ b/src/fastoad/models/weight/cg/__init__.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/weight/cg/cg.py
+++ b/src/fastoad/models/weight/cg/cg.py
@@ -1,7 +1,7 @@
 """
     FAST - Copyright (c) 2016 ONERA ISAE
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/weight/cg/cg_components/__init__.py
+++ b/src/fastoad/models/weight/cg/cg_components/__init__.py
@@ -1,7 +1,7 @@
 """
 Estimation of centers of gravity
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/weight/cg/cg_components/compute_cg_control_surfaces.py
+++ b/src/fastoad/models/weight/cg/cg_components/compute_cg_control_surfaces.py
@@ -2,7 +2,7 @@
     Estimation of control surfaces center of gravity
 """
 
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/weight/cg/cg_components/compute_cg_loadcase1.py
+++ b/src/fastoad/models/weight/cg/cg_components/compute_cg_loadcase1.py
@@ -2,7 +2,7 @@
     Estimation of center of gravity for load case 1
 """
 
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/weight/cg/cg_components/compute_cg_loadcase2.py
+++ b/src/fastoad/models/weight/cg/cg_components/compute_cg_loadcase2.py
@@ -2,7 +2,7 @@
     Estimation of center of gravity for load case 2
 """
 
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/weight/cg/cg_components/compute_cg_loadcase3.py
+++ b/src/fastoad/models/weight/cg/cg_components/compute_cg_loadcase3.py
@@ -2,7 +2,7 @@
     Estimation of center of gravity for load case 3
 """
 
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/weight/cg/cg_components/compute_cg_loadcase4.py
+++ b/src/fastoad/models/weight/cg/cg_components/compute_cg_loadcase4.py
@@ -2,7 +2,7 @@
     Estimation of center of gravity for load case 4
 """
 
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/weight/cg/cg_components/compute_cg_others.py
+++ b/src/fastoad/models/weight/cg/cg_components/compute_cg_others.py
@@ -2,7 +2,7 @@
     Estimation of other components center of gravities
 """
 
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/weight/cg/cg_components/compute_cg_ratio_aft.py
+++ b/src/fastoad/models/weight/cg/cg_components/compute_cg_ratio_aft.py
@@ -1,7 +1,7 @@
 """
     Estimation of center of gravity ratio with aft
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/weight/cg/cg_components/compute_cg_tanks.py
+++ b/src/fastoad/models/weight/cg/cg_components/compute_cg_tanks.py
@@ -2,7 +2,7 @@
     Estimation of tanks center of gravity
 """
 
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -18,10 +18,11 @@
 import math
 
 import numpy as np
-from fastoad.models.geometry import resources
 from importlib_resources import open_text
 from openmdao.core.explicitcomponent import ExplicitComponent
 from scipy import interpolate
+
+from fastoad.models.geometry import resources
 
 
 class ComputeTanksCG(ExplicitComponent):

--- a/src/fastoad/models/weight/cg/cg_components/compute_cg_wing.py
+++ b/src/fastoad/models/weight/cg/cg_components/compute_cg_wing.py
@@ -2,7 +2,7 @@
     Estimation of wing center of gravity
 """
 
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/weight/cg/cg_components/compute_global_cg.py
+++ b/src/fastoad/models/weight/cg/cg_components/compute_global_cg.py
@@ -2,7 +2,7 @@
     Estimation of global center of gravity
 """
 
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -15,14 +15,14 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from openmdao.api import Group
+
 from fastoad.models.weight.cg.cg_components import ComputeCGLoadCase1
 from fastoad.models.weight.cg.cg_components.compute_cg_loadcase2 import ComputeCGLoadCase2
 from fastoad.models.weight.cg.cg_components.compute_cg_loadcase3 import ComputeCGLoadCase3
 from fastoad.models.weight.cg.cg_components.compute_cg_loadcase4 import ComputeCGLoadCase4
 from fastoad.models.weight.cg.cg_components.compute_cg_ratio_aft import ComputeCGRatioAft
 from fastoad.models.weight.cg.cg_components.compute_max_cg_ratio import ComputeMaxCGratio
-
-from openmdao.api import Group
 
 
 class ComputeGlobalCG(Group):

--- a/src/fastoad/models/weight/cg/cg_components/compute_ht_cg.py
+++ b/src/fastoad/models/weight/cg/cg_components/compute_ht_cg.py
@@ -2,7 +2,7 @@
     Estimation of horizontal tail center of gravity
 """
 
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/weight/cg/cg_components/compute_max_cg_ratio.py
+++ b/src/fastoad/models/weight/cg/cg_components/compute_max_cg_ratio.py
@@ -2,7 +2,7 @@
     Estimation of maximum center of gravity ratio
 """
 
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/weight/cg/cg_components/compute_vt_cg.py
+++ b/src/fastoad/models/weight/cg/cg_components/compute_vt_cg.py
@@ -2,7 +2,7 @@
     Estimation of vertical tail center of gravity
 """
 
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/weight/cg/cg_components/update_mlg.py
+++ b/src/fastoad/models/weight/cg/cg_components/update_mlg.py
@@ -2,7 +2,7 @@
     Estimation of main landing gear center of gravity
 """
 
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/weight/cg/tests/__init__.py
+++ b/src/fastoad/models/weight/cg/tests/__init__.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/weight/cg/tests/data/cg_inputs.xml
+++ b/src/fastoad/models/weight/cg/tests/data/cg_inputs.xml
@@ -1,3 +1,18 @@
+<!--
+  ~ This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
+  ~ Copyright (C) 2020  ONERA & ISAE-SUPAERO
+  ~ FAST is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  -->
+
 <FASTOAD_model>
   <data>
     <TLAR>

--- a/src/fastoad/models/weight/cg/tests/test_geometry_cg_components.py
+++ b/src/fastoad/models/weight/cg/tests/test_geometry_cg_components.py
@@ -1,7 +1,7 @@
 """
 Test module for geometry functions of cg components
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -17,8 +17,8 @@ Test module for geometry functions of cg components
 import os.path as pth
 
 import pytest
-from fastoad.io import VariableIO
 
+from fastoad.io import VariableIO
 from tests.testing_utilities import run_system
 from ..cg import ComputeAircraftCG
 from ..cg_components import ComputeCGLoadCase1

--- a/src/fastoad/models/weight/mass_breakdown/__init__.py
+++ b/src/fastoad/models/weight/mass_breakdown/__init__.py
@@ -1,7 +1,7 @@
 """
 Estimation of Aircraft Weight
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/weight/mass_breakdown/a_airframe/__init__.py
+++ b/src/fastoad/models/weight/mass_breakdown/a_airframe/__init__.py
@@ -1,7 +1,7 @@
 """
 Estimation of airframe weight
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/weight/mass_breakdown/a_airframe/a1_wing_weight.py
+++ b/src/fastoad/models/weight/mass_breakdown/a_airframe/a1_wing_weight.py
@@ -1,7 +1,7 @@
 """
 Estimation of wing weight
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/weight/mass_breakdown/a_airframe/a2_fuselage_weight.py
+++ b/src/fastoad/models/weight/mass_breakdown/a_airframe/a2_fuselage_weight.py
@@ -1,7 +1,7 @@
 """
 Estimation of fuselage weight
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/weight/mass_breakdown/a_airframe/a3_empennage_weight.py
+++ b/src/fastoad/models/weight/mass_breakdown/a_airframe/a3_empennage_weight.py
@@ -1,7 +1,7 @@
 """
 Estimation of empennage weight
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/weight/mass_breakdown/a_airframe/a4_flight_control_weight.py
+++ b/src/fastoad/models/weight/mass_breakdown/a_airframe/a4_flight_control_weight.py
@@ -1,7 +1,7 @@
 """
 Estimation of flight controls weight
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/weight/mass_breakdown/a_airframe/a5_landing_gear_weight.py
+++ b/src/fastoad/models/weight/mass_breakdown/a_airframe/a5_landing_gear_weight.py
@@ -1,7 +1,7 @@
 """
 Estimation of landing gear weight
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/weight/mass_breakdown/a_airframe/a6_pylons_weight.py
+++ b/src/fastoad/models/weight/mass_breakdown/a_airframe/a6_pylons_weight.py
@@ -1,7 +1,7 @@
 """
 Estimation of pylons weight
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/weight/mass_breakdown/a_airframe/a7_paint_weight.py
+++ b/src/fastoad/models/weight/mass_breakdown/a_airframe/a7_paint_weight.py
@@ -1,7 +1,7 @@
 """
 Estimation of paint weight
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/weight/mass_breakdown/b_propulsion/__init__.py
+++ b/src/fastoad/models/weight/mass_breakdown/b_propulsion/__init__.py
@@ -1,7 +1,7 @@
 """
 Estimation of propulsion weight
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/weight/mass_breakdown/b_propulsion/b1_engine_weight.py
+++ b/src/fastoad/models/weight/mass_breakdown/b_propulsion/b1_engine_weight.py
@@ -1,7 +1,7 @@
 """
 Estimation of engine weight
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/weight/mass_breakdown/b_propulsion/b2_fuel_lines_weight.py
+++ b/src/fastoad/models/weight/mass_breakdown/b_propulsion/b2_fuel_lines_weight.py
@@ -1,7 +1,7 @@
 """
 Estimation of fuel lines weight
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/weight/mass_breakdown/b_propulsion/b3_unconsumables_weight.py
+++ b/src/fastoad/models/weight/mass_breakdown/b_propulsion/b3_unconsumables_weight.py
@@ -1,7 +1,7 @@
 """
 Estimation of fuel lines weight
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/weight/mass_breakdown/c_systems/__init__.py
+++ b/src/fastoad/models/weight/mass_breakdown/c_systems/__init__.py
@@ -2,7 +2,7 @@
 Estimation of weight of all-mission systems
 """
 
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/weight/mass_breakdown/c_systems/c1_power_systems_weight.py
+++ b/src/fastoad/models/weight/mass_breakdown/c_systems/c1_power_systems_weight.py
@@ -1,7 +1,7 @@
 """
 Estimation of power systems weight
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/weight/mass_breakdown/c_systems/c2_life_support_systems_weight.py
+++ b/src/fastoad/models/weight/mass_breakdown/c_systems/c2_life_support_systems_weight.py
@@ -1,7 +1,7 @@
 """
 Estimation of life support systems weight
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/weight/mass_breakdown/c_systems/c3_navigation_systems_weight.py
+++ b/src/fastoad/models/weight/mass_breakdown/c_systems/c3_navigation_systems_weight.py
@@ -1,7 +1,7 @@
 """
 Estimation of navigation systems weight
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -15,8 +15,9 @@ Estimation of navigation systems weight
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import numpy as np
-from fastoad.constants import RangeCategory
 from openmdao.core.explicitcomponent import ExplicitComponent
+
+from fastoad.constants import RangeCategory
 
 
 class NavigationSystemsWeight(ExplicitComponent):

--- a/src/fastoad/models/weight/mass_breakdown/c_systems/c4_transmissions_systems_weight.py
+++ b/src/fastoad/models/weight/mass_breakdown/c_systems/c4_transmissions_systems_weight.py
@@ -1,7 +1,7 @@
 """
 Estimation of transmissions systems weight
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/weight/mass_breakdown/c_systems/c5_fixed_operational_systems_weight.py
+++ b/src/fastoad/models/weight/mass_breakdown/c_systems/c5_fixed_operational_systems_weight.py
@@ -1,7 +1,7 @@
 """
 Estimation of fixed operational systems weight
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/weight/mass_breakdown/c_systems/c6_flight_kit_weight.py
+++ b/src/fastoad/models/weight/mass_breakdown/c_systems/c6_flight_kit_weight.py
@@ -1,7 +1,7 @@
 """
 Estimation of flight kit weight
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/weight/mass_breakdown/cs25.py
+++ b/src/fastoad/models/weight/mass_breakdown/cs25.py
@@ -1,7 +1,7 @@
 """
 Computation of load cases
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -15,8 +15,9 @@ Computation of load cases
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import numpy as np
-from fastoad.utils.physics.atmosphere import Atmosphere
 from openmdao.core.explicitcomponent import ExplicitComponent
+
+from fastoad.utils.physics.atmosphere import Atmosphere
 
 
 class Loads(ExplicitComponent):

--- a/src/fastoad/models/weight/mass_breakdown/d_furniture/__init__.py
+++ b/src/fastoad/models/weight/mass_breakdown/d_furniture/__init__.py
@@ -1,7 +1,7 @@
 """
 Estimation of furniture weight
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/weight/mass_breakdown/d_furniture/d1_cargo_configuration_weight.py
+++ b/src/fastoad/models/weight/mass_breakdown/d_furniture/d1_cargo_configuration_weight.py
@@ -1,7 +1,7 @@
 """
 Estimation of cargo configuration weight
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/weight/mass_breakdown/d_furniture/d2_passenger_seats_weight.py
+++ b/src/fastoad/models/weight/mass_breakdown/d_furniture/d2_passenger_seats_weight.py
@@ -1,7 +1,7 @@
 """
 Estimation of passenger seats weight
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/weight/mass_breakdown/d_furniture/d3_food_water_weight.py
+++ b/src/fastoad/models/weight/mass_breakdown/d_furniture/d3_food_water_weight.py
@@ -1,7 +1,7 @@
 """
 Estimation of food water weight
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/weight/mass_breakdown/d_furniture/d4_security_kit_weight.py
+++ b/src/fastoad/models/weight/mass_breakdown/d_furniture/d4_security_kit_weight.py
@@ -1,7 +1,7 @@
 """
 Estimation of security kit weight
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/weight/mass_breakdown/d_furniture/d5_toilets_weight.py
+++ b/src/fastoad/models/weight/mass_breakdown/d_furniture/d5_toilets_weight.py
@@ -1,7 +1,7 @@
 """
 Estimation of toilets weight
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/weight/mass_breakdown/e_crew/__init__.py
+++ b/src/fastoad/models/weight/mass_breakdown/e_crew/__init__.py
@@ -1,7 +1,7 @@
 """
 Estimation of crew weight
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/weight/mass_breakdown/e_crew/crew_weight.py
+++ b/src/fastoad/models/weight/mass_breakdown/e_crew/crew_weight.py
@@ -1,7 +1,7 @@
 """
 Estimation of crew weight
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/weight/mass_breakdown/mass_breakdown.py
+++ b/src/fastoad/models/weight/mass_breakdown/mass_breakdown.py
@@ -1,5 +1,5 @@
 """Main components for mass breakdown."""
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/weight/mass_breakdown/payload.py
+++ b/src/fastoad/models/weight/mass_breakdown/payload.py
@@ -1,7 +1,7 @@
 """
 Payload mass computation
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/weight/mass_breakdown/tests/__init__.py
+++ b/src/fastoad/models/weight/mass_breakdown/tests/__init__.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/weight/mass_breakdown/tests/data/mass_breakdown_inputs.xml
+++ b/src/fastoad/models/weight/mass_breakdown/tests/data/mass_breakdown_inputs.xml
@@ -1,3 +1,18 @@
+<!--
+  ~ This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
+  ~ Copyright (C) 2020  ONERA & ISAE-SUPAERO
+  ~ FAST is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  -->
+
 <FASTOAD_model>
   <data>
     <TLAR>

--- a/src/fastoad/models/weight/mass_breakdown/tests/test_mass_breakdown.py
+++ b/src/fastoad/models/weight/mass_breakdown/tests/test_mass_breakdown.py
@@ -1,7 +1,7 @@
 """
 Test module for mass breakdown functions
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -19,8 +19,8 @@ import os.path as pth
 
 import openmdao.api as om
 import pytest
-from fastoad.io import VariableIO
 
+from fastoad.io import VariableIO
 from tests.testing_utilities import run_system
 from ..a_airframe import (
     EmpennageWeight,

--- a/src/fastoad/models/weight/mass_breakdown/update_mlw_and_mzfw.py
+++ b/src/fastoad/models/weight/mass_breakdown/update_mlw_and_mzfw.py
@@ -1,7 +1,7 @@
 """
 Main component for mass breakdown
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/models/weight/weight.py
+++ b/src/fastoad/models/weight/weight.py
@@ -1,7 +1,7 @@
 """
 Weight computation (mass and CG)
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/module_management/__init__.py
+++ b/src/fastoad/module_management/__init__.py
@@ -1,7 +1,7 @@
 """
 Management of modules using Pelix/iPOPO
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/module_management/bundle_loader.py
+++ b/src/fastoad/module_management/bundle_loader.py
@@ -1,7 +1,7 @@
 """
 Basis for registering and retrieving services
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/module_management/constants.py
+++ b/src/fastoad/module_management/constants.py
@@ -1,5 +1,5 @@
 """The place for module-level constants."""
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/module_management/exceptions.py
+++ b/src/fastoad/module_management/exceptions.py
@@ -1,5 +1,5 @@
 """Exceptions for module_management package."""
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/module_management/openmdao_system_registry.py
+++ b/src/fastoad/module_management/openmdao_system_registry.py
@@ -1,7 +1,7 @@
 """
 The base layer for registering and retrieving OpenMDAO systems
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/module_management/service_registry.py
+++ b/src/fastoad/module_management/service_registry.py
@@ -1,5 +1,5 @@
 """Module for registering services."""
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/module_management/tests/__init__.py
+++ b/src/fastoad/module_management/tests/__init__.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/module_management/tests/dummy_pelix_bundles/hello_world_with_decorators.py
+++ b/src/fastoad/module_management/tests/dummy_pelix_bundles/hello_world_with_decorators.py
@@ -1,7 +1,7 @@
 """
 Basic "Hello World" services using iPOPO decorators
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/module_management/tests/dummy_pelix_bundles/hello_world_without_decorators.py
+++ b/src/fastoad/module_management/tests/dummy_pelix_bundles/hello_world_without_decorators.py
@@ -1,7 +1,7 @@
 """
 Basic "Hello World" services without using iPOPO decorators
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/module_management/tests/sellar_example/__init__.py
+++ b/src/fastoad/module_management/tests/sellar_example/__init__.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/module_management/tests/sellar_example/disc1.py
+++ b/src/fastoad/module_management/tests/sellar_example/disc1.py
@@ -3,7 +3,7 @@
     Sellar discipline 1
 """
 
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/module_management/tests/sellar_example/disc1_base.py
+++ b/src/fastoad/module_management/tests/sellar_example/disc1_base.py
@@ -2,7 +2,7 @@
 """
     Sellar discipline 1
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/module_management/tests/sellar_example/disc2.py
+++ b/src/fastoad/module_management/tests/sellar_example/disc2.py
@@ -2,7 +2,7 @@
 """
     Sellar discipline 2
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/module_management/tests/sellar_example/disc2_base.py
+++ b/src/fastoad/module_management/tests/sellar_example/disc2_base.py
@@ -2,7 +2,7 @@
 """
     Sellar discipline 2
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/module_management/tests/sellar_example/functions.py
+++ b/src/fastoad/module_management/tests/sellar_example/functions.py
@@ -2,7 +2,7 @@
 """
   Sellar functions
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/module_management/tests/sellar_example/functions_base.py
+++ b/src/fastoad/module_management/tests/sellar_example/functions_base.py
@@ -2,7 +2,7 @@
 """
   Sellar functions
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/module_management/tests/sellar_example/register_components.py
+++ b/src/fastoad/module_management/tests/sellar_example/register_components.py
@@ -1,7 +1,7 @@
 """
 Demonstrates how to register components in OpenMDAOSystemRegistry
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/module_management/tests/sellar_example/sellar.py
+++ b/src/fastoad/module_management/tests/sellar_example/sellar.py
@@ -2,7 +2,7 @@
 """
   Sellar openMDAO group
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/module_management/tests/test_background_pelix_framework.py
+++ b/src/fastoad/module_management/tests/test_background_pelix_framework.py
@@ -1,7 +1,7 @@
 """
 Just checking that Pelix framework is automatically started
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/module_management/tests/test_bundle_loader.py
+++ b/src/fastoad/module_management/tests/test_bundle_loader.py
@@ -1,7 +1,7 @@
 """
 Test module for bundle_loader.py
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/module_management/tests/test_openmdao_system_registry.py
+++ b/src/fastoad/module_management/tests/test_openmdao_system_registry.py
@@ -1,7 +1,7 @@
 """
 Test module for openmdao_system_registry.py
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/notebooks/__init__.py
+++ b/src/fastoad/notebooks/__init__.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/notebooks/tutorial/__init__.py
+++ b/src/fastoad/notebooks/tutorial/__init__.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/notebooks/tutorial/data/__init__.py
+++ b/src/fastoad/notebooks/tutorial/data/__init__.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/notebooks/tutorial/img/__init__.py
+++ b/src/fastoad/notebooks/tutorial/img/__init__.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/openmdao/__init__.py
+++ b/src/fastoad/openmdao/__init__.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/openmdao/problem.py
+++ b/src/fastoad/openmdao/problem.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/openmdao/resources/__init__.py
+++ b/src/fastoad/openmdao/resources/__init__.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/openmdao/tests/__init__.py
+++ b/src/fastoad/openmdao/tests/__init__.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/openmdao/tests/sellar_example/__init__.py
+++ b/src/fastoad/openmdao/tests/sellar_example/__init__.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/openmdao/tests/sellar_example/disc1.py
+++ b/src/fastoad/openmdao/tests/sellar_example/disc1.py
@@ -3,7 +3,7 @@
     Sellar discipline 1
 """
 
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/openmdao/tests/sellar_example/disc1_base.py
+++ b/src/fastoad/openmdao/tests/sellar_example/disc1_base.py
@@ -2,7 +2,7 @@
 """
     Sellar discipline 1
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/openmdao/tests/sellar_example/disc2.py
+++ b/src/fastoad/openmdao/tests/sellar_example/disc2.py
@@ -2,7 +2,7 @@
 """
     Sellar discipline 2
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/openmdao/tests/sellar_example/disc2_base.py
+++ b/src/fastoad/openmdao/tests/sellar_example/disc2_base.py
@@ -2,7 +2,7 @@
 """
     Sellar discipline 2
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/openmdao/tests/sellar_example/functions.py
+++ b/src/fastoad/openmdao/tests/sellar_example/functions.py
@@ -2,7 +2,7 @@
 """
   Sellar functions
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/openmdao/tests/sellar_example/functions_base.py
+++ b/src/fastoad/openmdao/tests/sellar_example/functions_base.py
@@ -2,7 +2,7 @@
 """
   Sellar functions
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/openmdao/tests/sellar_example/register_components.py
+++ b/src/fastoad/openmdao/tests/sellar_example/register_components.py
@@ -1,7 +1,7 @@
 """
 Demonstrates how to register components in OpenMDAOSystemRegistry
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/openmdao/tests/sellar_example/sellar.py
+++ b/src/fastoad/openmdao/tests/sellar_example/sellar.py
@@ -2,7 +2,7 @@
 """
   Sellar openMDAO group
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/openmdao/tests/test_utils.py
+++ b/src/fastoad/openmdao/tests/test_utils.py
@@ -1,7 +1,7 @@
 """
 Test module for OpenMDAO checks
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/openmdao/tests/test_validity_checker.py
+++ b/src/fastoad/openmdao/tests/test_validity_checker.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -19,6 +19,7 @@ from shutil import rmtree
 
 import openmdao.api as om
 import pytest
+
 from fastoad.openmdao.validity_checker import ValidityDomainChecker, ValidityStatus
 from fastoad.openmdao.variables import VariableList, Variable
 

--- a/src/fastoad/openmdao/tests/test_variables.py
+++ b/src/fastoad/openmdao/tests/test_variables.py
@@ -1,7 +1,7 @@
 """
 Module for testing VariableList.py
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/openmdao/types.py
+++ b/src/fastoad/openmdao/types.py
@@ -1,7 +1,7 @@
 """
 Types to interact with OpenMDAO
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/openmdao/utils.py
+++ b/src/fastoad/openmdao/utils.py
@@ -1,7 +1,7 @@
 """
 Utility functions for OpenMDAO classes/instances
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/openmdao/validity_checker.py
+++ b/src/fastoad/openmdao/validity_checker.py
@@ -1,5 +1,5 @@
 """For checking validity domain of OpenMDAO variables."""
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -23,8 +23,9 @@ from uuid import UUID
 
 import numpy as np
 import openmdao.api as om
-from fastoad.openmdao.variables import VariableList
 from openmdao.utils.units import convert_units
+
+from fastoad.openmdao.variables import VariableList
 
 CheckRecord = namedtuple(
     "CheckRecord",

--- a/src/fastoad/openmdao/variables.py
+++ b/src/fastoad/openmdao/variables.py
@@ -1,7 +1,7 @@
 """
 Module for managing OpenMDAO variables
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/register.py
+++ b/src/fastoad/register.py
@@ -2,7 +2,7 @@
 This module is for registering all internal OpenMDAO modules that we want
 available through OpenMDAOSystemRegistry
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/utils/__init__.py
+++ b/src/fastoad/utils/__init__.py
@@ -2,7 +2,7 @@
 """
 This package contains various utilities
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/utils/files.py
+++ b/src/fastoad/utils/files.py
@@ -2,7 +2,7 @@
 Convenience functions for file and directories
 """
 
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/utils/physics/__init__.py
+++ b/src/fastoad/utils/physics/__init__.py
@@ -1,7 +1,7 @@
 """
 This package contains utilities regarding physics
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/utils/physics/atmosphere.py
+++ b/src/fastoad/utils/physics/atmosphere.py
@@ -1,7 +1,7 @@
 """
 Simple implementation of International Standard Atmosphere.
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/utils/physics/tests/__init__.py
+++ b/src/fastoad/utils/physics/tests/__init__.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/utils/physics/tests/test_atmosphere.py
+++ b/src/fastoad/utils/physics/tests/test_atmosphere.py
@@ -1,5 +1,5 @@
 """Tests for Atmosphere class"""
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/utils/postprocessing/__init__.py
+++ b/src/fastoad/utils/postprocessing/__init__.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -11,5 +11,5 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from .variable_viewer import VariableViewer
 from .optimization_viewer import OptimizationViewer
+from .variable_viewer import VariableViewer

--- a/src/fastoad/utils/postprocessing/analysis_and_plots.py
+++ b/src/fastoad/utils/postprocessing/analysis_and_plots.py
@@ -1,7 +1,7 @@
 """
 Defines the analysis and plotting functions for postprocessing
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/utils/postprocessing/exceptions.py
+++ b/src/fastoad/utils/postprocessing/exceptions.py
@@ -1,7 +1,7 @@
 """
 Exception for postprocessing
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/utils/postprocessing/optimization_viewer.py
+++ b/src/fastoad/utils/postprocessing/optimization_viewer.py
@@ -1,7 +1,7 @@
 """
 Defines the variable viewer for postprocessing
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/utils/postprocessing/tests/__init__.py
+++ b/src/fastoad/utils/postprocessing/tests/__init__.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/utils/postprocessing/tests/data/inputs.xml
+++ b/src/fastoad/utils/postprocessing/tests/data/inputs.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ This file is part of FAST : A framework for rapid Overall Aircraft Design
+  ~ This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
   ~ Copyright (C) 2020  ONERA & ISAE-SUPAERO
   ~ FAST is free software: you can redistribute it and/or modify
   ~ it under the terms of the GNU General Public License as published by

--- a/src/fastoad/utils/postprocessing/tests/data/light_data.xml
+++ b/src/fastoad/utils/postprocessing/tests/data/light_data.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ This file is part of FAST : A framework for rapid Overall Aircraft Design
+  ~ This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
   ~ Copyright (C) 2020  ONERA & ISAE-SUPAERO
   ~ FAST is free software: you can redistribute it and/or modify
   ~ it under the terms of the GNU General Public License as published by

--- a/src/fastoad/utils/postprocessing/tests/data/problem_outputs.xml
+++ b/src/fastoad/utils/postprocessing/tests/data/problem_outputs.xml
@@ -1,3 +1,18 @@
+<!--
+  ~ This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
+  ~ Copyright (C) 2020  ONERA & ISAE-SUPAERO
+  ~ FAST is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  -->
+
 <FASTOAD_model>
   <data>
     <TLAR>

--- a/src/fastoad/utils/postprocessing/tests/data/sellar_example/disc1.py
+++ b/src/fastoad/utils/postprocessing/tests/data/sellar_example/disc1.py
@@ -3,7 +3,7 @@
     Sellar discipline 1
 """
 
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/utils/postprocessing/tests/data/sellar_example/disc1_base.py
+++ b/src/fastoad/utils/postprocessing/tests/data/sellar_example/disc1_base.py
@@ -2,7 +2,7 @@
 """
     Sellar discipline 1
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/utils/postprocessing/tests/data/sellar_example/disc2.py
+++ b/src/fastoad/utils/postprocessing/tests/data/sellar_example/disc2.py
@@ -2,7 +2,7 @@
 """
     Sellar discipline 2
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/utils/postprocessing/tests/data/sellar_example/disc2_base.py
+++ b/src/fastoad/utils/postprocessing/tests/data/sellar_example/disc2_base.py
@@ -2,7 +2,7 @@
 """
     Sellar discipline 2
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/utils/postprocessing/tests/data/sellar_example/functions.py
+++ b/src/fastoad/utils/postprocessing/tests/data/sellar_example/functions.py
@@ -2,7 +2,7 @@
 """
   Sellar functions
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/utils/postprocessing/tests/data/sellar_example/functions_base.py
+++ b/src/fastoad/utils/postprocessing/tests/data/sellar_example/functions_base.py
@@ -2,7 +2,7 @@
 """
   Sellar functions
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/utils/postprocessing/tests/data/sellar_example/register_components.py
+++ b/src/fastoad/utils/postprocessing/tests/data/sellar_example/register_components.py
@@ -1,7 +1,7 @@
 """
 Demonstrates how to register components in OpenMDAOSystemRegistry
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/utils/postprocessing/tests/data/sellar_example/sellar.py
+++ b/src/fastoad/utils/postprocessing/tests/data/sellar_example/sellar.py
@@ -2,7 +2,7 @@
 """
   Sellar openMDAO group
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/utils/postprocessing/tests/test_analysis_and_plots.py
+++ b/src/fastoad/utils/postprocessing/tests/test_analysis_and_plots.py
@@ -1,7 +1,7 @@
 """
 Tests for analysis and plots functions
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/utils/postprocessing/tests/test_optimization_viewer.py
+++ b/src/fastoad/utils/postprocessing/tests/test_optimization_viewer.py
@@ -1,7 +1,7 @@
 """
 Tests for FAST-OAD optimization viewer
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -18,9 +18,9 @@ import os.path as pth
 from shutil import rmtree, copyfile
 
 import pytest
+
 from fastoad.cmd import api
 from fastoad.io.configuration.configuration import FASTOADProblemConfigurator
-
 from .. import OptimizationViewer
 from ..exceptions import FastMissingFile
 

--- a/src/fastoad/utils/postprocessing/tests/test_variable_viewer.py
+++ b/src/fastoad/utils/postprocessing/tests/test_variable_viewer.py
@@ -1,7 +1,7 @@
 """
 Tests for FAST-OAD variable viewer
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/utils/postprocessing/variable_viewer.py
+++ b/src/fastoad/utils/postprocessing/variable_viewer.py
@@ -1,7 +1,7 @@
 """
 Defines the variable viewer for postprocessing
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/utils/resource_management/__init__.py
+++ b/src/fastoad/utils/resource_management/__init__.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/utils/resource_management/copy.py
+++ b/src/fastoad/utils/resource_management/copy.py
@@ -1,7 +1,7 @@
 """
 Helper module for copying resources
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/utils/resource_management/tests/__init__.py
+++ b/src/fastoad/utils/resource_management/tests/__init__.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/utils/resource_management/tests/resources/__init__.py
+++ b/src/fastoad/utils/resource_management/tests/resources/__init__.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/utils/resource_management/tests/resources/subfolder/__init__.py
+++ b/src/fastoad/utils/resource_management/tests/resources/subfolder/__init__.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/utils/resource_management/tests/test_copy.py
+++ b/src/fastoad/utils/resource_management/tests/test_copy.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/utils/strings.py
+++ b/src/fastoad/utils/strings.py
@@ -2,7 +2,7 @@
 Module for string-related operations
 """
 
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
@@ -19,6 +19,7 @@ import io
 import re
 
 import numpy as np
+
 from fastoad.exceptions import FastError
 
 

--- a/src/fastoad/utils/tests/__init__.py
+++ b/src/fastoad/utils/tests/__init__.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/src/fastoad/utils/tests/test_get_float_list_from_string.py
+++ b/src/fastoad/utils/tests/test_get_float_list_from_string.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,7 +1,7 @@
 """
 Test package
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 """
     Basic settings for tests
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/tests/integration_tests/__init__.py
+++ b/tests/integration_tests/__init__.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/tests/integration_tests/oad_process/__init__.py
+++ b/tests/integration_tests/oad_process/__init__.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/tests/integration_tests/oad_process/data/CeRAS01_legacy.xml
+++ b/tests/integration_tests/oad_process/data/CeRAS01_legacy.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet type="text/xsl" href="fastDataModel.xsl"?>
 <!--
-  ~ This file is part of FAST : A framework for rapid Overall Aircraft Design
+  ~ This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
   ~ Copyright (C) 2020  ONERA & ISAE-SUPAERO
   ~ FAST is free software: you can redistribute it and/or modify
   ~ it under the terms of the GNU General Public License as published by

--- a/tests/integration_tests/oad_process/data/CeRAS01_legacy_breguet_result.xml
+++ b/tests/integration_tests/oad_process/data/CeRAS01_legacy_breguet_result.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet type="text/xsl" href="fastDataModel.xsl"?>
 <!--
-  ~ This file is part of FAST : A framework for rapid Overall Aircraft Design
+  ~ This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
   ~ Copyright (C) 2020  ONERA & ISAE-SUPAERO
   ~ FAST is free software: you can redistribute it and/or modify
   ~ it under the terms of the GNU General Public License as published by

--- a/tests/integration_tests/oad_process/data/CeRAS01_legacy_mission_result.xml
+++ b/tests/integration_tests/oad_process/data/CeRAS01_legacy_mission_result.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <?xml-stylesheet type="text/xsl" href="fastDataModel.xsl"?>
 <!--
-  ~ This file is part of FAST : A framework for rapid Overall Aircraft Design
+  ~ This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
   ~ Copyright (C) 2020  ONERA & ISAE-SUPAERO
   ~ FAST is free software: you can redistribute it and/or modify
   ~ it under the terms of the GNU General Public License as published by

--- a/tests/testing_utilities.py
+++ b/tests/testing_utilities.py
@@ -1,8 +1,8 @@
 """
 Convenience functions for helping tests
 """
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA/ISAE
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
+#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or

--- a/tests/xfoil_exe/__init__.py
+++ b/tests/xfoil_exe/__init__.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by

--- a/tests/xfoil_exe/get_xfoil.py
+++ b/tests/xfoil_exe/get_xfoil.py
@@ -1,4 +1,4 @@
-#  This file is part of FAST : A framework for rapid Overall Aircraft Design
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2020  ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
In copyright texts, "FAST" become "FAST-OAD".

By the way, some changes appear in imports, because PyCharm did its import optimization in all modified files (i.e. all files), but the result is just more consistent.