### PR TITLE
Issue 363 taper ratio

### DIFF
--- a/src/fastoad/cmd/tests/data/short_inputs.xml
+++ b/src/fastoad/cmd/tests/data/short_inputs.xml
@@ -70,7 +70,7 @@
       <wing>
         <aspect_ratio is_input="True">9.48<!--wing aspect ratio--></aspect_ratio>
         <sweep_25 units="deg" is_input="True">25.0<!--sweep angle at 25% chord of wing--></sweep_25>
-        <taper_ratio is_input="True">0.38<!--taper ratio of wing--></taper_ratio>
+        <virtual_taper_ratio is_input="True">0.38<!--taper ratio of wing--></virtual_taper_ratio>
         <kink>
           <span_ratio is_input="True">0.4<!--ratio (Y-position of kink)/(semi-span)--></span_ratio>
         </kink>

--- a/src/fastoad/models/geometry/geom_components/wing/components/compute_l1_l4.py
+++ b/src/fastoad/models/geometry/geom_components/wing/components/compute_l1_l4.py
@@ -30,7 +30,7 @@ class ComputeL1AndL4Wing(ExplicitComponent):
         self.add_input("data:geometry:wing:kink:y", val=np.nan, units="m")
         self.add_input("data:geometry:wing:span", val=np.nan, units="m")
         self.add_input("data:geometry:fuselage:maximum_width", val=np.nan, units="m")
-        self.add_input("data:geometry:wing:taper_ratio", val=np.nan)
+        self.add_input("data:geometry:wing:virtual_taper_ratio", val=np.nan)
         self.add_input("data:geometry:wing:sweep_25", val=np.nan, units="deg")
 
         self.add_output("data:geometry:wing:root:virtual_chord", units="m")
@@ -47,19 +47,19 @@ class ComputeL1AndL4Wing(ExplicitComponent):
         y3_wing = inputs["data:geometry:wing:kink:y"]
         sweep_25 = inputs["data:geometry:wing:sweep_25"]
         width_max = inputs["data:geometry:fuselage:maximum_width"]
-        taper_ratio = inputs["data:geometry:wing:taper_ratio"]
+        virtual_taper_ratio = inputs["data:geometry:wing:virtual_taper_ratio"]
 
         l1_wing = (
             wing_area
             - (y3_wing - y2_wing) * (y3_wing + y2_wing) * math.tan(sweep_25 / 180.0 * math.pi)
         ) / (
-            (1.0 + taper_ratio) / 2.0 * (span - width_max)
+            (1.0 + virtual_taper_ratio) / 2.0 * (span - width_max)
             + width_max
-            - (3.0 * (1.0 - taper_ratio) * (y3_wing - y2_wing) * (y3_wing + y2_wing))
+            - (3.0 * (1.0 - virtual_taper_ratio) * (y3_wing - y2_wing) * (y3_wing + y2_wing))
             / (2.0 * (span - width_max))
         )
 
-        l4_wing = l1_wing * taper_ratio
+        l4_wing = l1_wing * virtual_taper_ratio
 
         outputs["data:geometry:wing:root:virtual_chord"] = l1_wing
         outputs["data:geometry:wing:tip:chord"] = l4_wing

--- a/src/fastoad/models/geometry/geom_components/wing/components/compute_l2_l3.py
+++ b/src/fastoad/models/geometry/geom_components/wing/components/compute_l2_l3.py
@@ -32,11 +32,12 @@ class ComputeL2AndL3Wing(ExplicitComponent):
         self.add_input("data:geometry:wing:root:y", val=np.nan, units="m")
         self.add_input("data:geometry:wing:kink:y", val=np.nan, units="m")
         self.add_input("data:geometry:wing:tip:y", val=np.nan, units="m")
-        self.add_input("data:geometry:wing:taper_ratio", val=np.nan)
+        self.add_input("data:geometry:wing:virtual_taper_ratio", val=np.nan)
         self.add_input("data:geometry:fuselage:maximum_width", val=np.nan, units="m")
 
         self.add_output("data:geometry:wing:root:chord", units="m")
         self.add_output("data:geometry:wing:kink:chord", units="m")
+        self.add_output("data:geometry:wing:taper_ratio")
 
     def setup_partials(self):
         self.declare_partials(
@@ -45,7 +46,7 @@ class ComputeL2AndL3Wing(ExplicitComponent):
                 "data:geometry:wing:root:virtual_chord",
                 "data:geometry:wing:root:y",
                 "data:geometry:wing:kink:y",
-                "data:geometry:wing:taper_ratio",
+                "data:geometry:wing:virtual_taper_ratio",
                 "data:geometry:wing:span",
                 "data:geometry:fuselage:maximum_width",
                 "data:geometry:wing:sweep_25",
@@ -72,15 +73,16 @@ class ComputeL2AndL3Wing(ExplicitComponent):
         y4_wing = inputs["data:geometry:wing:tip:y"]
         span = inputs["data:geometry:wing:span"]
         width_max = inputs["data:geometry:fuselage:maximum_width"]
-        taper_ratio = inputs["data:geometry:wing:taper_ratio"]
+        virtual_taper_ratio = inputs["data:geometry:wing:virtual_taper_ratio"]
         sweep_25 = inputs["data:geometry:wing:sweep_25"]
 
         l2_wing = l1_wing + (y3_wing - y2_wing) * (
             math.tan(sweep_25 / 180.0 * math.pi)
-            - 3.0 / 2.0 * (1.0 - taper_ratio) / (span - width_max) * l1_wing
+            - 3.0 / 2.0 * (1.0 - virtual_taper_ratio) / (span - width_max) * l1_wing
         )
 
         l3_wing = l4_wing + (l1_wing - l4_wing) * (y4_wing - y3_wing) / (y4_wing - y2_wing)
 
         outputs["data:geometry:wing:root:chord"] = l2_wing
         outputs["data:geometry:wing:kink:chord"] = l3_wing
+        outputs["data:geometry:wing:taper_ratio"] = l4_wing / l2_wing

--- a/src/fastoad/models/geometry/tests/data/geometry_inputs_full.xml
+++ b/src/fastoad/models/geometry/tests/data/geometry_inputs_full.xml
@@ -197,7 +197,7 @@
         <sweep_100_inner>0.0<!--sweep angle at trailing edge of wing (inner side of the kink)--></sweep_100_inner>
         <sweep_100_outer>16.696<!--sweep angle at trailing edge of wing (outer side of the kink)--></sweep_100_outer>
         <sweep_25>25.0<!--sweep angle at 25% chord of wing--></sweep_25>
-        <taper_ratio>0.38<!--taper ratio of wing--></taper_ratio>
+        <virtual_taper_ratio>0.38<!--taper ratio of wing--></virtual_taper_ratio>
         <thickness_ratio>0.128<!--mean thickness ratio of wing--></thickness_ratio>
         <wetted_area>200.607<!--wetted area of wing--></wetted_area>
         <MAC>

--- a/src/fastoad/models/geometry/tests/test_geometry_geom_comps.py
+++ b/src/fastoad/models/geometry/tests/test_geometry_geom_comps.py
@@ -447,7 +447,7 @@ def test_geometry_wing_l1_l4(input_xml):
         "data:geometry:wing:kink:y",
         "data:geometry:wing:span",
         "data:geometry:fuselage:maximum_width",
-        "data:geometry:wing:taper_ratio",
+        "data:geometry:wing:virtual_taper_ratio",
         "data:geometry:wing:sweep_25",
     ]
 
@@ -469,7 +469,7 @@ def test_geometry_wing_l2_l3(input_xml):
     input_list = [
         "data:geometry:wing:span",
         "data:geometry:fuselage:maximum_width",
-        "data:geometry:wing:taper_ratio",
+        "data:geometry:wing:virtual_taper_ratio",
         "data:geometry:wing:sweep_25",
         "data:geometry:wing:root:virtual_chord",
         "data:geometry:wing:tip:chord",
@@ -488,6 +488,8 @@ def test_geometry_wing_l2_l3(input_xml):
     assert wing_l2 == pytest.approx(6.26, abs=1e-2)
     wing_l3 = problem["data:geometry:wing:kink:chord"]
     assert wing_l3 == pytest.approx(3.985, abs=1e-3)
+    taper_ratio = problem["data:geometry:wing:taper_ratio"]
+    assert taper_ratio == pytest.approx(0.301, abs=1e-3)
 
 
 def test_geometry_wing_mac(input_xml):

--- a/src/fastoad/models/variable_descriptions.txt
+++ b/src/fastoad/models/variable_descriptions.txt
@@ -158,6 +158,7 @@ data:geometry:wing:sweep_0 || sweep angle at leading edge of wing
 data:geometry:wing:sweep_100_inner || sweep angle at trailing edge of wing (inner side of the kink)
 data:geometry:wing:sweep_100_outer || sweep angle at trailing edge of wing (outer side of the kink)
 data:geometry:wing:sweep_25 || sweep angle at 25% chord of wing
+data:geometry:wing:virtual_taper_ratio || taper ratio of wing computed from virtual root chord
 data:geometry:wing:taper_ratio || taper ratio of wing
 data:geometry:wing:thickness_ratio || mean thickness ratio of wing
 data:geometry:wing:tip:chord || chord length at wing tip

--- a/src/fastoad/models/weight/cg/tests/data/cg_inputs.xml
+++ b/src/fastoad/models/weight/cg/tests/data/cg_inputs.xml
@@ -144,7 +144,7 @@
         <sweep_100_inner>0.0<!--sweep angle at trailing edge of wing (inner side of the kink)--></sweep_100_inner>
         <sweep_100_outer>16.696<!--sweep angle at trailing edge of wing (outer side of the kink)--></sweep_100_outer>
         <sweep_25>25.0<!--sweep angle at 25% chord of wing--></sweep_25>
-        <taper_ratio>0.38<!--taper ratio of wing--></taper_ratio>
+        <virtual_taper_ratio>0.38<!--taper ratio of wing--></virtual_taper_ratio>
         <thickness_ratio>0.128<!--mean thickness ratio of wing--></thickness_ratio>
         <wetted_area>200.607<!--wetted area of wing--></wetted_area>
         <MAC>

--- a/src/fastoad/notebooks/01_tutorial/data/CeRAS01_baseline.xml
+++ b/src/fastoad/notebooks/01_tutorial/data/CeRAS01_baseline.xml
@@ -215,7 +215,7 @@
                     0.319732377799903<!--sweep angle at trailing edge of wing (outer side of the kink)--></sweep_100_outer>
                 <sweep_25 units="deg">
                     24.54<!--sweep angle at 25% chord of wing--></sweep_25>
-                <taper_ratio>0.313<!--taper ratio of wing--></taper_ratio>
+                <virtual_taper_ratio>0.313<!--taper ratio of wing computed from virtual chord--></virtual_taper_ratio>
                 <thickness_ratio>
                     0.12839840880979247<!--mean thickness ratio of wing--></thickness_ratio>
                 <wetted_area units="m**2">

--- a/src/fastoad/notebooks/02_CeRAS_case_study/data/CeRAS_data_for_plots.xml
+++ b/src/fastoad/notebooks/02_CeRAS_case_study/data/CeRAS_data_for_plots.xml
@@ -32,7 +32,7 @@
                     16.59<!--sweep angle at trailing edge of wing (outer side of the kink)--></sweep_100_outer>
                 <sweep_25 units="deg" is_input="True">
                     24.54<!--sweep angle at 25% chord of wing--></sweep_25>
-                <taper_ratio is_input="True">0.38<!--taper ratio of wing--></taper_ratio>
+                <virtual_taper_ratio is_input="True">0.38<!--taper ratio of wing--></virtual_taper_ratio>
                 <thickness_ratio is_input="False">
                     0.12839840880979247<!--mean thickness ratio of wing--></thickness_ratio>
                 <wetted_area units="m**2" is_input="False">

--- a/src/fastoad/notebooks/02_CeRAS_case_study/data/CeRAS_reference_data.xml
+++ b/src/fastoad/notebooks/02_CeRAS_case_study/data/CeRAS_reference_data.xml
@@ -215,7 +215,7 @@
                     0.319732377799903<!--sweep angle at trailing edge of wing (outer side of the kink)--></sweep_100_outer>
                 <sweep_25 units="deg" is_input="True">
                     24.54<!--sweep angle at 25% chord of wing--></sweep_25>
-                <taper_ratio is_input="True">0.313<!--taper ratio of wing--></taper_ratio>
+                <virtual_taper_ratio is_input="True">0.313<!--taper ratio of wing computed from virtual chord--></virtual_taper_ratio>
                 <thickness_ratio is_input="False">
                     0.12839840880979247<!--mean thickness ratio of wing--></thickness_ratio>
                 <wetted_area units="m**2" is_input="False">

--- a/tests/integration_tests/oad_process/data/CeRAS01_legacy.xml
+++ b/tests/integration_tests/oad_process/data/CeRAS01_legacy.xml
@@ -157,7 +157,7 @@
         <sweep_100_inner units="deg">0.0<!--sweep angle at trailing edge of wing (inner side of the kink)--></sweep_100_inner>
         <sweep_100_outer units="deg">18.3291325299<!--sweep angle at trailing edge of wing (outer side of the kink)--></sweep_100_outer>
         <sweep_25 units="deg">25.0<!--sweep angle at 25% chord of wing--></sweep_25>
-        <taper_ratio>0.38<!--taper ratio of wing--></taper_ratio>
+        <virtual_taper_ratio>0.38<!--taper ratio of wing computed from virtual chord--></virtual_taper_ratio>
         <thickness_ratio>0.12839840881<!--mean thickness ratio of wing--></thickness_ratio>
         <wetted_area units="m**2">202.210352928<!--wetted area of wing--></wetted_area>
         <MAC>

--- a/tests/integration_tests/oad_process/data/CeRAS01_legacy_breguet_result.xml
+++ b/tests/integration_tests/oad_process/data/CeRAS01_legacy_breguet_result.xml
@@ -153,7 +153,7 @@
         <sweep_100_inner units="deg">0.0<!--sweep angle at trailing edge of wing (inner side of the kink)--></sweep_100_inner>
         <sweep_100_outer units="deg">18.3446480708<!--sweep angle at trailing edge of wing (outer side of the kink)--></sweep_100_outer>
         <sweep_25 units="deg">25.0<!--sweep angle at 25% chord of wing--></sweep_25>
-        <taper_ratio>0.38<!--taper ratio of wing--></taper_ratio>
+        <virtual_taper_ratio>0.38<!--taper ratio of wing computed from virtual chord--></virtual_taper_ratio>
         <thickness_ratio>0.12839840881<!--mean thickness ratio of wing--></thickness_ratio>
         <wetted_area units="m**2">211.680754233<!--wetted area of wing--></wetted_area>
         <MAC>

--- a/tests/integration_tests/oad_process/data/CeRAS01_legacy_mission_result.xml
+++ b/tests/integration_tests/oad_process/data/CeRAS01_legacy_mission_result.xml
@@ -157,7 +157,7 @@
         <sweep_100_inner units="deg">0.0<!--sweep angle at trailing edge of wing (inner side of the kink)--></sweep_100_inner>
         <sweep_100_outer units="deg">18.3392156723<!--sweep angle at trailing edge of wing (outer side of the kink)--></sweep_100_outer>
         <sweep_25 units="deg">25.0<!--sweep angle at 25% chord of wing--></sweep_25>
-        <taper_ratio>0.38<!--taper ratio of wing--></taper_ratio>
+        <virtual_taper_ratio>0.38<!--taper ratio of wing computed from virtual chord--></virtual_taper_ratio>
         <thickness_ratio>0.12839840881<!--mean thickness ratio of wing--></thickness_ratio>
         <wetted_area units="m**2">208.283494947<!--wetted area of wing--></wetted_area>
         <MAC>


### PR DESCRIPTION
This PR resolve #363.

The "data:geometry:wing:taper_ratio" variable used as an input so far does not correspond to the classical definition of wing taper ratio. Therefore, not to modify all the geometry definition of the wing, the input variable was changed to "data:geoemetry:wing:virtual_taper_ratio" and an ouput "data:geometry:wing:taper_ratio" was created with the proper definition. 