### PR TITLE
Test workflows are now launched whatever the changed files are.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,12 +6,6 @@ on:
       - '**'
     tags-ignore:
       - '**'
-    paths:
-      - 'src/**'
-      - 'tests/**'
-      - 'poetry.lock'
-      - '.github/workflows/**'
-      - 'CHANGELOG.rst'  # To ensure CI runs when merging release branch
 
 
 jobs:
@@ -20,7 +14,7 @@ jobs:
     if: ${{ !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') }}
     strategy:
       matrix:
-        python-version: [ 3.7, 3.8 ]
+        python-version: [ 3.7, 3.8, 3.9 ]
         os: [ ubuntu-latest, windows-latest, macos-latest ]
 
     steps:

--- a/.github/workflows/watchman_tests.yml
+++ b/.github/workflows/watchman_tests.yml
@@ -17,7 +17,7 @@ jobs:
     if: ${{ !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') }}
     strategy:
       matrix:
-        python-version: [ 3.8 ]
+        python-version: [ 3.9 ]
         os: [ ubuntu-latest, windows-latest, macos-latest ]
 
     steps:

--- a/.github/workflows/watchman_tests.yml
+++ b/.github/workflows/watchman_tests.yml
@@ -9,12 +9,6 @@ on:
       - '**'
     tags-ignore:
       - '**'
-    paths:
-      - 'src/**'
-      - 'tests/**'
-      - 'pyproject.toml'
-      - '.github/workflows/**'
-      - 'CHANGELOG.rst'   # To ensure CI runs when merging release branch
 
 
 jobs:


### PR DESCRIPTION
Avoiding to launch tests when only non-python files were changed looked attractive, but it has some drawbacks:
- if a commit on the master branch has not been tested, it has no coverage report for Codecov. And then, a branch
  that starts from that commit will not have a relevant base for coverage comparison.
- if the last commit of a branch has not been tested, the associated PR will not show any test-related check.

However, we keep avoiding launching tests on new tags, and we keep doing sparingly the time-consuming notebook tests.

Also, python 3.9 runners have been added to the test matrix, and watchman tests are now launched with Python 3.9.