### PR TITLE
Fix mission-based computation in tutorial notebook

### DIFF
--- a/src/fastoad/cmd/api.py
+++ b/src/fastoad/cmd/api.py
@@ -48,6 +48,9 @@ _LOGGER = logging.getLogger(__name__)
 SAMPLE_FILENAME = "fastoad.yml"
 MAX_TABLE_WIDTH = 200  # For variable list text output
 
+# Used for test purposes only
+_PROBLEM_CONFIGURATOR = None
+
 
 def generate_configuration_file(configuration_file_path: str, overwrite: bool = False):
     """
@@ -87,6 +90,7 @@ def generate_inputs(
     :raise FastFileExistsError: if overwrite==False and configuration_file_path already exists
     """
     conf = FASTOADProblemConfigurator(configuration_file_path)
+    conf._set_configuration_modifier(_PROBLEM_CONFIGURATOR)
 
     input_file_path = conf.input_file_path
     if not overwrite and pth.exists(conf.input_file_path):
@@ -136,6 +140,7 @@ def list_variables(
         out = sys.stdout
 
     conf = FASTOADProblemConfigurator(configuration_file_path)
+    conf._set_configuration_modifier(_PROBLEM_CONFIGURATOR)
     problem = conf.get_problem()
     problem.setup()
 
@@ -208,6 +213,7 @@ def list_systems(
 
     if configuration_file_path:
         conf = FASTOADProblemConfigurator(configuration_file_path)
+        conf._set_configuration_modifier(_PROBLEM_CONFIGURATOR)
         conf.load(configuration_file_path)
     # As the problem has been configured, BundleLoader now knows additional registered systems
 
@@ -277,7 +283,9 @@ def write_n2(configuration_file_path: str, n2_file_path: str = None, overwrite: 
         )
 
     make_parent_dir(n2_file_path)
-    problem = FASTOADProblemConfigurator(configuration_file_path).get_problem()
+    conf = FASTOADProblemConfigurator(configuration_file_path)
+    conf._set_configuration_modifier(_PROBLEM_CONFIGURATOR)
+    problem = conf.get_problem()
     problem.setup()
     problem.final_setup()
 
@@ -316,7 +324,9 @@ def write_xdsm(
 
     make_parent_dir(xdsm_file_path)
 
-    problem = FASTOADProblemConfigurator(configuration_file_path).get_problem()
+    conf = FASTOADProblemConfigurator(configuration_file_path)
+    conf._set_configuration_modifier(_PROBLEM_CONFIGURATOR)
+    problem = conf.get_problem()
     problem.setup()
     problem.final_setup()
 
@@ -366,9 +376,9 @@ def _run_problem(
     :return: the OpenMDAO problem after run
     """
 
-    problem = FASTOADProblemConfigurator(configuration_file_path).get_problem(
-        read_inputs=True, auto_scaling=auto_scaling
-    )
+    conf = FASTOADProblemConfigurator(configuration_file_path)
+    conf._set_configuration_modifier(_PROBLEM_CONFIGURATOR)
+    problem = conf.get_problem(read_inputs=True, auto_scaling=auto_scaling)
 
     outputs_path = pth.normpath(problem.output_file_path)
     if not overwrite and pth.exists(outputs_path):
@@ -431,9 +441,10 @@ def optimization_viewer(configuration_file_path: str):
     :param configuration_file_path: problem definition
     :return: display of the OptimizationViewer
     """
-    problem_configuration = FASTOADProblemConfigurator(configuration_file_path)
+    conf = FASTOADProblemConfigurator(configuration_file_path)
+    conf._set_configuration_modifier(_PROBLEM_CONFIGURATOR)
     viewer = OptimizationViewer()
-    viewer.load(problem_configuration)
+    viewer.load(conf)
 
     return viewer.display()
 

--- a/src/fastoad/cmd/resources/fastoad.yml
+++ b/src/fastoad/cmd/resources/fastoad.yml
@@ -11,47 +11,57 @@ output_file: ./problem_outputs.xml
 driver: om.ScipyOptimizeDriver(tol=1e-6, optimizer='COBYLA')
 
 # Definition of OpenMDAO model
+# Although "model" is a mandatory name for the top level of the model, its
+# sub-components can be freely named by user
 model:
-  # Solvers are defined assuming the OpenMDAO convention "import openmdao.api as om"
+
+  #  Solvers are defined assuming the OpenMDAO convention "import openmdao.api as om"
   nonlinear_solver: om.NonlinearBlockGS(maxiter=100, atol=1e-2)
   linear_solver: om.DirectSolver()
 
-  # Although "model" is a mandatory name for the top level of the model, its
-  # sub-components can be freely named by user
-  geometry:
-    # An OpenMDAO component is identified by its "id"
-    id: fastoad.geometry.legacy
-  weight:
-    id: fastoad.weight.legacy
-  mtow:
-    id: fastoad.mass_performances.compute_MTOW
-  hq_tail_sizing:
-    id: fastoad.handling_qualities.tail_sizing
-  hq_static_margin:
-    id : fastoad.handling_qualities.static_margin
-  wing_position:
-    id: fastoad.loop.wing_position
-  aerodynamics_highspeed:
-    id: fastoad.aerodynamics.highspeed.legacy
-  aerodynamics_lowspeed:
-    id: fastoad.aerodynamics.lowspeed.legacy
-  aerodynamics_takeoff:
-    id: fastoad.aerodynamics.takeoff.legacy
-  aerodynamics_landing:
-    id: fastoad.aerodynamics.landing.legacy
-    use_xfoil: false
+
+  # Components can be put in sub-groups
+  subgroup:
+
+    # A group can be set with its own solvers.
+    # Uncomment the 2 next lines for using the performance module with "mission_file_path: ::sizing_mission"
+    #nonlinear_solver: om.NonlinearBlockGS(maxiter=100, atol=1e-2, iprint=0)
+    #linear_solver: om.DirectSolver()
+
+    geometry:
+      # An OpenMDAO component is identified by its "id"
+      id: fastoad.geometry.legacy
+    weight:
+      id: fastoad.weight.legacy
+    mtow:
+      id: fastoad.mass_performances.compute_MTOW
+    hq_tail_sizing:
+      id: fastoad.handling_qualities.tail_sizing
+    hq_static_margin:
+      id: fastoad.handling_qualities.static_margin
+    wing_position:
+      id: fastoad.loop.wing_position
+    aerodynamics_highspeed:
+      id: fastoad.aerodynamics.highspeed.legacy
+    aerodynamics_lowspeed:
+      id: fastoad.aerodynamics.lowspeed.legacy
+    aerodynamics_takeoff:
+      id: fastoad.aerodynamics.takeoff.legacy
+    aerodynamics_landing:
+      id: fastoad.aerodynamics.landing.legacy
+      use_xfoil: false
   performance:
     id: fastoad.performances.mission
     propulsion_id: fastoad.wrapper.propulsion.rubber_engine
     mission_file_path: ::sizing_breguet
-    # mission_file_path: ::sizing_mission
-    out_file:  ./flight_points.csv
+    # mission_file_path: ::sizing_mission  # Activate solvers in "subgroup" if you use this line.
+    out_file: ./flight_points.csv
     adjust_fuel: true
     is_sizing: true
   wing_area:
     id: fastoad.loop.wing_area
 
-optimization:  # This section is needed only if optimization process is run
+optimization: # This section is needed only if optimization process is run
   design_variables:
     - name: data:geometry:wing:aspect_ratio
       lower: 9.0

--- a/src/fastoad/cmd/resources/fastoad.yml
+++ b/src/fastoad/cmd/resources/fastoad.yml
@@ -8,7 +8,7 @@ input_file: ./problem_inputs.xml
 output_file: ./problem_outputs.xml
 
 # Definition of problem driver assuming the OpenMDAO convention "import openmdao.api as om"
-driver: om.ScipyOptimizeDriver(tol=1e-6, optimizer='COBYLA')
+driver: om.ScipyOptimizeDriver(tol=1e-2, optimizer='COBYLA')
 
 # Definition of OpenMDAO model
 # Although "model" is a mandatory name for the top level of the model, its

--- a/src/fastoad/notebooks/tutorial/01_tutorial.ipynb
+++ b/src/fastoad/notebooks/tutorial/01_tutorial.ipynb
@@ -87,7 +87,7 @@
     "\n",
     "# The above generated configuration uses the quick and simple Breguet module to compute performances. \n",
     "# If you want to use the more accurate, much more CPU-costly time-step integration, uncomment and run \n",
-    "# the next line, but don't do the optimization part (will be fixed after this alpha release):\n",
+    "# the next line:\n",
     "#shutil.copy(pth.join(DATA_FOLDER_PATH, \"oad_process_timestep_mission.yml\"), CONFIGURATION_FILE)"
    ]
   },

--- a/src/fastoad/notebooks/tutorial/data/oad_process_timestep_mission.yml
+++ b/src/fastoad/notebooks/tutorial/data/oad_process_timestep_mission.yml
@@ -11,53 +11,64 @@ output_file: ./problem_outputs.xml
 driver: om.ScipyOptimizeDriver(tol=1e-6, optimizer='COBYLA')
 
 # Definition of OpenMDAO model
+# Although "model" is a mandatory name for the top level of the model, its
+# sub-components can be freely named by user
 model:
-  # Solvers are defined assuming the OpenMDAO convention "import openmdao.api as om"
-  nonlinear_solver: om.NonlinearBlockGS(maxiter=100)
+
+  #  Solvers are defined assuming the OpenMDAO convention "import openmdao.api as om"
+  nonlinear_solver: om.NonlinearBlockGS(maxiter=100, atol=1e-2)
   linear_solver: om.DirectSolver()
 
-  # Although "model" is a mandatory name for the top level of the model, its
-  # sub-components can be freely named by user
-  geometry:
-    # An OpenMDAO component is identified by its "id"
-    id: fastoad.geometry.legacy
-  weight:
-    id: fastoad.weight.legacy
-  mtow:
-    id: fastoad.mass_performances.compute_MTOW
-  aerodynamics_highspeed:
-    id: fastoad.aerodynamics.highspeed.legacy
-  aerodynamics_lowspeed:
-    id: fastoad.aerodynamics.lowspeed.legacy
-  aerodynamics_takeoff:
-    id: fastoad.aerodynamics.takeoff.legacy
-  aerodynamics_landing:
-    id: fastoad.aerodynamics.landing.legacy
-    use_xfoil: false
+
+  # Components can be put in sub-groups
+  subgroup:
+
+    # A group can be set with its own solvers.
+    # Uncomment the 2 next lines for using the performance module with "mission_file_path: ::sizing_mission"
+    nonlinear_solver: om.NonlinearBlockGS(maxiter=100, atol=1e-2, iprint=0)
+    linear_solver: om.DirectSolver()
+
+    geometry:
+      # An OpenMDAO component is identified by its "id"
+      id: fastoad.geometry.legacy
+    weight:
+      id: fastoad.weight.legacy
+    mtow:
+      id: fastoad.mass_performances.compute_MTOW
+    hq_tail_sizing:
+      id: fastoad.handling_qualities.tail_sizing
+    hq_static_margin:
+      id: fastoad.handling_qualities.static_margin
+    wing_position:
+      id: fastoad.loop.wing_position
+    aerodynamics_highspeed:
+      id: fastoad.aerodynamics.highspeed.legacy
+    aerodynamics_lowspeed:
+      id: fastoad.aerodynamics.lowspeed.legacy
+    aerodynamics_takeoff:
+      id: fastoad.aerodynamics.takeoff.legacy
+    aerodynamics_landing:
+      id: fastoad.aerodynamics.landing.legacy
+      use_xfoil: false
   performance:
     id: fastoad.performances.mission
     propulsion_id: fastoad.wrapper.propulsion.rubber_engine
+    #mission_file_path: ::sizing_breguet
+    mission_file_path: ::sizing_mission  # Activate solvers in "subgroup" if you use this line.
     out_file: ./flight_points.csv
     adjust_fuel: true
-    add_solver: false
     is_sizing: true
-    use_initializer_iteration: true
-  hq_tail_sizing:
-    id: fastoad.handling_qualities.tail_sizing
-  hq_static_margin:
-    id: fastoad.handling_qualities.static_margin
   wing_area:
     id: fastoad.loop.wing_area
 
 optimization: # This section is needed only if optimization process is run
   design_variables:
-    - name: data:geometry:wing:MAC:at25percent:x
-      lower: 16.0
+    - name: data:geometry:wing:aspect_ratio
+      lower: 9.0
       upper: 18.0
   constraints:
-    - name: data:handling_qualities:static_margin
-      lower: 0.05
-      upper: 0.1
+    - name: data:geometry:wing:span
+      upper: 60.0
   objective:
-    - name: data:mission:sizing:fuel
+    - name: data:mission:sizing:needed_block_fuel
       scaler: 1.e-4

--- a/src/fastoad/notebooks/tutorial/data/oad_process_timestep_mission.yml
+++ b/src/fastoad/notebooks/tutorial/data/oad_process_timestep_mission.yml
@@ -8,7 +8,7 @@ input_file: ./problem_inputs.xml
 output_file: ./problem_outputs.xml
 
 # Definition of problem driver assuming the OpenMDAO convention "import openmdao.api as om"
-driver: om.ScipyOptimizeDriver(tol=1e-6, optimizer='COBYLA')
+driver: om.ScipyOptimizeDriver(tol=1e-2, optimizer='COBYLA')
 
 # Definition of OpenMDAO model
 # Although "model" is a mandatory name for the top level of the model, its

--- a/tests/integration_tests/oad_process/test_oad_process.py
+++ b/tests/integration_tests/oad_process/test_oad_process.py
@@ -331,7 +331,7 @@ def test_api_optim(cleanup):
     assert_allclose(problem["data:geometry:wing:aspect_ratio"], 13.58, atol=1e-2)
 
     # Constraint
-    assert_allclose(problem["data:geometry:wing:span"], 44.02, rtol=1e-2)
+    assert_allclose(problem["data:geometry:wing:span"], 44.03, atol=1e-2)
 
     # Objective
     assert_allclose(problem["data:mission:sizing:needed_block_fuel"], 20363, atol=1)


### PR DESCRIPTION
This PR ensures that computation works in tutorial notebook, even when activating the time-step mission computation.

`fastoad.yml` has been modified to achieve that. It needed a subgroup that does not contain the performance model. It was the occasion to illustrate the capability to create subgroups, with or without solvers.

Also, tolerance for the driver has been increased. It slightly reduces the computation time, with negligible impact on results.