### PR TITLE
Limitation of test workflow triggering

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,15 @@
 name: Tests
 
-on: [push]
+on:
+  push:
+    branches:
+      - '**'
+    tags-ignore:
+      - '**'
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'poetry.lock'
 
 jobs:
 

--- a/.github/workflows/watchman_tests.yml
+++ b/.github/workflows/watchman_tests.yml
@@ -3,7 +3,16 @@ name: Watchman Tests
 # of the locked one.
 # It will warn developers if the update of a dependency broke something.
 
-on: [push]
+on:
+  push:
+    branches:
+      - '**'
+    tags-ignore:
+      - '**'
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'pyproject.toml'
 
 jobs:
 
@@ -13,8 +22,8 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')"
     strategy:
       matrix:
-        python-version: [3.8]
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        python-version: [ 3.8 ]
+        os: [ ubuntu-latest, windows-latest, macos-latest ]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This PR modifies the tests workflow so they run only when changes are to software code, tests, or dependencies.
Also, tag creation do not trigger test workflows anymore.

> Here you may consider the PR approval as a simple read confirmation.