### PR TITLE
Adjustment of test triggering in GitHub workflows

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,7 @@ on:
       - 'poetry.lock'
       - '.github/workflows/**'
   pull_request:
+    types: [ready_for_review, closed]
     branches:
       - '**'
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -89,6 +89,6 @@ jobs:
         shell: bash
 
       - name: Notebook tests
-        if: "${{ github.event_name == 'pull_request' || contains(github.event.head_commit.message, '[test nb]')}}"
+        if: "github.event_name == 'pull_request' || contains(github.event.head_commit.message, '[test nb]') || github.event.ref == 'master'"
         run: poetry run pytest --no-cov --nbval-lax -p no:python src
         shell: bash

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -89,5 +89,6 @@ jobs:
         shell: bash
 
       - name: Notebook tests
+        if: "${{ github.event_name == 'pull_request' || contains(github.event.head_commit.message, '[test nb]')}}"
         run: poetry run pytest --no-cov --nbval-lax -p no:python src
         shell: bash

--- a/.github/workflows/watchman_tests.yml
+++ b/.github/workflows/watchman_tests.yml
@@ -15,6 +15,7 @@ on:
       - 'pyproject.toml'
       - '.github/workflows/**'
   pull_request:
+    types: [ready_for_review, closed]
     branches:
       - '**'
 

--- a/.github/workflows/watchman_tests.yml
+++ b/.github/workflows/watchman_tests.yml
@@ -48,6 +48,6 @@ jobs:
         shell: bash
 
       - name: Notebook tests
-        if: "${{ github.event_name == 'pull_request' || contains(github.event.head_commit.message, '[test nb]')}}"
+        if: "github.event_name == 'pull_request' || contains(github.event.head_commit.message, '[test nb]') || github.event.ref == 'master'"
         run: pytest --no-cov --nbval-lax -p no:python src
         shell: bash

--- a/.github/workflows/watchman_tests.yml
+++ b/.github/workflows/watchman_tests.yml
@@ -48,5 +48,6 @@ jobs:
         shell: bash
 
       - name: Notebook tests
+        if: "${{ github.event_name == 'pull_request' || contains(github.event.head_commit.message, '[test nb]')}}"
         run: pytest --no-cov --nbval-lax -p no:python src
         shell: bash


### PR DESCRIPTION
Currently, GitHub workflows for tests are triggered only when source code is changed, to avoid some useless runs of actions.
But it happened to prevent tests to be run when merging a release branch that modifies only the change log. It results in a commit on master branch that dis not send its coverage data, so that next branches cannot be evaluated by Codecov, since it has no base for comparison.

Therefore, following changes are done in GitHub workflows for tests:
- Tried to force tests to run, whatever the changed files, when some pull request events happen. We will probably have to see the real effect on the long run...
- As notebook tests have become very long, made that notebook tests are triggered only on master commits, pull requests, or when `[test nb]` is in the commit message.