### PR TITLE
Release v1.3.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,7 +5,7 @@ Changelog
 Version 1.3.1
 =============
 - Fixed:
-    - Version requirement for StdAtm and FAST-OAD-CS25 were unwillingly pinned to 0.1.x. (#422)
+    - Version requirements for StdAtm and FAST-OAD-CS25 were unwillingly pinned to 0.1.x. (#422)
     - `fastoad -v` was producing `unknown` when only FAST-OAD-core was installed. (#422)
     - Fixed some deprecation warnings. (#423)
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Changelog
 =========
 
+Version 1.3.1
+=============
+- Fixed:
+    - Version requirement for StdAtm and FAST-OAD-CS25 were unwillingly pinned to 0.1.x. (#422)
+    - `fastoad -v` was producing `unknown` when only FAST-OAD-core was installed. (#422)
+    - Fixed some deprecation warnings. (#423)
+
 Version 1.3.0.post0
 ===================
 - Modified package organization. (#420)

--- a/README.md
+++ b/README.md
@@ -25,12 +25,19 @@ More details can be found in the [official documentation](https://fast-oad.readt
 
 > **Important notice:**
 >
-> Since version 1.3.0, FAST-OAD models for commercial transport aircraft have moved in package  
+> Since version 1.3.0, FAST-OAD models for commercial transport aircraft have moved in 
+> package  
 > [FAST-OAD-CS25](https://pypi.org/project/fast-oad-cs25/). This package is installed along with 
 > FAST-OAD, to keep backward compatibility.
-> Keep in mind that any update of these models will now come through new releases of FAST-OAD-CS25
+> 
+> Keep in mind that any update of these models will now come through new releases of FAST-OAD-CS25.
+> 
 > To get FAST-OAD without these models, you may install
 > [FAST-OAD-core](https://pypi.org/project/fast-oad-core/).
+> 
+> :warning: Upgrading from an earlier version than 1.3 may break the `fastoad` command line (no 
+> impact on PythonAPI). See [this issue](https://github.com/fast-aircraft-design/FAST-OAD/issues/425)
+> for details and fix.
 
 Want to try quickly?
 --------------------


### PR DESCRIPTION
Maintenance release, especially for allowing usage of StdAtm 0.2.

Draft release here: https://github.com/fast-aircraft-design/FAST-OAD/releases/tag/untagged-91e6f3abfdde6aa2e7a0