### PR TITLE
Fixed case with no configuration file available

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,16 +32,13 @@ jobs:
         run: echo "$HOME/.poetry/bin" >> $GITHUB_PATH
         shell: bash
 
-      - uses: actions/cache@v2
-        if: ${{ startsWith(runner.os, 'Linux') }}
-        with:
-          path: ~/.cache/pypoetry
-          key: ${{ runner.os }}-Py${{ matrix.python-version }}-pypoetry-${{ hashFiles('**/poetry.lock') }}
+      - name: Sets unique cache directory for Poetry
+        run: poetry config cache-dir ~/poetry_cache
+        shell: bash
 
       - uses: actions/cache@v2
-        if: ${{ startsWith(runner.os, 'macOS') }}
         with:
-          path: ~/Library/Caches/pypoetry
+          path: ~/poetry_cache
           key: ${{ runner.os }}-Py${{ matrix.python-version }}-pypoetry-${{ hashFiles('**/poetry.lock') }}
 
       - name: Activate environment and install dependencies

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -138,6 +138,30 @@ def with_dummy_plugin_2():
 
 
 @pytest.fixture
+def with_dummy_plugin_4():
+    """
+    Reduces plugin list to dummy-dist-1 with plugin test_plugin_4
+    (no configuration file, no model folder, notebooks).
+
+    Any previous state of plugins is restored during teardown.
+    """
+    _setup()
+    dummy_dist_1 = Mock(Distribution)
+    dummy_dist_1.name = "dummy-dist-1"
+    entry_points = [
+        EntryPoint(
+            name="test_plugin_4",
+            value="tests.dummy_plugins.dist_1.dummy_plugin_4",
+            group=MODEL_PLUGIN_ID,
+        )
+    ]
+    entry_points[0].dist = dummy_dist_1
+    _update_entry_map(entry_points)
+    yield
+    _teardown()
+
+
+@pytest.fixture
 def with_dummy_plugin_distribution_1():
     """
     Reduces plugin list to dummy-dist-1 with plugins test_plugin_1 and test_plugin_4

--- a/src/fastoad/cmd/cli.py
+++ b/src/fastoad/cmd/cli.py
@@ -25,6 +25,7 @@ from fastoad.cmd.cli_utils import (
 )
 from fastoad.cmd.exceptions import FastNoAvailableNotebookError
 from fastoad.module_management.exceptions import (
+    FastNoAvailableConfigurationFileError,
     FastNoDistPluginError,
     FastSeveralConfigurationFilesError,
     FastSeveralDistPluginsError,
@@ -84,6 +85,7 @@ def gen_conf(conf_file, from_package, source, force):
         FastUnknownDistPluginError,
         FastSeveralConfigurationFilesError,
         FastUnknownConfigurationFileError,
+        FastNoAvailableConfigurationFileError,
     ) as exc:
         click.echo(exc.args[0])
 

--- a/src/fastoad/module_management/_plugins.py
+++ b/src/fastoad/module_management/_plugins.py
@@ -26,6 +26,7 @@ import numpy as np
 from fastoad.openmdao.variables import Variable
 from ._bundle_loader import BundleLoader
 from .exceptions import (
+    FastNoAvailableConfigurationFileError,
     FastNoDistPluginError,
     FastSeveralConfigurationFilesError,
     FastSeveralDistPluginsError,
@@ -166,6 +167,9 @@ class DistributionPluginDefinition(dict):
                                                   available.
         """
         conf_file_list = self.get_configuration_file_list(plugin_name)
+        if not conf_file_list:
+            raise FastNoAvailableConfigurationFileError()
+
         if file_name is None:
             if len(conf_file_list) > 1:
                 raise FastSeveralConfigurationFilesError(self.dist_name)

--- a/src/fastoad/module_management/exceptions.py
+++ b/src/fastoad/module_management/exceptions.py
@@ -163,6 +163,13 @@ class FastSeveralDistPluginsError(FastError):
         )
 
 
+class FastNoAvailableConfigurationFileError(FastError):
+    """Raised when a configuration file is asked, but none is available in plugins."""
+
+    def __init__(self):
+        super().__init__("No configuration file provided with currently installed plugins.")
+
+
 class FastUnknownConfigurationFileError(FastError):
     """Raised when a configuration file is not found for named distribution."""
 

--- a/src/fastoad/module_management/tests/test_plugins.py
+++ b/src/fastoad/module_management/tests/test_plugins.py
@@ -19,6 +19,7 @@ from fastoad.openmdao.variables import Variable
 from .._plugins import FastoadLoader, SubPackageNames
 from ..exceptions import (
     FastBundleLoaderUnknownFactoryNameError,
+    FastNoAvailableConfigurationFileError,
     FastNoDistPluginError,
     FastSeveralConfigurationFilesError,
     FastSeveralDistPluginsError,
@@ -198,6 +199,13 @@ def test_get_configuration_file_info_with_1_plugin(with_dummy_plugin_1):
 
     file_info_bis = dist_def.get_configuration_file_info()
     assert file_info_bis == file_info
+
+
+def test_get_configuration_file_info_without_conf_file_available(with_dummy_plugin_4):
+    dist_def = FastoadLoader().get_distribution_plugin_definition("dummy-dist-1")
+
+    with pytest.raises(FastNoAvailableConfigurationFileError):
+        dist_def.get_configuration_file_info("unknown.yml")
 
 
 def test_get_configuration_file_info_with_plugins(with_dummy_plugins):


### PR DESCRIPTION
Minor change to amend PR #409. With no plugin installed, it is possible to have no configuration file available, and that case was not handled correctly.

Additionally, I take the occasion to try a new settings for cache in GitHub actions. Let's see if it behaves better on Windows now.