### PR TITLE
Issue 334 - local inputs connected to promoted variables

### DIFF
--- a/src/fastoad/openmdao/variables.py
+++ b/src/fastoad/openmdao/variables.py
@@ -638,13 +638,6 @@ class VariableList(list):
                 if prom_name not in promoted_inputs:
                     promoted_outputs[prom_name] = metadata
 
-            # # Remove from inputs the variables that are outputs of some other component
-            # promoted_inputs = {
-            #     metadata["prom_name"]: dict(metadata, is_input=True)
-            #     for metadata in inputs.values()
-            #     if metadata["prom_name"] not in promoted_outputs
-            # }
-
             final_inputs = promoted_inputs
             final_outputs = promoted_outputs
 

--- a/src/fastoad/openmdao/variables.py
+++ b/src/fastoad/openmdao/variables.py
@@ -580,8 +580,9 @@ class VariableList(list):
                 # Check connections
                 for name, metadata in inputs.copy().items():
                     source_name = problem.model.get_source(name)
-                    # If an local input is connected to a promoted output
                     if not source_name.startswith("_auto_ivc.") and source_name != name:
+                        # This variable is connected to another variable of the problem: it is
+                        # not an actual problem input. Let's move it to outputs.
                         del inputs[name]
                         outputs[name] = metadata
 


### PR DESCRIPTION
This PR fixes #334 (partly solved by #332) where some variables are tagged as inputs instead of outputs when using `VariableList.from_problem()`.

To fix this, `VariableList.from_problem()` was modified to handle the effect of using `connect()` with local inputs and promoted outputs. This behaviour can be observed when using `list_variables()` or the `variable_viewer()`.

However, `generate_inputs()` works fine and gives the correct input list because it uses `_utils.get_unconnected_input_names()`. This brings up the fact that `VariableList.from_problem()` is too complicated for what we really need it to do and should deserve a rework in a later PR.