### PR TITLE
Generate variable descriptions

### DIFF
--- a/src/fastoad/cmd/api.py
+++ b/src/fastoad/cmd/api.py
@@ -205,7 +205,7 @@ def _generate_var_desc_format(variables_df):
 
 
 def _generate_table_format(variables_df, tablefmt="grid"):
-    # In any other case, let's break descriptions that are too long
+    # Break descriptions that are too long
     variables_df["DESCRIPTION"] = variables_df["DESCRIPTION"].apply(
         lambda s: "\n".join(tw.wrap(s, 100))
     )

--- a/src/fastoad/cmd/api.py
+++ b/src/fastoad/cmd/api.py
@@ -194,9 +194,12 @@ def list_variables(
 
 
 def _generate_var_desc_format(variables_df):
-    df_name_descriptions = variables_df[["NAME", "DESCRIPTION"]]
-    content = df_name_descriptions.to_csv(
-        sep="|", index=False, header=False, line_terminator="\n"
+    content = variables_df.to_csv(
+        columns=["NAME", "DESCRIPTION"],
+        sep="|",
+        index=False,
+        header=False,
+        line_terminator="\n",
     ).replace("|", " || ")
     return content
 

--- a/src/fastoad/cmd/api.py
+++ b/src/fastoad/cmd/api.py
@@ -182,25 +182,34 @@ def list_variables(
         variables_df["NAME"] = variables_df["NAME"].apply(lambda s: "\n".join(tw.wrap(s, 50)))
 
     if tablefmt == "var_desc":
-        df_name_descriptions = variables_df[["NAME", "DESCRIPTION"]]
-        content = df_name_descriptions.to_csv(
-            sep="|", index=False, header=False, line_terminator="\n"
-        ).replace("|", " || ")
-        out_file.write(content)
+        content = _generate_var_desc_format(variables_df)
     else:
-        # In any other case, let's break descriptions that are too long
-        variables_df["DESCRIPTION"] = variables_df["DESCRIPTION"].apply(
-            lambda s: "\n".join(tw.wrap(s, 100))
-        )
+        content = _generate_table_format(variables_df, tablefmt=tablefmt)
 
-        out_file.write(
-            tabulate(variables_df, headers=variables_df.columns, showindex=False, tablefmt=tablefmt)
-        )
-        out_file.write("\n")
+    out_file.write(content)
 
     if isinstance(out, str):
         out_file.close()
         _LOGGER.info("Output list written in %s", out_file)
+
+
+def _generate_var_desc_format(variables_df):
+    df_name_descriptions = variables_df[["NAME", "DESCRIPTION"]]
+    content = df_name_descriptions.to_csv(
+        sep="|", index=False, header=False, line_terminator="\n"
+    ).replace("|", " || ")
+    return content
+
+
+def _generate_table_format(variables_df, tablefmt="grid"):
+    # In any other case, let's break descriptions that are too long
+    variables_df["DESCRIPTION"] = variables_df["DESCRIPTION"].apply(
+        lambda s: "\n".join(tw.wrap(s, 100))
+    )
+    content = tabulate(
+        variables_df, headers=variables_df.columns, showindex=False, tablefmt=tablefmt
+    )
+    return content + "\n"
 
 
 def list_modules(

--- a/src/fastoad/cmd/api.py
+++ b/src/fastoad/cmd/api.py
@@ -171,7 +171,7 @@ def list_variables(
                 out,
             )
         make_parent_dir(out)
-        out_file = open(out, "w+")
+        out_file = open(out, "w")
     else:
         if out == sys.stdout and InteractiveShell.initialized() and not force_text_output:
             display(HTML(variables_df.to_html(index=False)))

--- a/src/fastoad/cmd/api.py
+++ b/src/fastoad/cmd/api.py
@@ -133,8 +133,8 @@ def list_variables(
                               shells or if out parameter is not sys.stdout
     :param tablefmt: The formatting of the requested table. Options are the same as those available
                      to the tabulate package. See tabulate.tabulate_formats for a complete list.
-    :param variable_descriptions_format: if True and the out parameter is a file path, the file will
-                    use the variable_descriptions.txt format.
+    :param variable_descriptions_format: if True the file will use the
+                                         variable_descriptions.txt format.
     :raise FastFileExistsError: if overwrite==False and out parameter is a file path and the file
                                 exists
     """

--- a/src/fastoad/cmd/api.py
+++ b/src/fastoad/cmd/api.py
@@ -113,7 +113,6 @@ def list_variables(
     out: Union[IO, str] = None,
     overwrite: bool = False,
     force_text_output: bool = False,
-    variable_descriptions_format: bool = False,
     tablefmt: str = "grid",
 ):
     """
@@ -133,8 +132,7 @@ def list_variables(
                               shells or if out parameter is not sys.stdout
     :param tablefmt: The formatting of the requested table. Options are the same as those available
                      to the tabulate package. See tabulate.tabulate_formats for a complete list.
-    :param variable_descriptions_format: if True the file will use the
-                                         variable_descriptions.txt format.
+                     If "var_desc" the file will use the variable_descriptions.txt format.
     :raise FastFileExistsError: if overwrite==False and out parameter is a file path and the file
                                 exists
     """
@@ -183,7 +181,7 @@ def list_variables(
         # For a terminal output, we limit width of NAME column
         variables_df["NAME"] = variables_df["NAME"].apply(lambda s: "\n".join(tw.wrap(s, 50)))
 
-    if variable_descriptions_format:
+    if tablefmt == "var_desc":
         df_name_descriptions = variables_df[["NAME", "DESCRIPTION"]]
         content = df_name_descriptions.to_csv(
             sep="|", index=False, header=False, line_terminator="\n"

--- a/src/fastoad/cmd/api.py
+++ b/src/fastoad/cmd/api.py
@@ -178,9 +178,6 @@ def list_variables(
         # Here we continue with text output
         out_file = out
 
-        # For a terminal output, we limit width of NAME column
-        variables_df["NAME"] = variables_df["NAME"].apply(lambda s: "\n".join(tw.wrap(s, 50)))
-
     if tablefmt == "var_desc":
         content = _generate_var_desc_format(variables_df)
     else:

--- a/src/fastoad/cmd/fast.py
+++ b/src/fastoad/cmd/fast.py
@@ -19,6 +19,7 @@ import shutil
 import textwrap
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser, RawDescriptionHelpFormatter
 from distutils.util import strtobool
+import tabulate
 
 import fastoad
 from fastoad import notebooks
@@ -297,10 +298,13 @@ class Main:
         self._add_output_file_argument(parser_list_variables)
         self._add_overwrite_argument(parser_list_variables)
         parser_list_variables.add_argument(
-            "format",
+            "--format",
             nargs="?",
             default="grid",
-            help="format of the list (default: %(default)s)",
+            help="format of the list. Available options are "
+            f"{['var_desc'] + tabulate.tabulate_formats}. "
+            '"var_desc" is the variable_descriptions.txt format. Other formats are part of the '
+            "tabulate package. (default: %(default)s)",
         )
         parser_list_variables.set_defaults(func=self._list_variables)
 

--- a/src/fastoad/cmd/fast.py
+++ b/src/fastoad/cmd/fast.py
@@ -87,7 +87,12 @@ class Main:
     @staticmethod
     def _list_variables(args):
         """Prints list of system outputs."""
-        api.list_variables(args.conf_file, out=args.out_file, overwrite=args.force)
+        api.list_variables(
+            args.conf_file,
+            out=args.out_file,
+            overwrite=args.force,
+            tablefmt=args.format,
+        )
 
     @staticmethod
     def _write_n2(args):
@@ -291,6 +296,12 @@ class Main:
         self._add_conf_file_argument(parser_list_variables)
         self._add_output_file_argument(parser_list_variables)
         self._add_overwrite_argument(parser_list_variables)
+        parser_list_variables.add_argument(
+            "format",
+            nargs="?",
+            default="grid",
+            help="format of the list (default: %(default)s)",
+        )
         parser_list_variables.set_defaults(func=self._list_variables)
 
         # sub-command for writing N2 diagram -------------------------------------------------------

--- a/src/fastoad/cmd/tests/data/ref_list_variables_with_variable_descriptions_format.txt
+++ b/src/fastoad/cmd/tests/data/ref_list_variables_with_variable_descriptions_format.txt
@@ -1,0 +1,7 @@
+x || input x
+z || variable z
+f || Objective
+g1 || 
+g2 || 
+y1 || variable y1
+y2 || variable y2

--- a/src/fastoad/cmd/tests/test_api.py
+++ b/src/fastoad/cmd/tests/test_api.py
@@ -151,7 +151,7 @@ def test_list_variables(cleanup):
         CONFIGURATION_FILE_PATH,
         out=out_file_path,
         overwrite=True,
-        variable_descriptions_format=True,
+        tablefmt="var_desc",
     )
     assert pth.exists(out_file_path)
     ref_file_path = pth.join(

--- a/src/fastoad/cmd/tests/test_api.py
+++ b/src/fastoad/cmd/tests/test_api.py
@@ -146,6 +146,19 @@ def test_list_variables(cleanup):
     ref_file_path = pth.join(DATA_FOLDER_PATH, "ref_list_variables.txt")
     assert cmp(ref_file_path, out_file_path)
 
+    # Test with variable_description.txt format
+    api.list_variables(
+        CONFIGURATION_FILE_PATH,
+        out=out_file_path,
+        overwrite=True,
+        variable_descriptions_format=True,
+    )
+    assert pth.exists(out_file_path)
+    ref_file_path = pth.join(
+        DATA_FOLDER_PATH, "ref_list_variables_with_variable_descriptions_format.txt"
+    )
+    assert cmp(ref_file_path, out_file_path)
+
 
 def test_write_n2(cleanup):
 


### PR DESCRIPTION
This small PR aims at providing the possibility to generate a file such as the `variable_descriptions.txt` by activating an option in `api.list_variables(variable_descriptions_format=True)`.
This is particularly useful when building a new (large) custom module from scratch.