### PR TITLE
Issue 365 listing custom modules

### DIFF
--- a/src/fastoad/cmd/api.py
+++ b/src/fastoad/cmd/api.py
@@ -221,20 +221,24 @@ def list_modules(
     if out is None:
         out = sys.stdout
 
-    if source_path:
-        if isinstance(source_path, str) and pth.isfile(source_path):
+    if isinstance(source_path, str):
+        if pth.isfile(source_path):
             conf = FASTOADProblemConfigurator(source_path)
             conf._set_configuration_modifier(_PROBLEM_CONFIGURATOR)
             # As the problem has been configured,
             # BundleLoader now knows additional registered systems
-        elif isinstance(source_path, str) and pth.isdir(source_path):
+        elif pth.isdir(source_path):
             RegisterOpenMDAOSystem.explore_folder(source_path)
-        elif any(pth.isdir(x) for x in source_path):
-            for folder_path in source_path:
-                if not pth.exists(folder_path):
-                    _LOGGER.warning("SKIPPED %s: it does not exist.", folder_path)
-                else:
-                    RegisterOpenMDAOSystem.explore_folder(folder_path)
+        else:
+            raise FileNotFoundError("Could not find %s" % source_path)
+    elif isinstance(source_path, list):
+        for folder_path in source_path:
+            if not pth.isdir(folder_path):
+                _LOGGER.warning("SKIPPED %s: folder does not exist.", folder_path)
+            else:
+                RegisterOpenMDAOSystem.explore_folder(folder_path)
+    elif source_path is not None:
+        raise RuntimeError("Unexpected type for source_path")
 
     if verbose:
         cell_list = _get_detailed_system_list()

--- a/src/fastoad/cmd/api.py
+++ b/src/fastoad/cmd/api.py
@@ -19,7 +19,7 @@ import os.path as pth
 import sys
 import textwrap as tw
 from time import time
-from typing import IO, Union
+from typing import IO, Union, List
 
 import openmdao.api as om
 from IPython import InteractiveShell
@@ -196,7 +196,7 @@ def list_variables(
 
 
 def list_modules(
-    source_path: str = None,
+    source_path: Union[List[str], str] = None,
     out: Union[IO, str] = None,
     overwrite: bool = False,
     verbose: bool = False,

--- a/src/fastoad/cmd/fast.py
+++ b/src/fastoad/cmd/fast.py
@@ -276,7 +276,7 @@ class Main:
         )
         parser_list_modules.add_argument(
             "source_path",
-            nargs="?",
+            nargs="*",
             default=None,
             help="either a configuration file path, folder path, or list of folder path",
         )

--- a/src/fastoad/cmd/fast.py
+++ b/src/fastoad/cmd/fast.py
@@ -80,7 +80,7 @@ class Main:
     def _list_modules(args):
         """Prints list of system identifiers."""
         api.list_modules(
-            args.conf_file, out=args.out_file, overwrite=args.force, verbose=args.verbose
+            args.source_path, out=args.out_file, overwrite=args.force, verbose=args.verbose
         )
         print("\nDone. Use --verbose (-v) option for detailed information.")
 
@@ -266,7 +266,6 @@ class Main:
             help="Provides the identifiers of available systems",
             description="Provides the identifiers of available systems",
         )
-        self._add_conf_file_argument(parser_list_modules, required=False)
         self._add_output_file_argument(parser_list_modules)
         self._add_overwrite_argument(parser_list_modules)
         parser_list_modules.add_argument(
@@ -274,6 +273,12 @@ class Main:
             "--verbose",
             action="store_true",
             help="shows detailed information for each system",
+        )
+        parser_list_modules.add_argument(
+            "source_path",
+            nargs="?",
+            default=None,
+            help="either a configuration file path, folder path, or list of folder path",
         )
         parser_list_modules.set_defaults(func=self._list_modules)
 

--- a/src/fastoad/cmd/tests/test_api.py
+++ b/src/fastoad/cmd/tests/test_api.py
@@ -98,6 +98,28 @@ def test_list_modules(cleanup):
 
     assert pth.exists(out_file)
 
+    #
+    # Run with file output (test file existence)
+    source_folder = pth.join(DATA_FOLDER_PATH, "cmd_sellar_example")
+
+    # Run with file output with folders (test file existence)
+    out_file = pth.join(RESULTS_FOLDER_PATH, "list_modules_with_folder.txt")
+    assert not pth.exists(out_file)
+    api.list_modules(source_folder, out_file)
+    with pytest.raises(FastFileExistsError):
+        api.list_modules(source_folder, out_file)
+
+    # Testing with single folder
+    api.list_modules(source_folder, out_file, overwrite=True)
+
+    assert pth.exists(out_file)
+
+    # Testing with list of folders
+    source_folder = [source_folder]
+    api.list_modules(source_folder, out_file, overwrite=True)
+
+    assert pth.exists(out_file)
+
 
 def test_list_variables(cleanup):
     # Run with stdout output (no test)


### PR DESCRIPTION
This PR closes #365. It provides the possiblity to use `list_modules()` without providing a configuration file in the presence of custom modules. 
Now (but this is open to discussion), the source used for `list_modules()` can be:
- the path of a configuration file
- the path of a folder containing the custom modules
- a list of folder paths that each contain custom modules