### PR TITLE
Issue 394 list modules + Release 1.1.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog
 Version 1.1.1
 =============
 - Bug fixes:
-    - Fixed usage of list_modules with CLI. (#394)
+    - Fixed usage of list_modules with CLI. (#395)
 
 Version 1.1.0
 =============

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+Version 1.1.1
+=============
+- Bug fixes:
+    - Fixed usage of list_modules with CLI. (#394)
+
 Version 1.1.0
 =============
 - Changes:

--- a/src/fastoad/cmd/fast.py
+++ b/src/fastoad/cmd/fast.py
@@ -79,9 +79,13 @@ class Main:
     @staticmethod
     def _list_modules(args):
         """Prints list of system identifiers."""
-        api.list_modules(
-            args.source_path, out=args.out_file, overwrite=args.force, verbose=args.verbose
-        )
+        # If a configuration file or a single path is provided make sure it is sent as a
+        # string not a list
+        if len(args.source_path) == 1:
+            source_path = args.source_path[0]
+        else:
+            source_path = args.source_path
+        api.list_modules(source_path, out=args.out_file, overwrite=args.force, verbose=args.verbose)
         print("\nDone. Use --verbose (-v) option for detailed information.")
 
     @staticmethod
@@ -266,7 +270,6 @@ class Main:
             help="Provides the identifiers of available systems",
             description="Provides the identifiers of available systems",
         )
-        self._add_conf_file_argument(parser_list_modules, required=False)
         self._add_output_file_argument(parser_list_modules)
         self._add_overwrite_argument(parser_list_modules)
         parser_list_modules.add_argument(

--- a/src/fastoad/cmd/fast.py
+++ b/src/fastoad/cmd/fast.py
@@ -266,6 +266,7 @@ class Main:
             help="Provides the identifiers of available systems",
             description="Provides the identifiers of available systems",
         )
+        self._add_conf_file_argument(parser_list_modules, required=False)
         self._add_output_file_argument(parser_list_modules)
         self._add_overwrite_argument(parser_list_modules)
         parser_list_modules.add_argument(


### PR DESCRIPTION
This PR fixes #394 making list_modules functional again using CLI.
This is the opportunity to do a patch release 1.1.1 (https://github.com/fast-aircraft-design/FAST-OAD/releases/untagged-7eeb0813b780611d787d) to include this bug correction.