### PR TITLE
Issue 357 - Problem inputs cannot have shape_by_conn=True

### DIFF
--- a/src/fastoad/openmdao/_utils.py
+++ b/src/fastoad/openmdao/_utils.py
@@ -43,15 +43,24 @@ def get_unconnected_input_names(
     mandatory_unconnected = set()
     optional_unconnected = set()
 
-    for abs_name, metadata in model.get_io_metadata(
-        "input", metadata_keys=["value"], return_rel_names=False
-    ).items():
-        name = metadata["prom_name"] if promoted_names else abs_name
-        if model.get_source(abs_name).startswith("_auto_ivc."):
-            if np.all(np.isnan(metadata["value"])):
-                mandatory_unconnected.add(name)
-            else:
-                optional_unconnected.add(name)
+    try:
+        for abs_name, metadata in model.get_io_metadata(
+            "input", metadata_keys=["value"], return_rel_names=False
+        ).items():
+            name = metadata["prom_name"] if promoted_names else abs_name
+            if model.get_source(abs_name).startswith("_auto_ivc."):
+                if np.all(np.isnan(metadata["value"])):
+                    mandatory_unconnected.add(name)
+                else:
+                    optional_unconnected.add(name)
+    except:
+        # Code failure may be due to shape_by_conn variables and uncomplete setup with no acces to value
+        # then return all parameters as mandatory
+        for abs_name, metadata in model.get_io_metadata(
+            "input", metadata_keys=[], return_rel_names=False
+        ).items():
+            name = metadata["prom_name"] if promoted_names else abs_name
+            mandatory_unconnected.add(name)
 
     # If a promoted variable is defined both with NaN and non-NaN value, it is
     # considered as mandatory


### PR DESCRIPTION
This PR initiated the changes needed to use shape_by_conn parameters to be extracted from the input .xml file.

The basic idea is to make a partial setup of the problem (problem.setup() fail and return Runtime error but part of the metadata is available except keys: value/shape/size) to know which inputs are given in the .xml file, add them as IVC and retry a setup if needed.

This is just a proposal that seems to work for FASTGA OAD process, feel free to adapt it and correct.