### PR TITLE
Fix overwrite of input file

### DIFF
--- a/src/fastoad/cmd/api.py
+++ b/src/fastoad/cmd/api.py
@@ -520,7 +520,7 @@ def variable_viewer(file_path: str, file_formatter: IVariableIOFormatter = None,
 
         handle = viewer.display()
     else:
-        variables = DataFile(file_path, file_formatter)
+        variables = DataFile(file_path, formatter=file_formatter)
         variables.sort(key=lambda var: var.name)
 
         table = variables.to_dataframe()[["name", "value", "units", "is_input", "desc"]].rename(

--- a/src/fastoad/io/configuration/configuration.py
+++ b/src/fastoad/io/configuration/configuration.py
@@ -209,13 +209,13 @@ class FASTOADProblemConfigurator:
         """
         problem = self.get_problem(read_inputs=False)
         problem.setup()
-        variables = DataFile(self.input_file_path)
+        variables = DataFile(self.input_file_path, load_data=False)
         variables.update(
             VariableList.from_unconnected_inputs(problem, with_optional_inputs=True),
             add_variables=True,
         )
         if source_file_path:
-            ref_vars = DataFile(source_file_path, source_formatter)
+            ref_vars = DataFile(source_file_path, formatter=source_formatter)
             variables.update(ref_vars)
             for var in variables:
                 var.is_input = True

--- a/src/fastoad/io/variable_io.py
+++ b/src/fastoad/io/variable_io.py
@@ -128,15 +128,16 @@ class DataFile(VariableList):
     :meth:`save` methods.
     """
 
-    def __init__(self, file_path: str, formatter: IVariableIOFormatter = None):
+    def __init__(self, file_path: str, formatter: IVariableIOFormatter = None, load_data=True):
         """
-        :param file_path: if file exists, it will be loaded.
+        :param file_path: the file path where data will be loaded and saved.
         :param formatter: a class that determines the file format to be used. Defaults to FAST-OAD
                           native format. See :class:`VariableIO` for more information.
+        :param load_data: if True and if file exists, its content will be loaded at instantiation.
         """
         super().__init__()
         self._variable_io = VariableIO(file_path, formatter)
-        if pth.exists(file_path):
+        if pth.exists(file_path) and load_data:
             self.load()
 
     @property


### PR DESCRIPTION
This PR solves #328.

The `DataFile` class, now used in `generate_inputs` was intended to load the content of a data file if it existed.
The class constructor has been modified to allow the data not to be loaded if necessary.