### PR TITLE
Issue 311 - Incorrect taxi-in distance

### DIFF
--- a/src/fastoad/models/performances/mission/mission_definition/tests/data/mission.yml
+++ b/src/fastoad/models/performances/mission/mission_definition/tests/data/mission.yml
@@ -121,12 +121,14 @@ phases:
     parts:
       - segment: taxi
         thrust_rate: ~
+        true_airspeed: 0.
         target:
           time: ~duration
   taxi_in:
     thrust_rate: ~
     parts:
       - segment: taxi
+        true_airspeed: 0.
         target:
           time: ~duration
 

--- a/src/fastoad/models/performances/mission/openmdao/mission.py
+++ b/src/fastoad/models/performances/mission/openmdao/mission.py
@@ -238,6 +238,7 @@ _MissionVariables = namedtuple(
         "NEEDED_FUEL_AT_TAKEOFF",
         "TAXI_OUT_DURATION",
         "TAXI_OUT_THRUST_RATE",
+        "TAXI_OUT_DISTANCE",
         "TAXI_OUT_FUEL",
         "TAKEOFF_FUEL",
         "TAKEOFF_ALTITUDE",
@@ -293,6 +294,7 @@ class MissionComponent(om.ExplicitComponent):
             NEEDED_FUEL_AT_TAKEOFF="data:mission:%s:needed_onboard_fuel_at_takeoff" % mission_name,
             TAXI_OUT_DURATION="data:mission:%s:taxi_out:duration" % mission_name,
             TAXI_OUT_THRUST_RATE="data:mission:%s:taxi_out:thrust_rate" % mission_name,
+            TAXI_OUT_DISTANCE="data:mission:%s:taxi_out:distance" % mission_name,
             TAXI_OUT_FUEL="data:mission:%s:taxi_out:fuel" % mission_name,
             TAKEOFF_FUEL="data:mission:%s:takeoff:fuel" % mission_name,
             TAKEOFF_ALTITUDE="data:mission:%s:takeoff:altitude" % mission_name,
@@ -336,6 +338,11 @@ class MissionComponent(om.ExplicitComponent):
             np.nan,
             units="m/s",
             desc='takeoff safety speed for mission "%s"' % mission_name,
+        )
+        self.add_output(
+            self._mission_vars.TAXI_OUT_DISTANCE,
+            units="m",
+            desc='distance during taxi-out of mission "%s"' % mission_name,
         )
         self.add_output(
             self._mission_vars.TAXI_OUT_FUEL,
@@ -519,6 +526,9 @@ class MissionComponent(om.ExplicitComponent):
         )
         flight_points = taxi_segment.compute_from(start_of_taxi_out)
         end_of_taxi_out = flight_points.iloc[-1]
+        outputs[self._mission_vars.TAXI_OUT_DISTANCE] = (
+            end_of_taxi_out.ground_distance - start_of_taxi_out.ground_distance
+        )
         outputs[self._mission_vars.TAXI_OUT_FUEL] = start_of_taxi_out.mass - end_of_taxi_out.mass
 
     def _get_engine_wrapper(self) -> IOMPropulsionWrapper:

--- a/src/fastoad/models/performances/mission/openmdao/mission.py
+++ b/src/fastoad/models/performances/mission/openmdao/mission.py
@@ -316,7 +316,7 @@ class MissionComponent(om.ExplicitComponent):
         self.add_input(
             self._mission_vars.TAXI_OUT_THRUST_RATE,
             np.nan,
-            units="s",
+            units=None,
             desc='thrust rate during taxi-out in mission "%s"' % mission_name,
         )
         self.add_input(

--- a/src/fastoad/models/performances/mission/openmdao/resources/sizing_mission.yml
+++ b/src/fastoad/models/performances/mission/openmdao/resources/sizing_mission.yml
@@ -111,6 +111,7 @@ phases:
     parts:
       - segment: taxi
         thrust_rate: data:mission:sizing:taxi_in:thrust_rate
+        true_airspeed: 0.
         target:
           time: data:mission:sizing:taxi_in:duration
 

--- a/src/fastoad/models/performances/mission/segments/taxi.py
+++ b/src/fastoad/models/performances/mission/segments/taxi.py
@@ -14,7 +14,11 @@
 
 from dataclasses import dataclass
 from typing import Tuple
+from copy import deepcopy
 
+import pandas as pd
+
+from fastoad.model_base import FlightPoint
 from fastoad.models.performances.mission.segments.base import FixedDurationSegment
 from .base import ManualThrustSegment
 from ..polar import Polar
@@ -32,6 +36,15 @@ class TaxiSegment(ManualThrustSegment, FixedDurationSegment, mission_file_keywor
     polar: Polar = None
     reference_area: float = 1.0
     time_step: float = 60.0
+    true_airspeed: float = 0.0
 
     def _get_gamma_and_acceleration(self, mass, drag, thrust) -> Tuple[float, float]:
         return 0.0, 0.0
+
+    def compute_from(self, start: FlightPoint) -> pd.DataFrame:
+        new_start = deepcopy(start)
+        new_start.mach = None
+        new_start.equivalent_airspeed = None
+        new_start.true_airspeed = self.true_airspeed
+
+        return super().compute_from(new_start)

--- a/src/fastoad/models/performances/mission/segments/tests/test_segments.py
+++ b/src/fastoad/models/performances/mission/segments/tests/test_segments.py
@@ -612,10 +612,10 @@ def test_climb_and_cruise_at_optimal_flight_level_with_start_at_exact_flight_lev
 def test_taxi():
     propulsion = FuelEngineSet(DummyEngine(0.5e5, 1.0e-5), 2)
 
-    segment = TaxiSegment(target=FlightPoint(time=500.0), propulsion=propulsion, thrust_rate=0.1)
-    flight_points = segment.compute_from(
-        FlightPoint(altitude=10.0, true_airspeed=10.0, mass=50000.0, time=10000.0),
+    segment = TaxiSegment(
+        target=FlightPoint(time=500.0), propulsion=propulsion, thrust_rate=0.1, true_airspeed=10.0
     )
+    flight_points = segment.compute_from(FlightPoint(altitude=10.0, mass=50000.0, time=10000.0),)
 
     last_point = flight_points.iloc[-1]
     assert_allclose(last_point.altitude, 10.0, atol=1.0)

--- a/src/fastoad/notebooks/01_tutorial/data/CeRAS01_baseline.xml
+++ b/src/fastoad/notebooks/01_tutorial/data/CeRAS01_baseline.xml
@@ -475,7 +475,7 @@
                         276.0<!--mass of consumed fuel during taxi-out phase in sizing mission--></fuel>
                     <duration units="s" is_input="True">
                         540<!--duration of taxi-out phase in sizing mission--></duration>
-                    <thrust_rate units="s" is_input="True">
+                    <thrust_rate is_input="True">
                         0.25<!--thrust rate (between 0.0 and 1.0) during taxi-out phase in sizing mission--></thrust_rate>
                 </taxi_out>
             </sizing>

--- a/tests/integration_tests/oad_process/test_oad_process.py
+++ b/tests/integration_tests/oad_process/test_oad_process.py
@@ -289,11 +289,11 @@ def test_api_eval_mission(cleanup):
 
     assert_allclose(problem["data:handling_qualities:static_margin"], 0.05, atol=1e-2)
     assert_allclose(problem["data:geometry:wing:MAC:at25percent:x"], 17.149, atol=1e-2)
-    assert_allclose(problem["data:weight:aircraft:MTOW"], 74846, atol=1)
-    assert_allclose(problem["data:geometry:wing:area"], 126.581, atol=1e-2)
-    assert_allclose(problem["data:geometry:vertical_tail:area"], 27.535, atol=1e-2)
-    assert_allclose(problem["data:geometry:horizontal_tail:area"], 35.848, atol=1e-2)
-    assert_allclose(problem["data:mission:sizing:needed_block_fuel"], 19495, atol=1)
+    assert_allclose(problem["data:weight:aircraft:MTOW"], 74810, atol=1)
+    assert_allclose(problem["data:geometry:wing:area"], 126.463, atol=1e-2)
+    assert_allclose(problem["data:geometry:vertical_tail:area"], 27.512, atol=1e-2)
+    assert_allclose(problem["data:geometry:horizontal_tail:area"], 35.820, atol=1e-2)
+    assert_allclose(problem["data:mission:sizing:needed_block_fuel"], 19470, atol=1)
 
 
 def test_api_optim(cleanup):


### PR DESCRIPTION
This PR fixes #311.
It corrects a far too large assessment of the distance during the taxi-in segment. This was due to the fact that the last FlightPoint used was from the holding phase so a quite high mach applied to the duration of the taxi-in segment.

Now taxi segments have a distance which is equal to `0` since we now set the `true_airspeed` parameter of this segment to `0`. Changing the `true_airspeed` has lead to a lower `sfc` hence different fuel mass in the taxi-in segment. This change in mass has spread in the different loops which required an update of the variable values (MTOW, wing_area...) in the tests.