### PR TITLE
Check NaN values before computation

### DIFF
--- a/src/fastoad/io/configuration/exceptions.py
+++ b/src/fastoad/io/configuration/exceptions.py
@@ -2,7 +2,7 @@
 Exceptions for package configuration
 """
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -13,6 +13,8 @@ Exceptions for package configuration
 #  GNU General Public License for more details.
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from typing import List
 
 from fastoad.exceptions import FastError
 
@@ -89,5 +91,20 @@ class FASTConfigurationError(FastError):
             msg = "Section [%s] is missing" % self.missing_section
         else:
             msg = "Undefined"
+
+        super().__init__(self, msg)
+
+
+class FASTConfigurationNanInInputFile(FastError):
+    """Raised if NaN values are read in input data file."""
+
+    def __init__(self, input_file_path: str, nan_variable_names: List[str]):
+        self.input_file_path = input_file_path
+        self.nan_variable_names = nan_variable_names
+
+        msg = "NaN values found in input file (%s). Please check following variables: %s" % (
+            input_file_path,
+            nan_variable_names,
+        )
 
         super().__init__(self, msg)

--- a/src/fastoad/io/configuration/tests/data/nan_inputs.xml
+++ b/src/fastoad/io/configuration/tests/data/nan_inputs.xml
@@ -1,0 +1,20 @@
+<!--
+  ~ This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
+  ~ Copyright (C) 2021 ONERA & ISAE-SUPAERO
+  ~ FAST is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  -->
+
+<aircraft>
+  <x>nan</x>
+  <z units="m**2">nan</z>
+  <y1>nan</y1><!--if this variable is kept in the input IVC, OpenMDAO will raise an exception because it is an output of a component-->
+</aircraft>

--- a/src/fastoad/io/configuration/tests/data/ref_inputs.xml
+++ b/src/fastoad/io/configuration/tests/data/ref_inputs.xml
@@ -1,6 +1,6 @@
 <!--
   ~ This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-  ~ Copyright (C) 2020  ONERA & ISAE-SUPAERO
+  ~ Copyright (C) 2021 ONERA & ISAE-SUPAERO
   ~ FAST is free software: you can redistribute it and/or modify
   ~ it under the terms of the GNU General Public License as published by
   ~ the Free Software Foundation, either version 3 of the License, or
@@ -14,6 +14,8 @@
   -->
 
 <aircraft>
-  <x>1.0</x>
-  <z units="m**2">5.0 2.0</z>
+    <x>1.0</x>
+    <z units="m**2">5.0 2.0</z>
+    <y1>nan</y1><!-- If this variable is kept in the input IVC, OpenMDAO will raise an exception because it is an output of a component
+                     As it should be ignored, its NaN value should bring no harm.-->
 </aircraft>

--- a/src/fastoad/io/configuration/tests/data/ref_inputs.xml
+++ b/src/fastoad/io/configuration/tests/data/ref_inputs.xml
@@ -18,4 +18,6 @@
     <z units="m**2">5.0 2.0</z>
     <y1>nan</y1><!-- If this variable is kept in the input IVC, OpenMDAO will raise an exception because it is an output of a component
                      As it should be ignored, its NaN value should bring no harm.-->
+    <foo>nan</foo><!-- This totally unused variable is expected to be transferred in output file -->
+    <bar>42</bar><!-- This totally unused variable is expected to be transferred in output file -->
 </aircraft>

--- a/src/fastoad/io/configuration/tests/test_configuration.py
+++ b/src/fastoad/io/configuration/tests/test_configuration.py
@@ -30,8 +30,8 @@ from fastoad.io.configuration.configuration import (
     TABLE_MODEL,
 )
 from ..exceptions import (
-    FASTConfigurationError,
     FASTConfigurationBadOpenMDAOInstructionError,
+    FASTConfigurationError,
     FASTConfigurationNanInInputFile,
 )
 
@@ -89,6 +89,10 @@ def test_problem_definition_with_xml_ref(cleanup):
     """ Tests what happens when writing inputs using data from existing XML file"""
     conf = FASTOADProblemConfigurator(pth.join(DATA_FOLDER_PATH, "valid_sellar.toml"))
 
+    result_folder_path = pth.join(RESULTS_FOLDER_PATH, "problem_definition_with_xml_ref")
+    conf.input_file_path = pth.join(result_folder_path, "inputs.xml")
+    conf.output_file_path = pth.join(result_folder_path, "outputs.xml")
+
     input_data = pth.join(DATA_FOLDER_PATH, "ref_inputs.xml")
     conf.write_needed_inputs(input_data)
 
@@ -105,8 +109,12 @@ def test_problem_definition_with_custom_xml(cleanup):
     """ Tests what happens when writing inputs using existing XML with some unwanted var"""
     conf = FASTOADProblemConfigurator(pth.join(DATA_FOLDER_PATH, "valid_sellar.toml"))
 
+    result_folder_path = pth.join(RESULTS_FOLDER_PATH, "problem_definition_with_custom_xml")
+    conf.input_file_path = pth.join(result_folder_path, "inputs.xml")
+    conf.output_file_path = pth.join(result_folder_path, "outputs.xml")
+
     input_data = pth.join(DATA_FOLDER_PATH, "ref_inputs.xml")
-    os.makedirs(RESULTS_FOLDER_PATH, exist_ok=True)
+    os.makedirs(result_folder_path, exist_ok=True)
     shutil.copy(input_data, conf.input_file_path)
 
     problem = conf.get_problem(read_inputs=True, auto_scaling=True)
@@ -114,6 +122,7 @@ def test_problem_definition_with_custom_xml(cleanup):
     problem.run_model()
 
     assert problem["f"] == pytest.approx(28.58830817, abs=1e-6)
+    problem.write_outputs()
 
 
 def test_problem_definition_with_nan_inputs(cleanup):
@@ -137,6 +146,9 @@ def test_problem_definition_with_xml_ref_run_optim(cleanup):
     """
     conf = FASTOADProblemConfigurator(pth.join(DATA_FOLDER_PATH, "valid_sellar.toml"))
 
+    result_folder_path = pth.join(RESULTS_FOLDER_PATH, "problem_definition_with_xml_ref_run_optim")
+    conf.input_file_path = pth.join(result_folder_path, "inputs.xml")
+
     input_data = pth.join(DATA_FOLDER_PATH, "ref_inputs.xml")
     conf.write_needed_inputs(input_data)
 
@@ -147,6 +159,8 @@ def test_problem_definition_with_xml_ref_run_optim(cleanup):
     assert problem1["f"] == pytest.approx(28.58830817, abs=1e-6)
     problem1.run_driver()
     assert problem1["f"] == pytest.approx(3.18339395, abs=1e-6)
+    problem1.output_file_path = pth.join(result_folder_path, "outputs_1.xml")
+    problem1.write_outputs()
 
     # Runs optimization problem with monolithic FD
     problem2 = conf.get_problem(read_inputs=True)
@@ -156,6 +170,8 @@ def test_problem_definition_with_xml_ref_run_optim(cleanup):
     assert problem2["f"] == pytest.approx(28.58830817, abs=1e-6)
     problem2.run_driver()
     assert problem2["f"] == pytest.approx(3.18339395, abs=1e-6)
+    problem2.output_file_path = pth.join(result_folder_path, "outputs_2.xml")
+    problem2.write_outputs()
 
 
 def test_set_optimization_definition(cleanup):

--- a/src/fastoad/openmdao/utils.py
+++ b/src/fastoad/openmdao/utils.py
@@ -14,7 +14,7 @@ Utility functions for OpenMDAO classes/instances
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from typing import Tuple, List, TypeVar
+from typing import Tuple, List
 
 import numpy as np
 import openmdao.api as om
@@ -59,6 +59,3 @@ def get_unconnected_input_names(
         optional_unconnected = optional_unconnected - mandatory_unconnected
 
     return list(mandatory_unconnected), list(optional_unconnected)
-
-
-T = TypeVar("T", bound=om.Problem)


### PR DESCRIPTION
This PR makes FAST-OAD raise an error when the read inputs of a problem contain one or more NaN values, which fixes #241.

Also, the behavior has changed concerning input data that are not expected by the process:
  - Until now, the OpenMDAO problem was fed with all variables from provided input data file:
     1) if a variable was in input data file but was not part of the process, it was added to the input IVC with no more consequence (except possibly a slight performance loss...)
     2) but if a variable was in input data file and was an output somewhere in the process, then it made OpenMDAO rightly raise an error about having twice the same output.
   - With this PR, unneeded variables are ignored when reading input file, but stored to be written later in output file without having been part of the computation. It avoids problem (ii), and also avoids to raise an exception for a NaN value that would not be used anyway in case (i). It also allows to keep unused variables that may be used later in another computation.

