### PR TITLE
Release v1.3.0

### DIFF
--- a/.github/workflows/build_for_Binder.yml
+++ b/.github/workflows/build_for_Binder.yml
@@ -1,5 +1,6 @@
 name: Build Binder image for master branch
 on:
+  workflow_dispatch:
   push:
     branches:
       - master

--- a/.github/workflows/build_for_Binder.yml
+++ b/.github/workflows/build_for_Binder.yml
@@ -5,7 +5,7 @@ on:
       - master
 
 jobs:
-  Create-Tag:
+  build-binder:
     runs-on: ubuntu-latest
     steps:
       - name: cache binder build on mybinder.org

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -61,21 +61,17 @@ jobs:
           poetry build
         shell: bash
 
-      - uses: actions/upload-artifact@v2
-        with:
-          name: wheel
-          path: dist/*.whl
 
-      - uses: actions/upload-artifact@v2
-        with:
-          name: source
-          path: dist/*.gz
+      - name: build FAST-OAD-core
+        run: |
+          poetry remove FAST-OAD-CS25
+          sed -i s/'name = "FAST-OAD"'/'name = "FAST-OAD-core"'/ pyproject.toml
+          poetry build
+        shell: bash
 
       - name: publish to PyPI
         env:
-          TOKEN: ${{ secrets.PyPI }} # do not use the secret directly in run command, it would
-          # write it plainly in the log
+          TOKEN: ${{ secrets.PyPI }} # do not use the secret directly in run command, it would write it plainly in the log
         run: |
           poetry config pypi-token.pypi "$TOKEN"
           poetry publish
-

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -30,14 +30,8 @@ jobs:
             })
 
   build-binder-image:
-    needs: build-publish-package
-    runs-on: ubuntu-latest
-    steps:
-      - name: cache binder build on mybinder.org
-        uses: jupyterhub/repo2docker-action@master
-        with:
-          NO_PUSH: true
-          MYBINDERORG_TAG: latest-release
+    needs: move-tag
+    uses: ./.github/workflows/build_for_Binder.yml
 
   build-publish-package:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -1,6 +1,7 @@
 name: Build PyPI package and Binder image
 
 on:
+  workflow_dispatch:
   release:
     types: [ published ]
 
@@ -61,15 +62,21 @@ jobs:
           poetry build
         shell: bash
 
+      - name: publish to PyPI
+        env:
+          TOKEN: ${{ secrets.PyPI }} # do not use the secret directly in run command, it would write it plainly in the log
+        run: |
+          poetry config pypi-token.pypi "$TOKEN"
+          poetry publish
 
       - name: build FAST-OAD-core
         run: |
           poetry remove FAST-OAD-CS25
-          sed -i s/'name = "FAST-OAD"'/'name = "FAST-OAD-core"'/ pyproject.toml
+          sed -i 's/name = "FAST-OAD"/name = "FAST-OAD-core"/' pyproject.toml
           poetry build
         shell: bash
 
-      - name: publish to PyPI
+      - name: publish FAST-OAD-core to PyPI
         env:
           TOKEN: ${{ secrets.PyPI }} # do not use the secret directly in run command, it would write it plainly in the log
         run: |

--- a/.github/workflows/watchman_tests.yml
+++ b/.github/workflows/watchman_tests.yml
@@ -34,7 +34,7 @@ jobs:
         shell: bash
 
       - name: Unit tests
-        run: pytest --no-cov src -c ./conftest.py
+        run: pytest --no-cov src
         shell: bash
 
       - name: Notebook tests

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,7 +2,7 @@
 Changelog
 =========
 
-Version 1.2.1
+Version 1.3.0
 =============
 - Changes:
     - Rework of plugin system. (#409 - #417)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,22 @@ Changelog
 Version 1.2.1
 =============
 - Changes:
+    - Rework of plugin system. (#409 - #417)
+        - Plugin group identifier is now `fastoad.plugins` (usage of `fastoad_model` is deprecated)
+        - A plugin can now provide, besides models, notebooks and sample configuration files.
+        - CLI and API have been updated to allow choosing the source when generating a configuration file, and to provide the needed information about installed plugin (`fastoad plugin_info`)
+        - Models are loaded only when needed (speeds up some basic operations like `fastoad -h`)
+    - CS25-related models are now in separate package [FAST-OAD-CS25](https://pypi.org/project/fast-oad-cs25/). This package is still installed along with FAST-OAD to preserve backward-compatibility. Also, package [FAST-OAD-core](https://pypi.org/project/fast-oad-core/) is now available, which does NOT install FAST-OAD-CS25 (thus contains only the mission model). (#414)
+    - IndepVarComp variables in FAST-OAD models are now correctly handled and included in input data file. (#408)
+    - Changes in mission module. Most noticeable change is that the number of engines is no more an input of the mission module, but should be handled by the propulsion model. No impact when using the base CS-25 process, since the variable name has not changed.(#411)
+
+- Bug fixes:
+    - FAST-OAD is now able to manage dynamically shaped problem inputs. (#416 - #418)
+
+
+Version 1.2.1
+=============
+- Changes:
   - Updated dependency requirements. All used libraries are now compatible with Jupyter lab 3 without need for building extensions. (#392)
   - Now Atmosphere class is part of the [stdatm](https://pypi.org/project/stdatm/) package (#398)
   - For `list_variables` command, the output format can now be chosen, with the addition of the format of variables_description.txt (for custom modules now generate a variable descriptions. (#399)

--- a/README.md
+++ b/README.md
@@ -19,22 +19,18 @@ It proposes multi-disciplinary analysis and optimisation by relying on
 the [OpenMDAO framework](https://openmdao.org/).
 
 FAST-OAD allows easy switching between models for a same discipline, and
-also adding/removing disciplines to match the need of your study.
+also adding/removing/developing models to match the need of your study.
 
-Currently, FAST-OAD is bundled with models for commercial transport
-aircraft of years 1990-2000. Other models will come, and you may create
-your own models and use them instead of bundled ones.
+More details can be found in the [official documentation](https://fast-oad.readthedocs.io/).
 
-More details can be found in the [official
-documentation](https://fast-oad.readthedocs.io/).
-
->**_Note_**:
+> **Important notice:**
 >
-> Since version 1.0, FAST-OAD aims at providing a stable core software to 
-> propose a safe base for development of custom models.
->
-> Models in FAST-OAD are still a work in progress.
-
+> Since version 1.3.0, FAST-OAD models for commercial transport aircraft have moved in package  
+> [FAST-OAD-CS25](https://pypi.org/project/fast-oad-cs25/). This package is installed along with 
+> FAST-OAD, to keep backward compatibility.
+> Keep in mind that any update of these models will now come through new releases of FAST-OAD-CS25
+> To get FAST-OAD without these models, you may install
+> [FAST-OAD-core](https://pypi.org/project/fast-oad-core/).
 
 Want to try quickly?
 --------------------
@@ -61,4 +57,10 @@ You can install the latest version with this command:
 
 ``` {.bash}
 $ pip install --upgrade fast-oad
+```
+
+or, if you want the minimum installation without the CS25-related models:
+
+``` {.bash}
+$ pip install --upgrade fast-oad-core
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ keywords = [
 ]
 license = "GPL-3.0-only"
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "Environment :: Console",
     "Intended Audience :: Science/Research",
     "Intended Audience :: Education",

--- a/src/fastoad/module_management/_plugins.py
+++ b/src/fastoad/module_management/_plugins.py
@@ -17,6 +17,7 @@ Plugin system for declaration of FAST-OAD models.
 import logging
 import os.path as pth
 import sys
+import warnings
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Callable, Dict, List
@@ -133,6 +134,11 @@ class DistributionPluginDefinition(dict):
         self[entry_point.name] = plugin_definition
 
         if group == OLD_MODEL_PLUGIN_ID:
+            warnings.warn(
+                f'"{self.dist_name}" package uses `fastoad_model` as plugin group ID, which is '
+                "deprecated. `fastoad.plugins` should be used instead.",
+                DeprecationWarning,
+            )
             self[entry_point.name].subpackages[SubPackageNames.MODELS] = entry_point.module
 
         if group == MODEL_PLUGIN_ID:


### PR DESCRIPTION
Draft release: https://github.com/fast-aircraft-design/FAST-OAD/releases/tag/untagged-b92c8e0eee264465d34a

This PR officializes the new plugin system and the separation of CS25 models.
FAST-OAD is declared dependent of FAST-OAD-CS25 to ensure both will be installed by pip. Additionally, build/publish workflow has been modified so that it should publish also a release of FAST-OAD-core that does not require FAST-OAD-CS25 (if it does not work, I'll do it manually 😅).