### PR TITLE
Aero engine models update

### DIFF
--- a/src/fastoad/models/aerodynamics/components/high_lift_aero.py
+++ b/src/fastoad/models/aerodynamics/components/high_lift_aero.py
@@ -57,12 +57,12 @@ class ComputeDeltaHighLift(om.ExplicitComponent):
         self.add_input(
             "tuning:aerodynamics:high_lift_devices:landing:CD:multi_slotted_flap_effect:k",
             val=1.0,
-            desc="Multiple slots effect on drag w.r.t. single slotted flaps",
+            desc="correction ratio to apply to computed additional drag from flap to take into account multiple slots flaps",
         )
         self.add_input(
             "tuning:aerodynamics:high_lift_devices:landing:CL:multi_slotted_flap_effect:k",
             val=1.0,
-            desc="Multiple slots effect on lift w.r.t. single slotted flaps",
+            desc="correction ratio to apply to computed additional lift from flap to take into account multiple slots flaps",
         )
 
     def setup_partials(self):

--- a/src/fastoad/models/aerodynamics/components/high_lift_aero.py
+++ b/src/fastoad/models/aerodynamics/components/high_lift_aero.py
@@ -55,14 +55,10 @@ class ComputeDeltaHighLift(om.ExplicitComponent):
         self.add_input("data:geometry:slat:chord_ratio", val=np.nan)
         self.add_input("data:geometry:slat:span_ratio", val=np.nan)
         self.add_input(
-            "tuning:aerodynamics:high_lift_devices:landing:CD:multi_slotted_flap_effect:k",
-            val=1.0,
-            desc="correction ratio to apply to computed additional drag from flap to take into account multiple slots flaps",
+            "tuning:aerodynamics:high_lift_devices:landing:CD:multi_slotted_flap_effect:k", val=1.0
         )
         self.add_input(
-            "tuning:aerodynamics:high_lift_devices:landing:CL:multi_slotted_flap_effect:k",
-            val=1.0,
-            desc="correction ratio to apply to computed additional lift from flap to take into account multiple slots flaps",
+            "tuning:aerodynamics:high_lift_devices:landing:CL:multi_slotted_flap_effect:k", val=1.0
         )
 
     def setup_partials(self):

--- a/src/fastoad/models/aerodynamics/components/high_lift_aero.py
+++ b/src/fastoad/models/aerodynamics/components/high_lift_aero.py
@@ -54,6 +54,16 @@ class ComputeDeltaHighLift(om.ExplicitComponent):
         self.add_input("data:geometry:flap:span_ratio", val=np.nan)
         self.add_input("data:geometry:slat:chord_ratio", val=np.nan)
         self.add_input("data:geometry:slat:span_ratio", val=np.nan)
+        self.add_input(
+            "tuning:aerodynamics:high_lift_devices:landing:CD:multi_slotted_flap_effect:k",
+            val=1.0,
+            desc="Multiple slots effect on drag w.r.t. single slotted flaps",
+        )
+        self.add_input(
+            "tuning:aerodynamics:high_lift_devices:landing:CL:multi_slotted_flap_effect:k",
+            val=1.0,
+            desc="Multiple slots effect on lift w.r.t. single slotted flaps",
+        )
 
     def setup_partials(self):
         self.declare_partials("*", "*", method="fd")
@@ -69,6 +79,12 @@ class ComputeDeltaHighLift(om.ExplicitComponent):
             slat_angle = inputs["data:mission:sizing:takeoff:slat_angle"]
             mach = inputs["data:aerodynamics:aircraft:takeoff:mach"]
 
+        k_cd_slot = inputs[
+            "tuning:aerodynamics:high_lift_devices:landing:CD:multi_slotted_flap_effect:k"
+        ]
+        k_cl_slot = inputs[
+            "tuning:aerodynamics:high_lift_devices:landing:CL:multi_slotted_flap_effect:k"
+        ]
         le_sweep_angle = inputs["data:geometry:wing:sweep_0"]
         te_sweep_angle = inputs["data:geometry:wing:sweep_100_outer"]
         flap_chord_ratio = inputs["data:geometry:flap:chord_ratio"]
@@ -87,9 +103,10 @@ class ComputeDeltaHighLift(om.ExplicitComponent):
                 mach,
                 le_sweep_angle,
                 te_sweep_angle,
+                k_cl_slot,
             )
             outputs["data:aerodynamics:high_lift_devices:landing:CD"] = self._get_delta_cd(
-                slat_angle, flap_angle, slat_span_ratio, flap_span_ratio
+                slat_angle, flap_angle, slat_span_ratio, flap_span_ratio, k_cd_slot
             )
         else:
             outputs["data:aerodynamics:high_lift_devices:takeoff:CL"] = self._get_delta_cl(
@@ -102,9 +119,10 @@ class ComputeDeltaHighLift(om.ExplicitComponent):
                 mach,
                 le_sweep_angle,
                 te_sweep_angle,
+                k_cl_slot,
             )
             outputs["data:aerodynamics:high_lift_devices:takeoff:CD"] = self._get_delta_cd(
-                slat_angle, flap_angle, slat_span_ratio, flap_span_ratio
+                slat_angle, flap_angle, slat_span_ratio, flap_span_ratio, k_cd_slot
             )
 
     def _get_delta_cl(
@@ -118,6 +136,7 @@ class ComputeDeltaHighLift(om.ExplicitComponent):
         mach,
         le_sweep_angle,
         te_sweep_angle,
+        k_cl_slot,
     ):
         """
         Method based on Roskam book and Raymer book
@@ -131,6 +150,7 @@ class ComputeDeltaHighLift(om.ExplicitComponent):
         :param mach:
         :param le_sweep_angle: sweep angle at leading edge
         :param te_sweep_angle: sweep angle at trailing edge
+        :param k_cl_slot: multiple slotted flap correction factor
         :return: increment of lift coefficient
         """
 
@@ -144,7 +164,13 @@ class ComputeDeltaHighLift(om.ExplicitComponent):
 
         # cl created by the flap in 2D
         delta_cl_flap = (
-            2.0 * np.pi / np.sqrt(1 - mach ** 2) * ratio_c_flap * alpha_flap * flap_angle
+            2.0
+            * np.pi
+            / np.sqrt(1 - mach ** 2)
+            * ratio_c_flap
+            * alpha_flap
+            * flap_angle
+            * k_cl_slot
         )
 
         # ratio of chord with slat extended compared to clean chord
@@ -176,13 +202,14 @@ class ComputeDeltaHighLift(om.ExplicitComponent):
 
         return delta_cl_total
 
-    def _get_delta_cd(self, slat_angle, flap_angle, slat_span_ratio, flap_span_ratio):
+    def _get_delta_cd(self, slat_angle, flap_angle, slat_span_ratio, flap_span_ratio, k_cd_slot):
         """
 
         :param slat_angle: in degrees
         :param flap_angle: in degrees
         :param slat_span_ratio: the ratio of the part of wing which is equipped with slat
         :param flap_span_ratio: the ratio of the part of wing which is equipped with flap
+        :param k_cd_slot: multiple slotted flap correction factor
         :return: increment of drag coefficient
         """
 
@@ -209,6 +236,7 @@ class ComputeDeltaHighLift(om.ExplicitComponent):
                 - 9.53201e-4 * flap_angle ** 2
                 + 7.5972e-5 * flap_angle ** 3
             )
+            * k_cd_slot
             * flap_span_ratio
             / 100
         )

--- a/src/fastoad/models/aerodynamics/components/tests/test_components.py
+++ b/src/fastoad/models/aerodynamics/components/tests/test_components.py
@@ -54,7 +54,7 @@ def test_high_lift_aero():
         "data:geometry:slat:span_ratio",
     ]
 
-    def get_cl_cd(slat_angle, flap_angle, mach, landing_flag):
+    def get_cl_cd(slat_angle, flap_angle, mach, landing_flag, multi_slot_flag):
         ivc = get_indep_var_comp(input_list)
         if landing_flag:
             ivc.add_output("data:mission:sizing:landing:slat_angle", slat_angle, units="deg")
@@ -64,6 +64,13 @@ def test_high_lift_aero():
             ivc.add_output("data:mission:sizing:takeoff:slat_angle", slat_angle, units="deg")
             ivc.add_output("data:mission:sizing:takeoff:flap_angle", flap_angle, units="deg")
             ivc.add_output("data:aerodynamics:aircraft:takeoff:mach", mach)
+        if multi_slot_flag:
+            ivc.add_output(
+                "tuning:aerodynamics:high_lift_devices:landing:CL:multi_slotted_flap_effect:k", 1.1
+            )
+            ivc.add_output(
+                "tuning:aerodynamics:high_lift_devices:landing:CD:multi_slotted_flap_effect:k", 1.01
+            )
         component = ComputeDeltaHighLift()
         component.options["landing_flag"] = landing_flag
         problem = run_system(component, ivc)
@@ -78,17 +85,25 @@ def test_high_lift_aero():
             problem["data:aerodynamics:high_lift_devices:takeoff:CD"],
         )
 
-    cl, cd = get_cl_cd(18, 10, 0.2, False)
+    cl, cd = get_cl_cd(18, 10, 0.2, False, False)
     assert cl == approx(0.516, abs=1e-3)
     assert cd == approx(0.01430, abs=1e-5)
 
-    cl, cd = get_cl_cd(27, 35, 0.4, False)
+    cl, cd = get_cl_cd(27, 35, 0.4, False, False)
     assert cl == approx(1.431, abs=1e-3)
     assert cd == approx(0.04644, abs=1e-5)
 
-    cl, cd = get_cl_cd(22, 20, 0.2, True)
+    cl, cd = get_cl_cd(27, 35, 0.4, False, True)
+    assert cl == approx(1.564, abs=1e-3)
+    assert cd == approx(0.04675, abs=1e-5)
+
+    cl, cd = get_cl_cd(22, 20, 0.2, True, False)
     assert cl == approx(0.935, abs=1e-3)
     assert cd == approx(0.02220, abs=1e-5)
+
+    cl, cd = get_cl_cd(22, 20, 0.2, True, True)
+    assert cl == approx(1.021, abs=1e-3)
+    assert cd == approx(0.02230, abs=1e-5)
 
 
 def test_oswald():

--- a/src/fastoad/models/propulsion/fuel_propulsion/rubber_engine/openmdao.py
+++ b/src/fastoad/models/propulsion/fuel_propulsion/rubber_engine/openmdao.py
@@ -95,10 +95,14 @@ class OMRubberEngineWrapper(IOMPropulsionWrapper):
             "specified to avoid OpenMDAO making unwanted conversion",
         )
         component.add_input(
-            "tuning:propulsion:rubber_engine:SFC:k_sl", 1.0, desc="SFC correction at sea level"
+            "tuning:propulsion:rubber_engine:SFC:k_sl",
+            1.0,
+            desc="correction ratio to apply to the computed SFC at sea level",
         )
         component.add_input(
-            "tuning:propulsion:rubber_engine:SFC:k_cr", 1.0, desc="SFC correction at cruise FL430"
+            "tuning:propulsion:rubber_engine:SFC:k_cr",
+            1.0,
+            desc="correction ratio to apply to the computed SFC at cruise ceiling",
         )
 
     @staticmethod

--- a/src/fastoad/models/propulsion/fuel_propulsion/rubber_engine/openmdao.py
+++ b/src/fastoad/models/propulsion/fuel_propulsion/rubber_engine/openmdao.py
@@ -94,6 +94,12 @@ class OMRubberEngineWrapper(IOMPropulsionWrapper):
             desc="As it is a delta, unit is K or °C, but is not "
             "specified to avoid OpenMDAO making unwanted conversion",
         )
+        component.add_input(
+            "tuning:propulsion:rubber_engine:SFC:k_sl", 1.0, desc="SFC correction at sea level"
+        )
+        component.add_input(
+            "tuning:propulsion:rubber_engine:SFC:k_cr", 1.0, desc="SFC correction at cruise FL430"
+        )
 
     @staticmethod
     def get_model(inputs) -> IPropulsion:
@@ -116,6 +122,8 @@ class OMRubberEngineWrapper(IOMPropulsionWrapper):
             "delta_t4_climb": inputs["data:propulsion:rubber_engine:delta_t4_climb"],
             "delta_t4_cruise": inputs["data:propulsion:rubber_engine:delta_t4_cruise"],
             "mto_thrust": inputs["data:propulsion:MTO_thrust"],
+            "k_sfc_sl": inputs["tuning:propulsion:rubber_engine:SFC:k_sl"],
+            "k_sfc_cr": inputs["tuning:propulsion:rubber_engine:SFC:k_cr"],
         }
 
         return RubberEngine(**engine_params)

--- a/src/fastoad/models/propulsion/fuel_propulsion/rubber_engine/openmdao.py
+++ b/src/fastoad/models/propulsion/fuel_propulsion/rubber_engine/openmdao.py
@@ -94,16 +94,8 @@ class OMRubberEngineWrapper(IOMPropulsionWrapper):
             desc="As it is a delta, unit is K or °C, but is not "
             "specified to avoid OpenMDAO making unwanted conversion",
         )
-        component.add_input(
-            "tuning:propulsion:rubber_engine:SFC:k_sl",
-            1.0,
-            desc="correction ratio to apply to the computed SFC at sea level",
-        )
-        component.add_input(
-            "tuning:propulsion:rubber_engine:SFC:k_cr",
-            1.0,
-            desc="correction ratio to apply to the computed SFC at cruise ceiling",
-        )
+        component.add_input("tuning:propulsion:rubber_engine:SFC:k_sl", 1.0)
+        component.add_input("tuning:propulsion:rubber_engine:SFC:k_cr", 1.0)
 
     @staticmethod
     def get_model(inputs) -> IPropulsion:

--- a/src/fastoad/models/propulsion/fuel_propulsion/rubber_engine/rubber_engine.py
+++ b/src/fastoad/models/propulsion/fuel_propulsion/rubber_engine/rubber_engine.py
@@ -58,8 +58,8 @@ class RubberEngine(AbstractFuelPropulsion):
         design_altitude: float,
         delta_t4_climb: float = -50,
         delta_t4_cruise: float = -100,
-        k1_sfc: float = 1.0,
-        k2_sfc: float = 1.0,
+        k_sfc_sl: float = 1.0,
+        k_sfc_cr: float = 1.0,
     ):
         """
         Parametric turbofan engine.
@@ -79,6 +79,8 @@ class RubberEngine(AbstractFuelPropulsion):
         :param design_altitude: (unit=m)
         :param delta_t4_climb: (unit=K) difference between T4 during climb and design T4
         :param delta_t4_cruise: (unit=K) difference between T4 during cruise and design T4
+        :param k_sfc_sl: SFC correction at sea level and below
+        :param k_sfc_cr: SFC correction at 43000ft and above in cruise
         """
         # pylint: disable=too-many-arguments  # they define the engine
 
@@ -88,8 +90,8 @@ class RubberEngine(AbstractFuelPropulsion):
         self.f_0 = mto_thrust
         self.mach_max = maximum_mach
         self.design_alt = design_altitude
-        self.k1_sfc = k1_sfc
-        self.k2_sfc = k2_sfc
+        self.k_sfc_sl = k_sfc_sl
+        self.k_sfc_cr = k_sfc_cr
 
         # This dictionary is expected to have a dT4 value for all EngineSetting values
         self.dt4_values = {
@@ -124,7 +126,8 @@ class RubberEngine(AbstractFuelPropulsion):
 
         # SFC correction for NEO engines dependent on altitude.
         f = interp1d(
-            [-50000.0, 0.0, 12192.0, 100000.0], np.hstack((1.0, self.k1_sfc, self.k2_sfc, 1.0))
+            [-1000.0, 0.0, 13106.4, 20000.0],
+            np.hstack((self.k_sfc_sl, self.k_sfc_sl, self.k_sfc_cr, self.k_sfc_cr)),
         )
         k_sfc = f(flight_points.altitude)
 

--- a/src/fastoad/models/propulsion/fuel_propulsion/rubber_engine/rubber_engine.py
+++ b/src/fastoad/models/propulsion/fuel_propulsion/rubber_engine/rubber_engine.py
@@ -125,11 +125,11 @@ class RubberEngine(AbstractFuelPropulsion):
                     flight_points.insert(len(flight_points.columns), name, value=np.nan)
 
         # SFC correction for NEO engines dependent on altitude.
-        f = interp1d(
+        k_sfc_alt = interp1d(
             [-1000.0, 0.0, 13106.4, 20000.0],
             np.hstack((self.k_sfc_sl, self.k_sfc_sl, self.k_sfc_cr, self.k_sfc_cr)),
         )
-        k_sfc = f(flight_points.altitude)
+        k_sfc = k_sfc_alt(flight_points.altitude)
 
         flight_points.sfc = sfc * k_sfc
         flight_points.thrust_rate = thrust_rate

--- a/src/fastoad/models/propulsion/fuel_propulsion/rubber_engine/tests/test_openmdao_engine.py
+++ b/src/fastoad/models/propulsion/fuel_propulsion/rubber_engine/tests/test_openmdao_engine.py
@@ -64,3 +64,50 @@ def test_OMRubberEngineComponent():
         problem["data:propulsion:thrust_rate"], [thrust_rates, thrust_rates], rtol=1e-2
     )
     np.testing.assert_allclose(problem["data:propulsion:thrust"], [thrusts, thrusts], rtol=1e-2)
+
+
+def test_OMRubberEngineComponentWithSFCCorrections():
+    """ Tests ManualRubberEngine component """
+    # Same test as in test_rubber_engine.test_compute_flight_points
+    engine = OMRubberEngineComponent()
+
+    machs = [0, 0.3, 0.3, 0.8, 0.8]
+    altitudes = [0, 0, 0, 10000, 13000]
+    thrust_rates = [0.8, 0.5, 0.5, 0.4, 0.7]
+    thrusts = [0.955 * 0.8, 0.389, 0.357, 0.0967, 0.113]
+    phases = [
+        EngineSetting.TAKEOFF,
+        EngineSetting.TAKEOFF,
+        EngineSetting.CLIMB,
+        EngineSetting.IDLE,
+        EngineSetting.CRUISE.value,
+    ]  # mix EngineSetting with integers
+    expected_sfc = [0.794e-5, 1.08e-5, 1.08e-5, 1.61e-5, 1.44e-5]
+
+    ivc = om.IndepVarComp()
+    ivc.add_output("data:propulsion:rubber_engine:bypass_ratio", 5)
+    ivc.add_output("data:propulsion:rubber_engine:overall_pressure_ratio", 30)
+    ivc.add_output("data:propulsion:rubber_engine:turbine_inlet_temperature", 1500, units="K")
+    ivc.add_output("data:propulsion:MTO_thrust", 1, units="N")
+    ivc.add_output("data:propulsion:rubber_engine:maximum_mach", 0.95)
+    ivc.add_output("data:propulsion:rubber_engine:design_altitude", 10000, units="m")
+
+    ivc.add_output("data:propulsion:mach", [machs, machs])
+    ivc.add_output("data:propulsion:altitude", [altitudes, altitudes], units="m")
+    ivc.add_output("data:propulsion:engine_setting", [phases, phases])
+    ivc.add_output("data:propulsion:use_thrust_rate", [[True] * 5, [False] * 5])
+    ivc.add_output("data:propulsion:required_thrust_rate", [thrust_rates, [0] * 5])
+    ivc.add_output("data:propulsion:required_thrust", [[0] * 5, thrusts], units="N")
+
+    ivc.add_output("tuning:propulsion:rubber_engine:SFC:k_cr", 0.9)
+    ivc.add_output("tuning:propulsion:rubber_engine:SFC:k_sl", 0.8)
+
+    problem = run_system(engine, ivc)
+
+    np.testing.assert_allclose(
+        problem["data:propulsion:SFC"], [expected_sfc, expected_sfc], rtol=1e-2
+    )
+    np.testing.assert_allclose(
+        problem["data:propulsion:thrust_rate"], [thrust_rates, thrust_rates], rtol=1e-2
+    )
+    np.testing.assert_allclose(problem["data:propulsion:thrust"], [thrusts, thrusts], rtol=1e-2)

--- a/src/fastoad/models/variable_descriptions.txt
+++ b/src/fastoad/models/variable_descriptions.txt
@@ -377,6 +377,10 @@ tuning:aerodynamics:aircraft:cruise:CL:winglet_effect:k || ratio to apply to def
 tuning:aerodynamics:aircraft:cruise:CL:winglet_effect:offset || offset to apply to defined cl range (which goes by default from 0.0 to 1.5) in cruise polar computation
 tuning:aerodynamics:aircraft:landing:CL_max:landing_gear_effect:k || correction ratio to apply to computed maximum lift coefficient in landing conditions to take into account effect of landing gear
 tuning:aerodynamics:aircraft:landing:CL_max:landing_gear_effect:offset || correction offset to apply to computed maximum lift coefficient in landing conditions to take into account effect of landing gear
+tuning:aerodynamics:high_lift_devices:landing:CD:multi_slotted_flap_effect:k || correction ratio to apply to computed additional drag from flap to take into account multiple slots flaps
+tuning:aerodynamics:high_lift_devices:landing:CL:multi_slotted_flap_effect:k || correction ratio to apply to computed additional lift from flap to take into account multiple slots flaps
+tuning:propulsion:rubber_engine:SFC:k_sl || correction ratio to apply to the computed SFC at sea level
+tuning:propulsion:rubber_engine:SFC:k_cr || correction ratio to apply to the computed SFC at cruise ceiling
 tuning:weight:airframe:flight_controls:mass:k || flight controls (A4): correction ratio to be applied on computed mass
 tuning:weight:airframe:flight_controls:mass:offset || flight controls (A4): correction offset to be applied on computed mass
 tuning:weight:airframe:fuselage:mass:k || fuselage (A2): correction ratio to be applied on computed mass


### PR DESCRIPTION
This little PR adds changes to aerodynamic and rubber engine models: 

- The high lift aerodynamic model has been updated adding two tuning parameters to correct the additional lift and drag due to flaps to take into account multiple slotted flaps. 
- The rubber engine model has been updated adding two tuning parameters to correct SFC at sea level (SL) and at 43000ft (ceiling for most of commercial aircraft). Between SL and 43000 the correction is linearly interpolated and saturations are introduced below SL and above 43000ft. 