### PR TITLE
Issue 280 n2 rendering

### DIFF
--- a/src/fastoad/cmd/api.py
+++ b/src/fastoad/cmd/api.py
@@ -326,10 +326,6 @@ def write_n2(configuration_file_path: str, n2_file_path: str = None, overwrite: 
     :param overwrite:
     """
 
-    if not n2_file_path:
-        n2_file_path = pth.join(pth.dirname(configuration_file_path), "n2.html")
-    n2_file_path = pth.abspath(n2_file_path)
-
     if not overwrite and pth.exists(n2_file_path):
         raise FastFileExistsError(
             "N2-diagram file %s not written because it already exists. "

--- a/src/fastoad/cmd/api.py
+++ b/src/fastoad/cmd/api.py
@@ -317,7 +317,7 @@ def _get_detailed_system_list():
     return cell_list
 
 
-def write_n2(configuration_file_path: str, n2_file_path: str = None, overwrite: bool = False):
+def write_n2(configuration_file_path: str, n2_file_path: str = "n2.html", overwrite: bool = False):
     """
     Write the N2 diagram of the problem in file n2.html
 

--- a/src/fastoad/cmd/api.py
+++ b/src/fastoad/cmd/api.py
@@ -341,7 +341,7 @@ def write_n2(configuration_file_path: str, n2_file_path: str = None, overwrite: 
     problem.final_setup()
 
     om.n2(problem, outfile=n2_file_path, show_browser=False)
-    _LOGGER.info("N2 diagram written in %s", n2_file_path)
+    _LOGGER.info("N2 diagram written in %s", pth.abspath(n2_file_path))
 
 
 def write_xdsm(

--- a/src/fastoad/cmd/api.py
+++ b/src/fastoad/cmd/api.py
@@ -24,7 +24,7 @@ from typing import IO, Union
 import openmdao.api as om
 import requests
 from IPython import InteractiveShell
-from IPython.core.display import HTML, display
+from IPython.display import HTML, display, clear_output
 from tabulate import tabulate
 from whatsopt.show_utils import generate_xdsm_html
 from whatsopt.whatsopt_client import PROD_URL, WhatsOpt
@@ -341,6 +341,7 @@ def write_n2(configuration_file_path: str, n2_file_path: str = None, overwrite: 
     problem.final_setup()
 
     om.n2(problem, outfile=n2_file_path, show_browser=False)
+    clear_output()
     _LOGGER.info("N2 diagram written in %s", pth.abspath(n2_file_path))
 
 

--- a/src/fastoad/cmd/tests/test_api.py
+++ b/src/fastoad/cmd/tests/test_api.py
@@ -101,10 +101,6 @@ def test_list_variables(cleanup):
 
 
 def test_write_n2(cleanup):
-    default_n2_file_path = "n2.html"
-    api.write_n2(CONFIGURATION_FILE_PATH)
-    assert pth.exists(default_n2_file_path)
-    os.remove(default_n2_file_path)
 
     n2_file_path = pth.join(RESULTS_FOLDER_PATH, "other_n2.html")
     api.write_n2(CONFIGURATION_FILE_PATH, n2_file_path)

--- a/src/fastoad/cmd/tests/test_api.py
+++ b/src/fastoad/cmd/tests/test_api.py
@@ -101,7 +101,7 @@ def test_list_variables(cleanup):
 
 
 def test_write_n2(cleanup):
-    default_n2_file_path = pth.join(DATA_FOLDER_PATH, "n2.html")
+    default_n2_file_path = "n2.html"
     api.write_n2(CONFIGURATION_FILE_PATH)
     assert pth.exists(default_n2_file_path)
     os.remove(default_n2_file_path)


### PR DESCRIPTION
This PR is a work around for using `api.write_n2()`  introduced by openmdao 3.7 `om.n2()` display mecanism when using file absolute paths in Jupyter notebooks.

Later, we should probably use directly openmdao's `om.n2()` for displaying the n2 in Jupyter notebooks.

Fixes #280.