### PR TITLE
Fix doc

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -99,6 +99,9 @@ autodoc_member_order = "bysource"
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = "sphinx"
 
+# Will warn about all broken links
+nitpicky = True
+
 # -- Options for HTML output -------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for

--- a/docs/documentation/custom_modules/add_propulsion_module.rst
+++ b/docs/documentation/custom_modules/add_propulsion_module.rst
@@ -15,7 +15,7 @@ to access your engine parameters through FAST-OAD process.
 The FlightPoint class
 *********************
 
-The :class:`~fastoad.base.flight_point.FlightPoint` class is designed to store
+The :class:`~fastoad.model_base.flight_point.FlightPoint` class is designed to store
 flight parameters for one flight point.
 
 It is meant to be the class that performance modules will work with, and that
@@ -34,7 +34,7 @@ FlightPoint class is meant for:
 
 Available flight parameters
 ===========================
-The documentation of :class:`~fastoad.base.flight_point.FlightPoint` provides
+The documentation of :class:`~fastoad.model_base.flight_point.FlightPoint` provides
 the list of available flight parameters, available as attributes.
 As FlightPoint is a dataclass, this list is available through Python using::
 
@@ -72,7 +72,8 @@ assessment, but one might need additional fields.
 
 Python allows to add attributes to any instance at runtime, but for FlightPoint to run
 smoothly, especially when exchanging data with pandas, you have to work at class level.
-This can be done using :meth:`add_field`, preferably outside of any class or function::
+This can be done using :meth:`~fastoad.model_base.flight_point.FlightPoint.add_field`, preferably
+outside of any class or function::
 
     # Adds a float field with None as default value
     >>> FlightPoint.add_field("ion_drive_power")
@@ -92,14 +93,14 @@ The IPropulsion interface
 
 When developing your propulsion model, to ensure that it will work smoothly
 with current performances models, you have to do it in a class that
-implements the :class:`~fastoad.models.propulsion.propulsion.IPropulsion`
+implements the :class:`~fastoad.model_base.propulsion.IPropulsion`
 interface, meaning your class must have at least the 2 methods
-:meth:`~fastoad.models.propulsion.propulsion.IPropulsion.compute_flight_points`
-and :meth:`~fastoad.models.propulsion.propulsion.IPropulsion.get_consumed_mass`.
+:meth:`~fastoad.model_base.propulsion.IPropulsion.compute_flight_points`
+and :meth:`~fastoad.model_base.propulsion.IPropulsion.get_consumed_mass`.
 
 Computation of propulsion data
 ==============================
-:meth:`~fastoad.models.propulsion.propulsion.IPropulsion.compute_flight_points`
+:meth:`~fastoad.model_base.propulsion.IPropulsion.compute_flight_points`
 will modify the provided flight point(s) by adding propulsion-related parameters.
 A conventional fuel engine will rely on parameters like :code:`mach`,
 :code:`altitude` and will provide parameters like :code:`sfc` (Specific Fuel
@@ -110,7 +111,7 @@ Propulsion model inputs
 
 For your model to work with current performance models, your model is expected
 to rely on known flight parameters, i.e. the original parameters of
-:class:`~fastoad.base.flight_point.FlightPoint`.
+:class:`~fastoad.model_base.flight_point.FlightPoint`.
 
 .. note::
 
@@ -136,16 +137,16 @@ it to the FlightPoint class as described
 :ref:`above <flight_point_extensibility>`.
 
 The only requirement is that you have to implement
-:meth:`~fastoad.models.propulsion.propulsion.IPropulsion.get_consumed_mass`
+:meth:`~fastoad.model_base.propulsion.IPropulsion.get_consumed_mass`
 accordingly for the mission module to have a correct assessment of mass
 evolution.
 
 Computation of consumed mass
 ============================
-The :meth:`~fastoad.models.propulsion.propulsion.IPropulsion.get_consumed_mass`
+The :meth:`~fastoad.model_base.propulsion.IPropulsion.get_consumed_mass`
 simply provides the mass consumption over the provided time.
 It is meant to use the parameters computed in
-:meth:`~fastoad.models.propulsion.propulsion.IPropulsion.compute_flight_points`.
+:meth:`~fastoad.model_base.propulsion.IPropulsion.compute_flight_points`.
 
 
 ********************
@@ -159,11 +160,11 @@ Once your propulsion model is ready, you have to make a wrapper around it for:
 Defining the wrapper
 ====================
 Your wrapper class has to implement the
-:class:`~fastoad.models.propulsion.propulsion.IOMPropulsionWrapper` interface,
-meaning it should implement the 2 methods :meth:`~fastoad.models.propulsion.propulsion.IOMPropulsionWrapper.get_model`
-and :meth:`~fastoad.models.propulsion.propulsion.IOMPropulsionWrapper.setup`.
+:class:`~fastoad.model_base.propulsion.IOMPropulsionWrapper` interface,
+meaning it should implement the 2 methods :meth:`~fastoad.model_base.propulsion.IOMPropulsionWrapper.get_model`
+and :meth:`~fastoad.model_base.propulsion.IOMPropulsionWrapper.setup`.
 
-:meth:`~fastoad.models.propulsion.propulsion.IOMPropulsionWrapper.get_model` has
+:meth:`~fastoad.model_base.propulsion.IOMPropulsionWrapper.get_model` has
 to provide an instance of your model. If the constructor of your propulsion
 model class needs parameters, you may get them from :code:`inputs`, that will
 be the :code:`inputs` parameter that OpenMDAO will provide to the performance
@@ -172,7 +173,7 @@ module when calling :code:`compute()` method.
 Therefore, the performance module will have to define the inputs that your
 propulsion model needs in its :code:`setup` method, as required by OpenMDAO.
 To do this, the :code:`setup` method ot the performance module calls the
-:meth:`~fastoad.models.propulsion.propulsion.IOMPropulsionWrapper.setup` of
+:meth:`~fastoad.model_base.propulsion.IOMPropulsionWrapper.setup` of
 your wrapper, that is expected to define the needed input variables.
 
 For an example, please see the source code of

--- a/docs/documentation/custom_modules/add_variable_documentation.rst
+++ b/docs/documentation/custom_modules/add_variable_documentation.rst
@@ -6,7 +6,7 @@ How to document your variables
 
 FAST-OAD can associate a description to each variable. Such description will be put as
 comment in datafiles, or displayed along with other variable information, like in command line
-(see :ref:`_get-variable-list`).
+(see :ref:`get-variable-list`).
 
 The description of a variable can be defined in two ways:
 

--- a/docs/documentation/mission_module/mission_file/segments.rst
+++ b/docs/documentation/mission_module/mission_file/segments.rst
@@ -239,7 +239,7 @@ Segment target
 The target of a flight segment is a set of parameters that drives the end of the segment simulation.
 
 Possible target parameters are the available fields of
-:class:`~fastoad.base.flight_point.FlightPoint`. The actually useful parameters depend on the
+:class:`~fastoad.model_base.flight_point.FlightPoint`. The actually useful parameters depend on the
 segment.
 
 Each parameter can be set the :ref:`usual way<setting-values>`, generally with a numeric value or

--- a/src/fastoad/cmd/api.py
+++ b/src/fastoad/cmd/api.py
@@ -81,7 +81,7 @@ def generate_inputs(
     overwrite: bool = False,
 ) -> str:
     """
-    Generates input file for the :class:`FASTOADProblem` specified in configuration_file_path.
+    Generates input file for the problem specified in configuration_file_path.
 
     :param configuration_file_path: where the path of input file to write is set
     :param source_path: path of file data will be taken from
@@ -118,7 +118,7 @@ def list_variables(
     tablefmt: str = "grid",
 ):
     """
-    Writes list of variables for the :class:`FASTOADProblem` specified in configuration_file_path.
+    Writes list of variables for the problem specified in configuration_file_path.
 
     List is generally written as text. It can be displayed as a scrollable table view if:
     - function is used in an interactive IPython shell

--- a/src/fastoad/io/configuration/configuration.py
+++ b/src/fastoad/io/configuration/configuration.py
@@ -245,7 +245,7 @@ class FASTOADProblemConfigurator:
 
         Keys of the dictionary are: "design_var", "constraint", "objective".
 
-        Configuration file will not be modified until :meth:`write` is used.
+        Configuration file will not be modified until :meth:`save` is used.
 
         :param optimization_definition: dict containing the optimization problem definition
         """

--- a/src/fastoad/io/xml/translator.py
+++ b/src/fastoad/io/xml/translator.py
@@ -14,13 +14,13 @@ Conversion from OpenMDAO variables to XPath
 #  GNU General Public License for more details.
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
-from typing import Sequence, Union, IO, Set
+from typing import IO, Sequence, Set, Union
 
 import numpy as np
 
 from fastoad.io.xml.exceptions import (
-    FastXpathTranslatorInconsistentLists,
     FastXpathTranslatorDuplicates,
+    FastXpathTranslatorInconsistentLists,
     FastXpathTranslatorVariableError,
     FastXpathTranslatorXPathError,
 )
@@ -108,7 +108,7 @@ class VarXpathTranslator:
 
         :param var_name: OpenMDAO variable name
         :return: XPath that matches var_name
-        :raise VariableError: if var_name is unknown
+        :raise FastXpathTranslatorVariableError: if var_name is unknown
         """
         if var_name in self._variable_names:
             i = self._variable_names.index(var_name)

--- a/src/fastoad/model_base/propulsion.py
+++ b/src/fastoad/model_base/propulsion.py
@@ -52,7 +52,8 @@ class IPropulsion(ABC):
         """
         Computes Specific Fuel Consumption according to provided conditions.
 
-        See :class:`FlightPoint` for available fields that may be used for computation.
+        See :class:`~fastoad.model_base.flight_point.FlightPoint` for available fields that may be
+        used for computation.
         If a DataFrame instance is provided, it is expected that its columns match
         field names of FlightPoint (actually, the DataFrame instance should be
         generated from a list of FlightPoint instances).
@@ -103,8 +104,9 @@ class IOMPropulsionWrapper:
     :class:`IPropulsion` subclass in :meth:`setup` and use them for instantiation in
     :meth:`get_model`
 
-    see :class:`~fastoad.models.propulsion.fuel_propulsion.rubber_engine.OMRubberEngineWrapper` for
-    an example of implementation.
+    See
+    :class:`~fastoad.models.propulsion.fuel_propulsion.rubber_engine.openmdao.OMRubberEngineWrapper`
+    for an example of implementation.
     """
 
     @abstractmethod
@@ -131,7 +133,7 @@ class IOMPropulsionWrapper:
 
 class BaseOMPropulsionComponent(om.ExplicitComponent, ABC):
     """
-    Base class for OpenMDAO wrapping of subclasses of :class:`IEngineForOpenMDAO`.
+    Base class for creating an OpenMDAO component from subclasses of :class:`IOMPropulsionWrapper`.
 
     Classes that implements this interface should add their own inputs in setup()
     and implement :meth:`get_wrapper`.
@@ -178,7 +180,8 @@ class BaseOMPropulsionComponent(om.ExplicitComponent, ABC):
     @abstractmethod
     def get_wrapper() -> IOMPropulsionWrapper:
         """
-        This method defines the used :class:`IOMPropulsionWrapper` instance.
+        This method defines the used :class:`~fastoad.model_base.propulsion.IOMPropulsionWrapper`
+        instance.
 
         :return: an instance of OpenMDAO wrapper for propulsion model
         """

--- a/src/fastoad/models/performances/mission/base.py
+++ b/src/fastoad/models/performances/mission/base.py
@@ -34,7 +34,7 @@ class IFlightPart(ABC):
                       (`true_airspeed`, `equivalent_airspeed` or `mach`). Can also be
                       defined for `time` and/or `ground_distance`.
         :return: a pandas DataFrame where columns names match fields of
-                 :meth:`fastoad.base.flight_point.FlightPoint`
+                 :class:`~fastoad.model_base.flight_point.FlightPoint`
         """
 
 

--- a/src/fastoad/models/performances/mission/mission_definition/mission_builder.py
+++ b/src/fastoad/models/performances/mission/mission_definition/mission_builder.py
@@ -67,9 +67,9 @@ class MissionBuilder:
 
         :param mission_definition: as file path or MissionDefinition instance
         :param propulsion: if not provided, the property :attr:`propulsion` must be
-                           set before calling :meth:`compute`
+                           set before calling :meth:`build`
         :param reference_area: if not provided, the property :attr:`reference_area` must be
-                               set before calling :meth:`compute`
+                               set before calling :meth:`build`
         """
         super().__init__()
         self.definition = mission_definition

--- a/src/fastoad/models/performances/mission/openmdao/mission_wrapper.py
+++ b/src/fastoad/models/performances/mission/openmdao/mission_wrapper.py
@@ -48,7 +48,9 @@ BASE_UNITS = {
 
 class MissionWrapper(MissionBuilder):
     """
-    Wrapper around :class:`MissionBuilder` for using with OpenMDAO
+    Wrapper around
+    :class:`~fastoad.models.performances.mission.mission_definition.mission_builder.MissionBuilder`
+    for using with OpenMDAO.
     """
 
     def __init__(self, *args, **kwargs):
@@ -95,8 +97,8 @@ class MissionWrapper(MissionBuilder):
         :param inputs: the input vector of the OpenMDAO component
         :param outputs: the output vector of the OpenMDAO component
         :param start_flight_point: the starting flight point just after takeoff
-        :return: a pandas DataFrame where columns names match
-                 :meth:`fastoad.base.flight_point.FlightPoint.get_attribute_keys`
+        :return: a pandas DataFrame where columns names match fields of
+                 :class:`~fastoad.model_base.flight_point.FlightPoint`
         """
         mission = self.build(inputs, self.mission_name)
 

--- a/src/fastoad/models/performances/mission/segments/base.py
+++ b/src/fastoad/models/performances/mission/segments/base.py
@@ -22,12 +22,13 @@ import pandas as pd
 from scipy.constants import g
 from scipy.optimize import root_scalar
 
+import fastoad.model_base
 from fastoad.constants import EngineSetting
 from fastoad.model_base import AtmosphereSI, FlightPoint
 from fastoad.model_base.propulsion import IPropulsion
+from fastoad.models.performances.mission.polar import Polar
 from ..base import IFlightPart
 from ..exceptions import FastFlightSegmentIncompleteFlightPoint
-from ..polar import Polar
 
 _LOGGER = logging.getLogger(__name__)  # Logger for this module
 
@@ -43,16 +44,17 @@ class FlightSegment(IFlightPart):
     """
 
     #: A FlightPoint instance that provides parameter values that should all be reached at the
-    #: end of :meth:`compute_from`. Possible parameters depend on the current segment. A parameter
-    #: can also be set to :attr:`CONSTANT_VALUE` to tell that initial value should be kept during
-    #: all segment.
-    target: FlightPoint
+    #: end of :meth:`~fastoad.models.performances.mission.segments.base.FlightSegment.compute_from`.
+    #: Possible parameters depend on the current segment. A parameter can also be set to
+    #: :attr:`~fastoad.models.performances.mission.segments.base.FlightSegment.CONSTANT_VALUE`
+    #: to tell that initial value should be kept during all segment.
+    target: fastoad.model_base.flight_point.FlightPoint
 
     #: A IPropulsion instance that will be called at each time step.
-    propulsion: IPropulsion
+    propulsion: fastoad.model_base.propulsion.IPropulsion
 
     #: The Polar instance that will provide drag data.
-    polar: Polar
+    polar: fastoad.models.performances.mission.polar.Polar
 
     #: The reference area, in m**2.
     reference_area: float
@@ -100,7 +102,7 @@ class FlightSegment(IFlightPart):
                       (`true_airspeed`, `equivalent_airspeed` or `mach`). Can also be
                       defined for `time` and/or `ground_distance`.
         :return: a pandas DataFrame where columns names match fields of
-                 :meth:`fastoad.base.flight_point.FlightPoint`
+                 :meth:`~fastoad.model_base.flight_point.FlightPoint`
         """
         if start.time is None:
             start.time = 0.0

--- a/src/fastoad/models/propulsion/fuel_propulsion/rubber_engine/openmdao.py
+++ b/src/fastoad/models/propulsion/fuel_propulsion/rubber_engine/openmdao.py
@@ -31,8 +31,9 @@ class OMRubberEngineWrapper(IOMPropulsionWrapper):
     """
     Wrapper class of for rubber engine model.
 
-    It is made to allow a direct call to :class:`~.rubber_engine.RubberEngine` in an OpenMDAO
-    component.
+    It is made to allow a direct call to
+    :class:`~fastoad.models.propulsion.fuel_propulsion.rubber_engine.rubber_engine.RubberEngine`
+    in an OpenMDAO component.
 
     Example of usage of this class::
 
@@ -99,7 +100,8 @@ class OMRubberEngineWrapper(IOMPropulsionWrapper):
         """
 
         :param inputs: input parameters that define the engine
-        :return: an :class:`RubberEngine` instance
+        :return: a :class:`~fastoad.models.propulsion.fuel_propulsion.rubber_engine.rubber_engine.RubberEngine`
+                 instance
         """
         engine_params = {
             "bypass_ratio": inputs["data:propulsion:rubber_engine:bypass_ratio"],
@@ -149,7 +151,9 @@ class OMRubberEngineComponent(BaseOMPropulsionComponent):
     """
     Parametric engine model as OpenMDAO component
 
-    See :class:`RubberEngine` for more information.
+    See
+    :class:`~fastoad.models.propulsion.fuel_propulsion.rubber_engine.rubber_engine.RubberEngine`
+    for more information.
     """
 
     def setup(self):

--- a/src/fastoad/openmdao/variables.py
+++ b/src/fastoad/openmdao/variables.py
@@ -72,7 +72,7 @@ class Variable(Hashable):
     `here <http://openmdao.org/twodocs/versions/latest/_srcdocs/packages/core/
     component.html#openmdao.core.component.Component.add_output>`_.
 
-    These keys can be listed with class method :meth:`get_authorized_keys`.
+    These keys can be listed with class method :meth:`get_openmdao_keys`.
     **Any other key in kwargs will be silently ignored.**
 
     Special behaviour: :meth:`description` will return the content of kwargs['desc']
@@ -386,7 +386,7 @@ class VariableList(list):
         """
         Creates a DataFrame instance from a VariableList instance.
 
-        Column names are "name" + the keys returned by :meth:`Variable.get_authorized_keys`.
+        Column names are "name" + the keys returned by :meth:`Variable.get_openmdao_keys`.
         Values in Series "value" are floats or lists (numpy arrays are converted).
 
         :return: a pandas DataFrame instance with all variables from current list
@@ -474,7 +474,7 @@ class VariableList(list):
         Creates a VariableList instance from a pandas DataFrame instance.
 
         The DataFrame instance is expected to have column names "name" + some keys among the ones given by
-        :meth:`Variable.get_authorized_keys`.
+        :meth:`Variable.get_openmdao_keys`.
 
         :param df: a DataFrame instance
         :return: a VariableList instance


### PR DESCRIPTION
This PR solves #310, and fixes broken links in documentation, including docstrings.

Using `nitpick = True` in Sphinx configuration allows to get warnings about broken references. It is a bit painful, because it shows far much more "false positives" than actual problems, but it helped a lot anyway.