### PR TITLE
Allowing "useless" sections in configuration file

### DIFF
--- a/src/fastoad/cmd/api.py
+++ b/src/fastoad/cmd/api.py
@@ -226,7 +226,6 @@ def list_modules(
     if configuration_file_path:
         conf = FASTOADProblemConfigurator(configuration_file_path)
         conf._set_configuration_modifier(_PROBLEM_CONFIGURATOR)
-        conf.load(configuration_file_path)
     # As the problem has been configured, BundleLoader now knows additional registered systems
 
     if verbose:

--- a/src/fastoad/io/configuration/configuration.py
+++ b/src/fastoad/io/configuration/configuration.py
@@ -165,6 +165,10 @@ class FASTOADProblemConfigurator:
         with open_text(resources, JSON_SCHEMA_NAME) as json_file:
             json_schema = json.loads(json_file.read())
         validate(self._serializer.data, json_schema)
+        # Issue a simple warning for unknown keys at root level
+        for key in self._serializer.data:
+            if key not in json_schema["properties"].keys():
+                _LOGGER.warning('Configuration file: "%s" is not a FAST-OAD key.', key)
 
         # Looking for modules to register
         module_folder_paths = self._serializer.data.get(KEY_FOLDERS)

--- a/src/fastoad/io/configuration/resources/configuration.json
+++ b/src/fastoad/io/configuration/resources/configuration.json
@@ -111,7 +111,11 @@
       "type": "string"
     },
     "module_folders": {
-      "type": [ "array", "string", "null" ],
+      "type": [
+        "array",
+        "string",
+        "null"
+      ],
       "items": {
         "type": "string"
       }
@@ -159,7 +163,8 @@
             ]
           }
         }
-      }
+      },
+      "required": ["design_variables", "objective"]
     }
   },
   "required": [

--- a/src/fastoad/io/configuration/resources/configuration.json
+++ b/src/fastoad/io/configuration/resources/configuration.json
@@ -167,5 +167,5 @@
     "output_file",
     "model"
   ],
-  "additionalProperties": false
+  "additionalProperties": true
 }

--- a/src/fastoad/io/configuration/tests/data/valid_sellar.yml
+++ b/src/fastoad/io/configuration/tests/data/valid_sellar.yml
@@ -41,3 +41,6 @@ optimization:
   objective:
     - name: f
       scaler: 1e-1
+
+unknown_section:
+  foo: bar


### PR DESCRIPTION
This PR closes #324.

Unknown keys are now accepted in the configuration file (at root level).
To keep being informative about possible typos, a warning is issued for each found unknown key.