### PR TITLE
Removed useless exception catching in CLI

### DIFF
--- a/src/fastoad/cmd/fast.py
+++ b/src/fastoad/cmd/fast.py
@@ -367,10 +367,7 @@ class Main:
 
         # Parse ------------------------------------------------------------------------------------
         args = self.parser.parse_args()
-        try:
-            args.func(args)
-        except AttributeError:
-            self.parser.print_help()
+        args.func(args)
 
 
 def _query_yes_no(question):


### PR DESCRIPTION
Resolves #318 by "failing in plain sight" when an error is encountered in a custom module.

When searching a folder for custom modules, some errors (like import errors) are gracefully handled by iPOPO and issue a warning.
In the case of #318, the typo triggers an AttributeError that is not handled by iPOPO and ends in the `try... catch...` around the CLI parser... And I don't really understand what was my purpose when writing this `try...catch...`.
I would guess it was to automatically show the help content in case of misuse of the CLI, but it fails at doing that when I put an incorrect option.

Therefore, removing this try...catch... do not look harmful, and fixes the bug.

And for the future, refactoring the CLI with [click](https://click.palletsprojects.com) looks like a good idea....