### PR TITLE
Release v1.0.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+Version 1.0.2
+=============
+- FAST-OAD now requires a lower version of `ruamel.yaml`. It should prevent Anaconda to try and fail to update its
+  "clone" of `ruamel.yaml`. (#308)
+
 Version 1.0.1
 =============
 - Bug fixes:

--- a/src/fastoad/__init__.py
+++ b/src/fastoad/__init__.py
@@ -15,7 +15,6 @@
 from pkg_resources import DistributionNotFound, get_distribution
 
 import fastoad.module_management._plugins
-from .cmd import api
 
 try:
     # Change here if project is renamed and does not equal the package name


### PR DESCRIPTION
New release to integrate the workaround for #306.

draft release: https://github.com/fast-aircraft-design/FAST-OAD/releases/tag/untagged-401c159ae5382c940841