### PR TITLE
Fix partial derivatives

### DIFF
--- a/src/fastoad/cmd/tests/data/cmd_sellar_example/disc1_base.py
+++ b/src/fastoad/cmd/tests/data/cmd_sellar_example/disc1_base.py
@@ -25,4 +25,6 @@ class Disc1Base(ExplicitComponent):
         self.add_input("y2", val=1.0, desc="")
 
         self.add_output("y1", val=1.0, desc="")
+
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")

--- a/src/fastoad/cmd/tests/data/cmd_sellar_example/disc2_base.py
+++ b/src/fastoad/cmd/tests/data/cmd_sellar_example/disc2_base.py
@@ -26,4 +26,6 @@ class Disc2Base(ExplicitComponent):
         self.add_input("y1", val=1.0, desc="")
 
         self.add_output("y2", val=1.0, desc="")
+
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")

--- a/src/fastoad/cmd/tests/data/cmd_sellar_example/functions_base.py
+++ b/src/fastoad/cmd/tests/data/cmd_sellar_example/functions_base.py
@@ -35,4 +35,6 @@ class FunctionsBase(ExplicitComponent):
         self.add_output("g1", val=1.0, desc="")
 
         self.add_output("g2", val=1.0, desc="")
+
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")

--- a/src/fastoad/gui/tests/data/postproc_sellar_example/disc1_base.py
+++ b/src/fastoad/gui/tests/data/postproc_sellar_example/disc1_base.py
@@ -25,4 +25,6 @@ class Disc1Base(ExplicitComponent):
         self.add_input("y2", val=1.0, desc="")
 
         self.add_output("y1", val=1.0, desc="")
+
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")

--- a/src/fastoad/gui/tests/data/postproc_sellar_example/disc2_base.py
+++ b/src/fastoad/gui/tests/data/postproc_sellar_example/disc2_base.py
@@ -26,4 +26,6 @@ class Disc2Base(ExplicitComponent):
         self.add_input("y1", val=1.0, desc="")
 
         self.add_output("y2", val=1.0, desc="")
+
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")

--- a/src/fastoad/gui/tests/data/postproc_sellar_example/functions_base.py
+++ b/src/fastoad/gui/tests/data/postproc_sellar_example/functions_base.py
@@ -35,4 +35,6 @@ class FunctionsBase(ExplicitComponent):
         self.add_output("g1", val=1.0, desc="")
 
         self.add_output("g2", val=1.0, desc="")
+
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")

--- a/src/fastoad/io/configuration/tests/data/conf_sellar_example/disc1_base.py
+++ b/src/fastoad/io/configuration/tests/data/conf_sellar_example/disc1_base.py
@@ -26,4 +26,6 @@ class Disc1Base(ExplicitComponent):
         self.add_input("y2", val=1.0, desc="")
 
         self.add_output("y1", val=1.0, desc="")
+
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")

--- a/src/fastoad/io/configuration/tests/data/conf_sellar_example/disc2_base.py
+++ b/src/fastoad/io/configuration/tests/data/conf_sellar_example/disc2_base.py
@@ -26,4 +26,6 @@ class Disc2Base(ExplicitComponent):
         self.add_input("y1", val=1.0, desc="")
 
         self.add_output("y2", val=1.0, desc="")
+
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")

--- a/src/fastoad/io/configuration/tests/data/conf_sellar_example/functions_base.py
+++ b/src/fastoad/io/configuration/tests/data/conf_sellar_example/functions_base.py
@@ -36,4 +36,6 @@ class FunctionsBase(ExplicitComponent):
         self.add_output("g1", val=1.0, desc="")
 
         self.add_output("g2", val=1.0, desc="")
+
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")

--- a/src/fastoad/model_base/propulsion.py
+++ b/src/fastoad/model_base/propulsion.py
@@ -157,6 +157,7 @@ class BaseOMPropulsionComponent(om.ExplicitComponent, ABC):
             "data:propulsion:thrust", copy_shape="data:propulsion:mach", units="N", ref=1e5
         )
 
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):

--- a/src/fastoad/models/aerodynamics/aerodynamics_landing.py
+++ b/src/fastoad/models/aerodynamics/aerodynamics_landing.py
@@ -124,6 +124,7 @@ class ComputeMachReynolds(om.ExplicitComponent):
         self.add_output("data:aerodynamics:aircraft:landing:mach")
         self.add_output("data:aerodynamics:wing:landing:reynolds")
 
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
@@ -149,6 +150,7 @@ class Compute3DMaxCL(om.ExplicitComponent):
 
         self.add_output("data:aerodynamics:aircraft:landing:CL_max_clean")
 
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):

--- a/src/fastoad/models/aerodynamics/components/cd0_fuselage.py
+++ b/src/fastoad/models/aerodynamics/components/cd0_fuselage.py
@@ -2,7 +2,7 @@
     FAST - Copyright (c) 2016 ONERA ISAE
 """
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -51,6 +51,7 @@ class Cd0Fuselage(ExplicitComponent):
         self.add_input("data:geometry:fuselage:maximum_height", val=np.nan, units="m")
         self.add_input("data:geometry:fuselage:wetted_area", val=np.nan, units="m**2")
 
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")
 
     def compute(self, inputs, outputs):

--- a/src/fastoad/models/aerodynamics/components/cd0_ht.py
+++ b/src/fastoad/models/aerodynamics/components/cd0_ht.py
@@ -3,7 +3,7 @@
 """
 
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -42,6 +42,7 @@ class Cd0HorizontalTail(ExplicitComponent):
             self.add_input("data:TLAR:cruise_mach", val=np.nan)
             self.add_output("data:aerodynamics:horizontal_tail:cruise:CD0")
 
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")
 
     def compute(self, inputs, outputs):

--- a/src/fastoad/models/aerodynamics/components/cd0_nacelle_pylons.py
+++ b/src/fastoad/models/aerodynamics/components/cd0_nacelle_pylons.py
@@ -3,7 +3,7 @@
 """
 
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -47,6 +47,7 @@ class Cd0NacelleAndPylons(ExplicitComponent):
         self.add_input("data:geometry:propulsion:fan:length", val=np.nan, units="m")
         self.add_input("data:geometry:wing:area", val=np.nan, units="m**2")
 
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")
 
     def compute(self, inputs, outputs):

--- a/src/fastoad/models/aerodynamics/components/cd0_total.py
+++ b/src/fastoad/models/aerodynamics/components/cd0_total.py
@@ -2,7 +2,7 @@
     FAST - Copyright (c) 2016 ONERA ISAE
 """
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -52,6 +52,7 @@ class Cd0Total(ExplicitComponent):
                 copy_shape="data:aerodynamics:wing:cruise:CD0",
             )
 
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")
 
     def compute(self, inputs, outputs):

--- a/src/fastoad/models/aerodynamics/components/cd0_vt.py
+++ b/src/fastoad/models/aerodynamics/components/cd0_vt.py
@@ -3,7 +3,7 @@
 """
 
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -42,6 +42,7 @@ class Cd0VerticalTail(ExplicitComponent):
             self.add_input("data:TLAR:cruise_mach", val=np.nan)
             self.add_output("data:aerodynamics:vertical_tail:cruise:CD0")
 
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")
 
     def compute(self, inputs, outputs):

--- a/src/fastoad/models/aerodynamics/components/cd0_wing.py
+++ b/src/fastoad/models/aerodynamics/components/cd0_wing.py
@@ -2,7 +2,7 @@
     FAST - Copyright (c) 2016 ONERA ISAE
 """
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -50,6 +50,7 @@ class Cd0Wing(ExplicitComponent):
         self.add_input("data:geometry:wing:MAC:length", val=np.nan, units="m")
         self.add_input("data:geometry:wing:sweep_25", val=np.nan, units="deg")
 
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")
 
     def compute(self, inputs, outputs):

--- a/src/fastoad/models/aerodynamics/components/cd_compressibility.py
+++ b/src/fastoad/models/aerodynamics/components/cd_compressibility.py
@@ -3,7 +3,7 @@ Compressibility drag computation.
 """
 
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -48,6 +48,7 @@ class CdCompressibility(ExplicitComponent):
             copy_shape="data:aerodynamics:aircraft:cruise:CL",
         )
 
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")
 
     def compute(self, inputs, outputs):

--- a/src/fastoad/models/aerodynamics/components/cd_trim.py
+++ b/src/fastoad/models/aerodynamics/components/cd_trim.py
@@ -3,7 +3,7 @@
 """
 
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -41,6 +41,7 @@ class CdTrim(ExplicitComponent):
                 copy_shape="data:aerodynamics:aircraft:cruise:CL",
             )
 
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")
 
     def compute(self, inputs, outputs):

--- a/src/fastoad/models/aerodynamics/components/compute_low_speed_aero.py
+++ b/src/fastoad/models/aerodynamics/components/compute_low_speed_aero.py
@@ -2,7 +2,7 @@
     FAST - Copyright (c) 2016 ONERA ISAE
 """
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -14,7 +14,7 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from math import sqrt, pi, tan
+from math import pi, sqrt, tan
 
 import numpy as np
 from openmdao.core.explicitcomponent import ExplicitComponent
@@ -40,6 +40,7 @@ class ComputeAerodynamicsLowSpeed(ExplicitComponent):
         self.add_output("data:aerodynamics:aircraft:takeoff:CL_alpha", units="1/rad")
         self.add_output("data:aerodynamics:aircraft:takeoff:CL0_clean")
 
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")
 
     def compute(self, inputs, outputs):

--- a/src/fastoad/models/aerodynamics/components/compute_max_cl_landing.py
+++ b/src/fastoad/models/aerodynamics/components/compute_max_cl_landing.py
@@ -3,7 +3,7 @@
 """
 
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -28,6 +28,7 @@ class ComputeMaxClLanding(ExplicitComponent):
         )
         self.add_output("data:aerodynamics:aircraft:landing:CL_max")
 
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")
 
     def compute(self, inputs, outputs):

--- a/src/fastoad/models/aerodynamics/components/compute_polar.py
+++ b/src/fastoad/models/aerodynamics/components/compute_polar.py
@@ -2,7 +2,7 @@
     FAST - Copyright (c) 2016 ONERA ISAE
 """
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -105,6 +105,7 @@ class ComputePolar(ExplicitComponent):
             self.add_output("data:aerodynamics:aircraft:cruise:optimal_CL")
             self.add_output("data:aerodynamics:aircraft:cruise:optimal_CD")
 
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")
 
     def compute(self, inputs, outputs):

--- a/src/fastoad/models/aerodynamics/components/compute_reynolds.py
+++ b/src/fastoad/models/aerodynamics/components/compute_reynolds.py
@@ -37,6 +37,7 @@ class ComputeReynolds(ExplicitComponent):
             self.add_input("data:mission:sizing:main_route:cruise:altitude", val=np.nan, units="m")
             self.add_output("data:aerodynamics:wing:cruise:reynolds")
 
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")
 
     def compute(self, inputs, outputs):

--- a/src/fastoad/models/aerodynamics/components/high_lift_aero.py
+++ b/src/fastoad/models/aerodynamics/components/high_lift_aero.py
@@ -2,7 +2,7 @@
 Computation of lift and drag increment due to high-lift devices
 """
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -55,6 +55,7 @@ class ComputeDeltaHighLift(om.ExplicitComponent):
         self.add_input("data:geometry:slat:chord_ratio", val=np.nan)
         self.add_input("data:geometry:slat:span_ratio", val=np.nan)
 
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):

--- a/src/fastoad/models/aerodynamics/components/initialize_cl.py
+++ b/src/fastoad/models/aerodynamics/components/initialize_cl.py
@@ -2,7 +2,7 @@
     FAST - Copyright (c) 2016 ONERA ISAE
 """
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -37,6 +37,7 @@ class InitializeClPolar(ExplicitComponent):
         else:
             self.add_output("data:aerodynamics:aircraft:cruise:CL", shape=POLAR_POINT_COUNT)
 
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")
 
     def compute(self, inputs, outputs):

--- a/src/fastoad/models/aerodynamics/components/oswald.py
+++ b/src/fastoad/models/aerodynamics/components/oswald.py
@@ -3,7 +3,7 @@ Computation of Oswald coefficient
 """
 
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -45,6 +45,7 @@ class OswaldCoefficient(ExplicitComponent):
             self.add_input("data:TLAR:cruise_mach", val=np.nan)
             self.add_output("data:aerodynamics:aircraft:cruise:induced_drag_coefficient")
 
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")
 
     def compute(self, inputs, outputs):

--- a/src/fastoad/models/geometry/compute_aero_center.py
+++ b/src/fastoad/models/geometry/compute_aero_center.py
@@ -3,7 +3,7 @@
 """
 
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -39,6 +39,7 @@ class ComputeAeroCenter(ExplicitComponent):
 
         self.add_output("data:aerodynamics:cruise:neutral_point:x")
 
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")
 
     def compute(self, inputs, outputs):

--- a/src/fastoad/models/geometry/geom_components/compute_total_area.py
+++ b/src/fastoad/models/geometry/geom_components/compute_total_area.py
@@ -3,7 +3,7 @@
 """
 
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -33,6 +33,7 @@ class ComputeTotalArea(ExplicitComponent):
 
         self.add_output("data:geometry:aircraft:wetted_area", units="m**2")
 
+    def setup_partials(self):
         self.declare_partials("data:geometry:aircraft:wetted_area", "*", method="fd")
 
     def compute(self, inputs, outputs):

--- a/src/fastoad/models/geometry/geom_components/fuselage/compute_cnbeta_fuselage.py
+++ b/src/fastoad/models/geometry/geom_components/fuselage/compute_cnbeta_fuselage.py
@@ -3,7 +3,7 @@
 """
 
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -36,6 +36,7 @@ class ComputeCnBetaFuselage(ExplicitComponent):
 
         self.add_output("data:aerodynamics:fuselage:cruise:CnBeta")
 
+    def setup_partials(self):
         self.declare_partials("data:aerodynamics:fuselage:cruise:CnBeta", "*", method="fd")
 
     def compute(self, inputs, outputs):

--- a/src/fastoad/models/geometry/geom_components/fuselage/compute_fuselage.py
+++ b/src/fastoad/models/geometry/geom_components/fuselage/compute_fuselage.py
@@ -3,7 +3,7 @@
 """
 
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -39,6 +39,7 @@ class ComputeFuselageGeometryBasic(ExplicitComponent):
         self.add_output("data:geometry:fuselage:wetted_area", units="m**2")
         self.add_output("data:geometry:cabin:crew_count:commercial")
 
+    def setup_partials(self):
         self.declare_partials(
             "data:weight:systems:flight_kit:CG:x",
             ["data:geometry:fuselage:front_length", "data:geometry:fuselage:PAX_length"],
@@ -123,6 +124,7 @@ class ComputeFuselageGeometryCabinSizing(ExplicitComponent):
         self.add_output("data:geometry:fuselage:wetted_area", units="m**2")
         self.add_output("data:geometry:cabin:crew_count:commercial")
 
+    def setup_partials(self):
         self.declare_partials("data:geometry:cabin:NPAX1", ["data:TLAR:NPAX"], method="fd")
         self.declare_partials(
             "data:geometry:fuselage:maximum_width",

--- a/src/fastoad/models/geometry/geom_components/ht/components/compute_ht_chords.py
+++ b/src/fastoad/models/geometry/geom_components/ht/components/compute_ht_chords.py
@@ -2,7 +2,7 @@
     Estimation of horizontal tail chords and span
 """
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -33,6 +33,7 @@ class ComputeHTChord(ExplicitComponent):
         self.add_output("data:geometry:horizontal_tail:root:chord", units="m")
         self.add_output("data:geometry:horizontal_tail:tip:chord", units="m")
 
+    def setup_partials(self):
         self.declare_partials(
             "data:geometry:horizontal_tail:span",
             ["data:geometry:horizontal_tail:area", "data:geometry:horizontal_tail:aspect_ratio"],

--- a/src/fastoad/models/geometry/geom_components/ht/components/compute_ht_cl_alpha.py
+++ b/src/fastoad/models/geometry/geom_components/ht/components/compute_ht_cl_alpha.py
@@ -3,7 +3,7 @@
 """
 
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -32,6 +32,7 @@ class ComputeHTClalpha(ExplicitComponent):
 
         self.add_output("data:aerodynamics:horizontal_tail:cruise:CL_alpha")
 
+    def setup_partials(self):
         self.declare_partials("data:aerodynamics:horizontal_tail:cruise:CL_alpha", "*", method="fd")
 
     def compute(self, inputs, outputs):

--- a/src/fastoad/models/geometry/geom_components/ht/components/compute_ht_mac.py
+++ b/src/fastoad/models/geometry/geom_components/ht/components/compute_ht_mac.py
@@ -3,7 +3,7 @@
 """
 
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -35,6 +35,7 @@ class ComputeHTMAC(ExplicitComponent):
         self.add_output("data:geometry:horizontal_tail:MAC:at25percent:x:local", units="m")
         self.add_output("data:geometry:horizontal_tail:MAC:y", units="m")
 
+    def setup_partials(self):
         self.declare_partials(
             "data:geometry:horizontal_tail:MAC:length",
             ["data:geometry:horizontal_tail:root:chord", "data:geometry:horizontal_tail:tip:chord"],

--- a/src/fastoad/models/geometry/geom_components/ht/components/compute_ht_sweep.py
+++ b/src/fastoad/models/geometry/geom_components/ht/components/compute_ht_sweep.py
@@ -3,7 +3,7 @@
 """
 
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -33,6 +33,7 @@ class ComputeHTSweep(ExplicitComponent):
         self.add_output("data:geometry:horizontal_tail:sweep_0", units="deg")
         self.add_output("data:geometry:horizontal_tail:sweep_100", units="deg")
 
+    def setup_partials(self):
         self.declare_partials("data:geometry:horizontal_tail:sweep_0", "*", method="fd")
         self.declare_partials("data:geometry:horizontal_tail:sweep_100", "*", method="fd")
 

--- a/src/fastoad/models/geometry/geom_components/nacelle_pylons/compute_nacelle_pylons.py
+++ b/src/fastoad/models/geometry/geom_components/nacelle_pylons/compute_nacelle_pylons.py
@@ -2,7 +2,7 @@
     Estimation of nacelle and pylon geometry
 """
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -51,6 +51,7 @@ class ComputeNacelleAndPylonsGeometry(om.ExplicitComponent):
         self.add_output("data:geometry:propulsion:nacelle:wetted_area", units="m**2")
         self.add_output("data:weight:propulsion:engine:CG:x", units="m")
 
+    def setup_partials(self):
         self.declare_partials(
             "data:geometry:propulsion:nacelle:diameter", "data:propulsion:MTO_thrust", method="fd"
         )

--- a/src/fastoad/models/geometry/geom_components/vt/components/compute_vt_chords.py
+++ b/src/fastoad/models/geometry/geom_components/vt/components/compute_vt_chords.py
@@ -2,7 +2,7 @@
     Estimation of vertical tail chords and span
 """
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -32,6 +32,7 @@ class ComputeVTChords(ExplicitComponent):
         self.add_output("data:geometry:vertical_tail:root:chord", units="m")
         self.add_output("data:geometry:vertical_tail:tip:chord", units="m")
 
+    def setup_partials(self):
         self.declare_partials(
             "data:geometry:vertical_tail:span",
             ["data:geometry:vertical_tail:aspect_ratio", "data:geometry:vertical_tail:area"],

--- a/src/fastoad/models/geometry/geom_components/vt/components/compute_vt_clalpha.py
+++ b/src/fastoad/models/geometry/geom_components/vt/components/compute_vt_clalpha.py
@@ -2,7 +2,7 @@
     Estimation of vertical tail lift coefficient
 """
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -35,6 +35,7 @@ class ComputeVTClalpha(om.ExplicitComponent):
 
         self.add_output("data:aerodynamics:vertical_tail:cruise:CL_alpha")
 
+    def setup_partials(self):
         self.declare_partials("data:aerodynamics:vertical_tail:cruise:CL_alpha", "*", method="fd")
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):

--- a/src/fastoad/models/geometry/geom_components/vt/components/compute_vt_distance.py
+++ b/src/fastoad/models/geometry/geom_components/vt/components/compute_vt_distance.py
@@ -3,7 +3,7 @@
 """
 
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -31,6 +31,7 @@ class ComputeVTDistance(om.ExplicitComponent):
 
         self.add_output("data:geometry:vertical_tail:MAC:at25percent:x:from_wingMAC25", units="m")
 
+    def setup_partials(self):
         self.declare_partials(
             "data:geometry:vertical_tail:MAC:at25percent:x:from_wingMAC25",
             ["data:geometry:fuselage:length", "data:geometry:wing:MAC:at25percent:x"],

--- a/src/fastoad/models/geometry/geom_components/vt/components/compute_vt_mac.py
+++ b/src/fastoad/models/geometry/geom_components/vt/components/compute_vt_mac.py
@@ -3,7 +3,7 @@
 """
 
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -35,9 +35,11 @@ class ComputeVTMAC(ExplicitComponent):
         self.add_output("data:geometry:vertical_tail:MAC:at25percent:x:local", units="m")
         self.add_output("data:geometry:vertical_tail:MAC:z", units="m")
 
+    def setup_partials(self):
         self.declare_partials(
             "data:geometry:vertical_tail:MAC:length",
             ["data:geometry:vertical_tail:root:chord", "data:geometry:vertical_tail:tip:chord"],
+            method="fd",
         )
         self.declare_partials(
             "data:geometry:vertical_tail:MAC:at25percent:x:local", "*", method="fd"

--- a/src/fastoad/models/geometry/geom_components/vt/components/compute_vt_sweep.py
+++ b/src/fastoad/models/geometry/geom_components/vt/components/compute_vt_sweep.py
@@ -3,7 +3,7 @@
 """
 
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -34,6 +34,7 @@ class ComputeVTSweep(ExplicitComponent):
         self.add_output("data:geometry:vertical_tail:sweep_0", units="deg")
         self.add_output("data:geometry:vertical_tail:sweep_100", units="deg")
 
+    def setup_partials(self):
         self.declare_partials("data:geometry:vertical_tail:sweep_0", "*", method="fd")
         self.declare_partials("data:geometry:vertical_tail:sweep_100", "*", method="fd")
 

--- a/src/fastoad/models/geometry/geom_components/wing/components/compute_b_50.py
+++ b/src/fastoad/models/geometry/geom_components/wing/components/compute_b_50.py
@@ -3,7 +3,7 @@
 """
 
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -34,6 +34,7 @@ class ComputeB50(ExplicitComponent):
 
         self.add_output("data:geometry:wing:b_50", units="m")
 
+    def setup_partials(self):
         self.declare_partials("data:geometry:wing:b_50", "*", method="fd")
 
     def compute(self, inputs, outputs):

--- a/src/fastoad/models/geometry/geom_components/wing/components/compute_cl_alpha.py
+++ b/src/fastoad/models/geometry/geom_components/wing/components/compute_cl_alpha.py
@@ -3,7 +3,7 @@
 """
 
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -39,6 +39,7 @@ class ComputeCLalpha(ExplicitComponent):
 
         self.add_output("data:aerodynamics:aircraft:cruise:CL_alpha")
 
+    def setup_partials(self):
         self.declare_partials("data:aerodynamics:aircraft:cruise:CL_alpha", "*", method="fd")
 
     def compute(self, inputs, outputs):

--- a/src/fastoad/models/geometry/geom_components/wing/components/compute_l1_l4.py
+++ b/src/fastoad/models/geometry/geom_components/wing/components/compute_l1_l4.py
@@ -3,7 +3,7 @@
 """
 
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -36,6 +36,7 @@ class ComputeL1AndL4Wing(ExplicitComponent):
         self.add_output("data:geometry:wing:root:virtual_chord", units="m")
         self.add_output("data:geometry:wing:tip:chord", units="m")
 
+    def setup_partials(self):
         self.declare_partials("data:geometry:wing:root:virtual_chord", "*", method="fd")
         self.declare_partials("data:geometry:wing:tip:chord", "*", method="fd")
 

--- a/src/fastoad/models/geometry/geom_components/wing/components/compute_l2_l3.py
+++ b/src/fastoad/models/geometry/geom_components/wing/components/compute_l2_l3.py
@@ -3,7 +3,7 @@
 """
 
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -38,6 +38,7 @@ class ComputeL2AndL3Wing(ExplicitComponent):
         self.add_output("data:geometry:wing:root:chord", units="m")
         self.add_output("data:geometry:wing:kink:chord", units="m")
 
+    def setup_partials(self):
         self.declare_partials(
             "data:geometry:wing:root:chord",
             [

--- a/src/fastoad/models/geometry/geom_components/wing/components/compute_mac_wing.py
+++ b/src/fastoad/models/geometry/geom_components/wing/components/compute_mac_wing.py
@@ -3,7 +3,7 @@
 """
 
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -38,6 +38,7 @@ class ComputeMACWing(ExplicitComponent):
         self.add_output("data:geometry:wing:MAC:leading_edge:x:local", units="m")
         self.add_output("data:geometry:wing:MAC:y", units="m")
 
+    def setup_partials(self):
         self.declare_partials(
             "data:geometry:wing:MAC:length",
             [

--- a/src/fastoad/models/geometry/geom_components/wing/components/compute_mfw.py
+++ b/src/fastoad/models/geometry/geom_components/wing/components/compute_mfw.py
@@ -3,7 +3,7 @@
 """
 
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -30,6 +30,7 @@ class ComputeMFW(ExplicitComponent):
 
         self.add_output("data:weight:aircraft:MFW", units="kg")
 
+    def setup_partials(self):
         self.declare_partials("data:weight:aircraft:MFW", "*", method="fd")
 
     def compute(self, inputs, outputs):

--- a/src/fastoad/models/geometry/geom_components/wing/components/compute_sweep_wing.py
+++ b/src/fastoad/models/geometry/geom_components/wing/components/compute_sweep_wing.py
@@ -3,7 +3,7 @@
 """
 
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -38,6 +38,7 @@ class ComputeSweepWing(ExplicitComponent):
         self.add_output("data:geometry:wing:sweep_100_inner", units="deg")
         self.add_output("data:geometry:wing:sweep_100_outer", units="deg")
 
+    def setup_partials(self):
         self.declare_partials(
             "data:geometry:wing:sweep_0",
             [

--- a/src/fastoad/models/geometry/geom_components/wing/components/compute_toc_wing.py
+++ b/src/fastoad/models/geometry/geom_components/wing/components/compute_toc_wing.py
@@ -3,7 +3,7 @@
 """
 
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -34,6 +34,7 @@ class ComputeToCWing(ExplicitComponent):
         self.add_output("data:geometry:wing:kink:thickness_ratio")
         self.add_output("data:geometry:wing:tip:thickness_ratio")
 
+    def setup_partials(self):
         self.declare_partials("data:geometry:wing:thickness_ratio", "*", method="fd")
         self.declare_partials("data:geometry:wing:root:thickness_ratio", "*", method="fd")
         self.declare_partials("data:geometry:wing:kink:thickness_ratio", "*", method="fd")

--- a/src/fastoad/models/geometry/geom_components/wing/components/compute_wet_area_wing.py
+++ b/src/fastoad/models/geometry/geom_components/wing/components/compute_wet_area_wing.py
@@ -3,7 +3,7 @@
 """
 
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -31,6 +31,7 @@ class ComputeWetAreaWing(ExplicitComponent):
         self.add_output("data:geometry:wing:outer_area", units="m**2")
         self.add_output("data:geometry:wing:wetted_area", units="m**2")
 
+    def setup_partials(self):
         self.declare_partials(
             "data:geometry:wing:outer_area",
             [

--- a/src/fastoad/models/geometry/geom_components/wing/components/compute_x_wing.py
+++ b/src/fastoad/models/geometry/geom_components/wing/components/compute_x_wing.py
@@ -3,7 +3,7 @@
 """
 
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -36,6 +36,7 @@ class ComputeXWing(ExplicitComponent):
         self.add_output("data:geometry:wing:kink:leading_edge:x:local", units="m")
         self.add_output("data:geometry:wing:tip:leading_edge:x:local", units="m")
 
+    def setup_partials(self):
         self.declare_partials(
             "data:geometry:wing:kink:leading_edge:x:local",
             [

--- a/src/fastoad/models/geometry/geom_components/wing/components/compute_y_wing.py
+++ b/src/fastoad/models/geometry/geom_components/wing/components/compute_y_wing.py
@@ -3,7 +3,7 @@
 """
 
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -35,6 +35,7 @@ class ComputeYWing(ExplicitComponent):
         self.add_output("data:geometry:wing:kink:y", units="m")
         self.add_output("data:geometry:wing:tip:y", units="m")
 
+    def setup_partials(self):
         self.declare_partials(
             "data:geometry:wing:span",
             ["data:geometry:wing:area", "data:geometry:wing:aspect_ratio"],

--- a/src/fastoad/models/handling_qualities/compute_static_margin.py
+++ b/src/fastoad/models/handling_qualities/compute_static_margin.py
@@ -39,6 +39,7 @@ class ComputeStaticMargin(om.ExplicitComponent):
 
         self.add_output("data:handling_qualities:static_margin")
 
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):

--- a/src/fastoad/models/handling_qualities/tail_sizing/compute_ht_area.py
+++ b/src/fastoad/models/handling_qualities/tail_sizing/compute_ht_area.py
@@ -52,6 +52,7 @@ class ComputeHTArea(om.ExplicitComponent):
         self.add_output("data:geometry:horizontal_tail:wetted_area", units="m**2", ref=100.0)
         self.add_output("data:geometry:horizontal_tail:area", units="m**2", ref=50.0)
 
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")
         self.declare_partials(
             "data:geometry:horizontal_tail:MAC:at25percent:x:from_wingMAC25",

--- a/src/fastoad/models/handling_qualities/tail_sizing/compute_vt_area.py
+++ b/src/fastoad/models/handling_qualities/tail_sizing/compute_vt_area.py
@@ -2,7 +2,7 @@
 Estimation of vertical tail area
 """
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -42,6 +42,7 @@ class ComputeVTArea(om.ExplicitComponent):
         self.add_output("data:geometry:vertical_tail:area", units="m**2", ref=50.0)
         self.add_output("data:aerodynamics:vertical_tail:cruise:CnBeta", units="m**2")
 
+    def setup_partials(self):
         self.declare_partials("data:geometry:vertical_tail:wetted_area", "*", method="fd")
         self.declare_partials("data:geometry:vertical_tail:area", "*", method="fd")
         self.declare_partials("data:aerodynamics:vertical_tail:cruise:CnBeta", "*", method="fd")

--- a/src/fastoad/models/loops/compute_wing_area.py
+++ b/src/fastoad/models/loops/compute_wing_area.py
@@ -49,6 +49,8 @@ class _ComputeWingArea(om.ExplicitComponent):
         self.add_input("data:aerodynamics:aircraft:landing:CL_max", val=np.nan)
 
         self.add_output("data:geometry:wing:area", val=100.0, units="m**2")
+
+    def setup_partials(self):
         self.declare_partials("data:geometry:wing:area", "*", method="fd")
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
@@ -84,6 +86,7 @@ class _ComputeWingAreaConstraints(om.ExplicitComponent):
         self.add_output("data:weight:aircraft:additional_fuel_capacity", units="kg")
         self.add_output("data:aerodynamics:aircraft:landing:additional_CL_capacity")
 
+    def setup_partials(self):
         self.declare_partials(
             "data:weight:aircraft:additional_fuel_capacity",
             ["data:weight:aircraft:MFW", "data:weight:aircraft:sizing_block_fuel"],

--- a/src/fastoad/models/loops/compute_wing_position.py
+++ b/src/fastoad/models/loops/compute_wing_position.py
@@ -36,6 +36,7 @@ class ComputeWingPosition(om.ExplicitComponent):
 
         self.add_output("data:geometry:wing:MAC:at25percent:x", val=17.0, units="m")
 
+    def setup_partials(self):
         self.declare_partials(of="*", wrt="*", method="fd")
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):

--- a/src/fastoad/models/performances/mission/openmdao/mission.py
+++ b/src/fastoad/models/performances/mission/openmdao/mission.py
@@ -342,7 +342,8 @@ class MissionComponent(om.ExplicitComponent):
             self.add_output("data:weight:aircraft:sizing_block_fuel", units="kg")
             self.add_output("data:weight:aircraft:sizing_onboard_fuel_at_takeoff", units="kg")
 
-        self.declare_partials(["*"], ["*"])
+    def setup_partials(self):
+        self.declare_partials(["*"], ["*"], method="fd")
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
         iter_count = self.iter_count_without_approx

--- a/src/fastoad/models/propulsion/fuel_propulsion/rubber_engine/openmdao.py
+++ b/src/fastoad/models/propulsion/fuel_propulsion/rubber_engine/openmdao.py
@@ -160,6 +160,9 @@ class OMRubberEngineComponent(BaseOMPropulsionComponent):
         super().setup()
         self.get_wrapper().setup(self)
 
+    def setup_partials(self):
+        self.declare_partials("*", "*", method="fd")
+
     @staticmethod
     def get_wrapper() -> OMRubberEngineWrapper:
         return OMRubberEngineWrapper()

--- a/src/fastoad/models/weight/cg/cg.py
+++ b/src/fastoad/models/weight/cg/cg.py
@@ -2,7 +2,7 @@
     FAST - Copyright (c) 2016 ONERA ISAE
 """
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -17,14 +17,16 @@
 import numpy as np
 import openmdao.api as om
 
-from fastoad.models.weight.cg.cg_components import ComputeControlSurfacesCG
-from fastoad.models.weight.cg.cg_components import ComputeGlobalCG
-from fastoad.models.weight.cg.cg_components import ComputeHTcg
-from fastoad.models.weight.cg.cg_components import ComputeOthersCG
-from fastoad.models.weight.cg.cg_components import ComputeTanksCG
-from fastoad.models.weight.cg.cg_components import ComputeVTcg
-from fastoad.models.weight.cg.cg_components import ComputeWingCG
-from fastoad.models.weight.cg.cg_components import UpdateMLG
+from fastoad.models.weight.cg.cg_components import (
+    ComputeControlSurfacesCG,
+    ComputeGlobalCG,
+    ComputeHTcg,
+    ComputeOthersCG,
+    ComputeTanksCG,
+    ComputeVTcg,
+    ComputeWingCG,
+    UpdateMLG,
+)
 
 
 class CG(om.Group):
@@ -60,6 +62,7 @@ class ComputeAircraftCG(om.ExplicitComponent):
 
         self.add_output("data:weight:aircraft:CG:aft:x", units="m")
 
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")
 
     def compute(self, inputs, outputs):

--- a/src/fastoad/models/weight/cg/cg_components/compute_cg_control_surfaces.py
+++ b/src/fastoad/models/weight/cg/cg_components/compute_cg_control_surfaces.py
@@ -3,7 +3,7 @@
 """
 
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -35,6 +35,7 @@ class ComputeControlSurfacesCG(ExplicitComponent):
 
         self.add_output("data:weight:airframe:flight_controls:CG:x", units="m")
 
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")
 
     def compute(self, inputs, outputs):

--- a/src/fastoad/models/weight/cg/cg_components/compute_cg_loadcase1.py
+++ b/src/fastoad/models/weight/cg/cg_components/compute_cg_loadcase1.py
@@ -3,7 +3,7 @@
 """
 
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -34,6 +34,7 @@ class ComputeCGLoadCase1(ExplicitComponent):
 
         self.add_output("data:weight:aircraft:load_case_1:CG:MAC_position")
 
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):

--- a/src/fastoad/models/weight/cg/cg_components/compute_cg_loadcase2.py
+++ b/src/fastoad/models/weight/cg/cg_components/compute_cg_loadcase2.py
@@ -3,7 +3,7 @@
 """
 
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -36,6 +36,7 @@ class ComputeCGLoadCase2(ExplicitComponent):
 
         self.add_output("data:weight:aircraft:load_case_2:CG:MAC_position")
 
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):

--- a/src/fastoad/models/weight/cg/cg_components/compute_cg_loadcase3.py
+++ b/src/fastoad/models/weight/cg/cg_components/compute_cg_loadcase3.py
@@ -3,7 +3,7 @@
 """
 
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -34,6 +34,7 @@ class ComputeCGLoadCase3(ExplicitComponent):
 
         self.add_output("data:weight:aircraft:load_case_3:CG:MAC_position")
 
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):

--- a/src/fastoad/models/weight/cg/cg_components/compute_cg_loadcase4.py
+++ b/src/fastoad/models/weight/cg/cg_components/compute_cg_loadcase4.py
@@ -3,7 +3,7 @@
 """
 
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -34,6 +34,7 @@ class ComputeCGLoadCase4(ExplicitComponent):
 
         self.add_output("data:weight:aircraft:load_case_4:CG:MAC_position")
 
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):

--- a/src/fastoad/models/weight/cg/cg_components/compute_cg_others.py
+++ b/src/fastoad/models/weight/cg/cg_components/compute_cg_others.py
@@ -3,7 +3,7 @@
 """
 
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -65,6 +65,7 @@ class ComputeOthersCG(ExplicitComponent):
         self.add_output("data:weight:payload:rear_fret:CG:x", units="m")
         self.add_output("data:weight:payload:front_fret:CG:x", units="m")
 
+    def setup_partials(self):
         self.declare_partials(
             "data:weight:airframe:fuselage:CG:x", "data:geometry:fuselage:length", method="fd"
         )

--- a/src/fastoad/models/weight/cg/cg_components/compute_cg_ratio_aft.py
+++ b/src/fastoad/models/weight/cg/cg_components/compute_cg_ratio_aft.py
@@ -2,7 +2,7 @@
     Estimation of center of gravity ratio with aft
 """
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -109,6 +109,7 @@ class ComputeCG(om.ExplicitComponent):
         self.add_output("data:weight:aircraft_empty:mass", units="kg")
         self.add_output("data:weight:aircraft_empty:CG:x", units="m")
 
+    def setup_partials(self):
         self.declare_partials("data:weight:aircraft_empty:mass", "*", method="fd")
         self.declare_partials("data:weight:aircraft_empty:CG:x", "*", method="fd")
 
@@ -130,6 +131,9 @@ class CGRatio(om.ExplicitComponent):
         self.add_input("data:geometry:wing:MAC:at25percent:x", val=np.nan, units="m")
 
         self.add_output("data:weight:aircraft:empty:CG:MAC_position")
+
+    def setup_partials(self):
+        self.declare_partials("*", "*", method="fd")
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
         x_cg_all = inputs["data:weight:aircraft_empty:CG:x"]

--- a/src/fastoad/models/weight/cg/cg_components/compute_cg_tanks.py
+++ b/src/fastoad/models/weight/cg/cg_components/compute_cg_tanks.py
@@ -3,7 +3,7 @@
 """
 
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -54,6 +54,7 @@ class ComputeTanksCG(ExplicitComponent):
 
         self.add_output("data:weight:fuel_tank:CG:x", units="m")
 
+    def setup_partials(self):
         self.declare_partials("data:weight:fuel_tank:CG:x", "*", method="fd")
 
     def compute(self, inputs, outputs):

--- a/src/fastoad/models/weight/cg/cg_components/compute_cg_wing.py
+++ b/src/fastoad/models/weight/cg/cg_components/compute_cg_wing.py
@@ -3,7 +3,7 @@
 """
 
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -45,6 +45,7 @@ class ComputeWingCG(ExplicitComponent):
 
         self.add_output("data:weight:airframe:wing:CG:x", units="m")
 
+    def setup_partials(self):
         self.declare_partials("data:weight:airframe:wing:CG:x", "*", method="fd")
 
     def compute(self, inputs, outputs):

--- a/src/fastoad/models/weight/cg/cg_components/compute_ht_cg.py
+++ b/src/fastoad/models/weight/cg/cg_components/compute_ht_cg.py
@@ -3,7 +3,7 @@
 """
 
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -40,6 +40,7 @@ class ComputeHTcg(ExplicitComponent):
 
         self.add_output("data:weight:airframe:horizontal_tail:CG:x", units="m")
 
+    def setup_partials(self):
         self.declare_partials("data:weight:airframe:horizontal_tail:CG:x", "*", method="fd")
 
     def compute(self, inputs, outputs):

--- a/src/fastoad/models/weight/cg/cg_components/compute_max_cg_ratio.py
+++ b/src/fastoad/models/weight/cg/cg_components/compute_max_cg_ratio.py
@@ -3,7 +3,7 @@
 """
 
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -37,6 +37,7 @@ class ComputeMaxCGratio(ExplicitComponent):
 
         self.add_output("data:weight:aircraft:CG:aft:MAC_position")
 
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")
 
     def compute(self, inputs, outputs):

--- a/src/fastoad/models/weight/cg/cg_components/compute_vt_cg.py
+++ b/src/fastoad/models/weight/cg/cg_components/compute_vt_cg.py
@@ -3,7 +3,7 @@
 """
 
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -38,6 +38,7 @@ class ComputeVTcg(ExplicitComponent):
 
         self.add_output("data:weight:airframe:vertical_tail:CG:x", units="m")
 
+    def setup_partials(self):
         self.declare_partials("data:weight:airframe:vertical_tail:CG:x", "*", method="fd")
 
     def compute(self, inputs, outputs):

--- a/src/fastoad/models/weight/cg/cg_components/update_mlg.py
+++ b/src/fastoad/models/weight/cg/cg_components/update_mlg.py
@@ -3,7 +3,7 @@
 """
 
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -32,6 +32,7 @@ class UpdateMLG(om.ExplicitComponent):
 
         self.add_output("data:weight:airframe:landing_gear:main:CG:x", units="m")
 
+    def setup_partials(self):
         self.declare_partials("data:weight:airframe:landing_gear:main:CG:x", "*", method="fd")
 
     def compute(self, inputs, outputs):

--- a/src/fastoad/models/weight/mass_breakdown/a_airframe/a1_wing_weight.py
+++ b/src/fastoad/models/weight/mass_breakdown/a_airframe/a1_wing_weight.py
@@ -2,7 +2,7 @@
 Estimation of wing weight
 """
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -69,6 +69,7 @@ class WingWeight(om.ExplicitComponent):
 
         self.add_output("data:weight:airframe:wing:mass", units="kg")
 
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):

--- a/src/fastoad/models/weight/mass_breakdown/a_airframe/a2_fuselage_weight.py
+++ b/src/fastoad/models/weight/mass_breakdown/a_airframe/a2_fuselage_weight.py
@@ -2,7 +2,7 @@
 Estimation of fuselage weight
 """
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -37,6 +37,7 @@ class FuselageWeight(om.ExplicitComponent):
 
         self.add_output("data:weight:airframe:fuselage:mass", units="kg")
 
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):

--- a/src/fastoad/models/weight/mass_breakdown/a_airframe/a3_empennage_weight.py
+++ b/src/fastoad/models/weight/mass_breakdown/a_airframe/a3_empennage_weight.py
@@ -2,7 +2,7 @@
 Estimation of empennage weight
 """
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -38,6 +38,7 @@ class EmpennageWeight(om.ExplicitComponent):
         self.add_output("data:weight:airframe:horizontal_tail:mass", units="kg")
         self.add_output("data:weight:airframe:vertical_tail:mass", units="kg")
 
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")
 
     # pylint: disable=too-many-locals

--- a/src/fastoad/models/weight/mass_breakdown/a_airframe/a4_flight_control_weight.py
+++ b/src/fastoad/models/weight/mass_breakdown/a_airframe/a4_flight_control_weight.py
@@ -2,7 +2,7 @@
 Estimation of flight controls weight
 """
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -38,6 +38,7 @@ class FlightControlsWeight(om.ExplicitComponent):
 
         self.add_output("data:weight:airframe:flight_controls:mass", units="kg")
 
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):

--- a/src/fastoad/models/weight/mass_breakdown/a_airframe/a5_landing_gear_weight.py
+++ b/src/fastoad/models/weight/mass_breakdown/a_airframe/a5_landing_gear_weight.py
@@ -2,7 +2,7 @@
 Estimation of landing gear weight
 """
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -33,6 +33,7 @@ class LandingGearWeight(om.ExplicitComponent):
         self.add_output("data:weight:airframe:landing_gear:main:mass", units="kg")
         self.add_output("data:weight:airframe:landing_gear:front:mass", units="kg")
 
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):

--- a/src/fastoad/models/weight/mass_breakdown/a_airframe/a6_pylons_weight.py
+++ b/src/fastoad/models/weight/mass_breakdown/a_airframe/a6_pylons_weight.py
@@ -2,7 +2,7 @@
 Estimation of pylons weight
 """
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -35,6 +35,7 @@ class PylonsWeight(om.ExplicitComponent):
 
         self.add_output("data:weight:airframe:pylon:mass", units="kg")
 
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):

--- a/src/fastoad/models/weight/mass_breakdown/a_airframe/a7_paint_weight.py
+++ b/src/fastoad/models/weight/mass_breakdown/a_airframe/a7_paint_weight.py
@@ -2,7 +2,7 @@
 Estimation of paint weight
 """
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -32,6 +32,7 @@ class PaintWeight(om.ExplicitComponent):
 
         self.add_output("data:weight:airframe:paint:mass", units="kg")
 
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):

--- a/src/fastoad/models/weight/mass_breakdown/b_propulsion/b1_engine_weight.py
+++ b/src/fastoad/models/weight/mass_breakdown/b_propulsion/b1_engine_weight.py
@@ -2,7 +2,7 @@
 Estimation of engine weight
 """
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -34,6 +34,7 @@ class EngineWeight(ExplicitComponent):
 
         self.add_output("data:weight:propulsion:engine:mass", units="kg")
 
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):

--- a/src/fastoad/models/weight/mass_breakdown/b_propulsion/b2_fuel_lines_weight.py
+++ b/src/fastoad/models/weight/mass_breakdown/b_propulsion/b2_fuel_lines_weight.py
@@ -2,7 +2,7 @@
 Estimation of fuel lines weight
 """
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -34,6 +34,7 @@ class FuelLinesWeight(ExplicitComponent):
 
         self.add_output("data:weight:propulsion:fuel_lines:mass", units="kg")
 
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):

--- a/src/fastoad/models/weight/mass_breakdown/b_propulsion/b3_unconsumables_weight.py
+++ b/src/fastoad/models/weight/mass_breakdown/b_propulsion/b3_unconsumables_weight.py
@@ -2,7 +2,7 @@
 Estimation of fuel lines weight
 """
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -33,6 +33,7 @@ class UnconsumablesWeight(ExplicitComponent):
 
         self.add_output("data:weight:propulsion:unconsumables:mass", units="kg")
 
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):

--- a/src/fastoad/models/weight/mass_breakdown/c_systems/c1_power_systems_weight.py
+++ b/src/fastoad/models/weight/mass_breakdown/c_systems/c1_power_systems_weight.py
@@ -2,7 +2,7 @@
 Estimation of power systems weight
 """
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -53,6 +53,7 @@ class PowerSystemsWeight(ExplicitComponent):
         self.add_output("data:weight:systems:power:electric_systems:mass", units="kg")
         self.add_output("data:weight:systems:power:hydraulic_systems:mass", units="kg")
 
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")
 
     # pylint: disable=too-many-locals

--- a/src/fastoad/models/weight/mass_breakdown/c_systems/c2_life_support_systems_weight.py
+++ b/src/fastoad/models/weight/mass_breakdown/c_systems/c2_life_support_systems_weight.py
@@ -2,7 +2,7 @@
 Estimation of life support systems weight
 """
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -91,6 +91,7 @@ class LifeSupportSystemsWeight(ExplicitComponent):
         self.add_output("data:weight:systems:life_support:oxygen:mass", units="kg")
         self.add_output("data:weight:systems:life_support:safety_equipment:mass", units="kg")
 
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")
 
     # pylint: disable=too-many-locals

--- a/src/fastoad/models/weight/mass_breakdown/c_systems/c3_navigation_systems_weight.py
+++ b/src/fastoad/models/weight/mass_breakdown/c_systems/c3_navigation_systems_weight.py
@@ -2,7 +2,7 @@
 Estimation of navigation systems weight
 """
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -36,6 +36,7 @@ class NavigationSystemsWeight(ExplicitComponent):
 
         self.add_output("data:weight:systems:navigation:mass", units="kg")
 
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):

--- a/src/fastoad/models/weight/mass_breakdown/c_systems/c4_transmissions_systems_weight.py
+++ b/src/fastoad/models/weight/mass_breakdown/c_systems/c4_transmissions_systems_weight.py
@@ -2,7 +2,7 @@
 Estimation of transmissions systems weight
 """
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -34,6 +34,7 @@ class TransmissionSystemsWeight(om.ExplicitComponent):
 
         self.add_output("data:weight:systems:transmission:mass", units="kg")
 
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):

--- a/src/fastoad/models/weight/mass_breakdown/c_systems/c5_fixed_operational_systems_weight.py
+++ b/src/fastoad/models/weight/mass_breakdown/c_systems/c5_fixed_operational_systems_weight.py
@@ -2,7 +2,7 @@
 Estimation of fixed operational systems weight
 """
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -38,6 +38,7 @@ class FixedOperationalSystemsWeight(ExplicitComponent):
         self.add_output("data:weight:systems:operational:radar:mass", units="kg")
         self.add_output("data:weight:systems:operational:cargo_hold:mass", units="kg")
 
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")
 
     # pylint: disable=too-many-locals

--- a/src/fastoad/models/weight/mass_breakdown/c_systems/c6_flight_kit_weight.py
+++ b/src/fastoad/models/weight/mass_breakdown/c_systems/c6_flight_kit_weight.py
@@ -2,7 +2,7 @@
 Estimation of flight kit weight
 """
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -34,6 +34,7 @@ class FlightKitWeight(om.ExplicitComponent):
 
         self.add_output("data:weight:systems:flight_kit:mass", units="kg")
 
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):

--- a/src/fastoad/models/weight/mass_breakdown/cs25.py
+++ b/src/fastoad/models/weight/mass_breakdown/cs25.py
@@ -48,6 +48,7 @@ class Loads(ExplicitComponent):
         self.add_output("data:mission:sizing:cs25:sizing_load_1", units="kg")
         self.add_output("data:mission:sizing:cs25:sizing_load_2", units="kg")
 
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")
 
     # pylint: disable=too-many-locals

--- a/src/fastoad/models/weight/mass_breakdown/d_furniture/d1_cargo_configuration_weight.py
+++ b/src/fastoad/models/weight/mass_breakdown/d_furniture/d1_cargo_configuration_weight.py
@@ -2,7 +2,7 @@
 Estimation of cargo configuration weight
 """
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -37,6 +37,7 @@ class CargoConfigurationWeight(om.ExplicitComponent):
 
         self.add_output("data:weight:furniture:cargo_configuration:mass", units="kg")
 
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):

--- a/src/fastoad/models/weight/mass_breakdown/d_furniture/d2_passenger_seats_weight.py
+++ b/src/fastoad/models/weight/mass_breakdown/d_furniture/d2_passenger_seats_weight.py
@@ -2,7 +2,7 @@
 Estimation of passenger seats weight
 """
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -35,6 +35,7 @@ class PassengerSeatsWeight(om.ExplicitComponent):
 
         self.add_output("data:weight:furniture:passenger_seats:mass", units="kg")
 
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):

--- a/src/fastoad/models/weight/mass_breakdown/d_furniture/d3_food_water_weight.py
+++ b/src/fastoad/models/weight/mass_breakdown/d_furniture/d3_food_water_weight.py
@@ -2,7 +2,7 @@
 Estimation of food water weight
 """
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -34,6 +34,7 @@ class FoodWaterWeight(om.ExplicitComponent):
 
         self.add_output("data:weight:furniture:food_water:mass", units="kg")
 
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):

--- a/src/fastoad/models/weight/mass_breakdown/d_furniture/d4_security_kit_weight.py
+++ b/src/fastoad/models/weight/mass_breakdown/d_furniture/d4_security_kit_weight.py
@@ -2,7 +2,7 @@
 Estimation of security kit weight
 """
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -34,6 +34,7 @@ class SecurityKitWeight(om.ExplicitComponent):
 
         self.add_output("data:weight:furniture:security_kit:mass", units="kg")
 
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):

--- a/src/fastoad/models/weight/mass_breakdown/d_furniture/d5_toilets_weight.py
+++ b/src/fastoad/models/weight/mass_breakdown/d_furniture/d5_toilets_weight.py
@@ -2,7 +2,7 @@
 Estimation of toilets weight
 """
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -35,6 +35,7 @@ class ToiletsWeight(om.ExplicitComponent):
 
         self.add_output("data:weight:furniture:toilets:mass", units="kg")
 
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):

--- a/src/fastoad/models/weight/mass_breakdown/e_crew/crew_weight.py
+++ b/src/fastoad/models/weight/mass_breakdown/e_crew/crew_weight.py
@@ -2,7 +2,7 @@
 Estimation of crew weight
 """
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -31,6 +31,7 @@ class CrewWeight(ExplicitComponent):
 
         self.add_output("data:weight:crew:mass", units="kg")
 
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):

--- a/src/fastoad/models/weight/mass_breakdown/payload.py
+++ b/src/fastoad/models/weight/mass_breakdown/payload.py
@@ -2,7 +2,7 @@
 Payload mass computation
 """
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -39,6 +39,7 @@ class ComputePayload(om.ExplicitComponent):
         self.add_output("data:weight:aircraft:payload", units="kg")
         self.add_output("data:weight:aircraft:max_payload", units="kg")
 
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):

--- a/src/fastoad/models/weight/mass_breakdown/update_mlw_and_mzfw.py
+++ b/src/fastoad/models/weight/mass_breakdown/update_mlw_and_mzfw.py
@@ -2,7 +2,7 @@
 Main component for mass breakdown
 """
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -31,6 +31,7 @@ class UpdateMLWandMZFW(ExplicitComponent):
         self.add_output("data:weight:aircraft:MZFW", units="kg")
         self.add_output("data:weight:aircraft:MLW", units="kg")
 
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):

--- a/src/fastoad/module_management/tests/data/module_sellar_example/disc1/disc1.py
+++ b/src/fastoad/module_management/tests/data/module_sellar_example/disc1/disc1.py
@@ -31,6 +31,8 @@ class Disc1(om.ExplicitComponent):
         self.add_input("y2", val=1.0, desc="")
 
         self.add_output("y1", val=1.0, desc="This description should not apply")
+
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")
 
     # pylint: disable=invalid-name

--- a/src/fastoad/module_management/tests/data/module_sellar_example/disc2/disc2.py
+++ b/src/fastoad/module_management/tests/data/module_sellar_example/disc2/disc2.py
@@ -29,6 +29,8 @@ class Disc2(om.ExplicitComponent):
         self.add_input("y1", val=1.0, desc="")
 
         self.add_output("y2", val=1.0, desc="")
+
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")
 
     # pylint: disable=invalid-name

--- a/src/fastoad/module_management/tests/data/module_sellar_example/functions/function_f.py
+++ b/src/fastoad/module_management/tests/data/module_sellar_example/functions/function_f.py
@@ -39,6 +39,7 @@ class FunctionF(om.ExplicitComponent):
 
         self.add_output("f", val=1.0, desc="")
 
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):

--- a/src/fastoad/module_management/tests/data/module_sellar_example/functions/functions_g.py
+++ b/src/fastoad/module_management/tests/data/module_sellar_example/functions/functions_g.py
@@ -28,6 +28,8 @@ class FunctionG1(om.ExplicitComponent):
         self.add_input("y1", val=1.0, desc="")
 
         self.add_output("g1", val=1.0, desc="")
+
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
@@ -49,6 +51,8 @@ class FunctionG2(om.ExplicitComponent):
         self.add_input("y2", val=1.0, desc="")
 
         self.add_output("g2", val=1.0, desc="")
+
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):

--- a/src/fastoad/openmdao/tests/openmdao_sellar_example/disc1.py
+++ b/src/fastoad/openmdao/tests/openmdao_sellar_example/disc1.py
@@ -25,6 +25,8 @@ class Disc1(om.ExplicitComponent):
         self.add_input("y2", val=1.0, desc="")
 
         self.add_output("y1", val=1.0, desc="")
+
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):

--- a/src/fastoad/openmdao/tests/openmdao_sellar_example/disc2.py
+++ b/src/fastoad/openmdao/tests/openmdao_sellar_example/disc2.py
@@ -23,6 +23,8 @@ class Disc2(om.ExplicitComponent):
         self.add_input("y1", val=1.0, desc="")
 
         self.add_output("y2", val=1.0, desc="")
+
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):

--- a/src/fastoad/openmdao/tests/openmdao_sellar_example/functions.py
+++ b/src/fastoad/openmdao/tests/openmdao_sellar_example/functions.py
@@ -34,6 +34,8 @@ class Functions(om.ExplicitComponent):
         self.add_output("g1", val=1.0, desc="")
 
         self.add_output("g2", val=1.0, desc="")
+
+    def setup_partials(self):
         self.declare_partials("*", "*", method="fd")
 
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):


### PR DESCRIPTION
This PR fixes some OpenMDAO components where partial derivatives were incorrectly defined (i.e. without `method="fd"`), in particular the mission module.

Also, all `declare_partials()` have been moved in the dedicated `setup_partials()` method, since it is now the standard in OpenMDAO.

