### PR TITLE
Hot fix release 1.3.2 :  compatibility with OpenMDAO 3.17

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+Version 1.3.2
+=============
+- Fixed:
+    - Compatibility with OpenMDAO 3.17.0. (#428)
+
 Version 1.3.1
 =============
 - Fixed:

--- a/src/fastoad/openmdao/problem.py
+++ b/src/fastoad/openmdao/problem.py
@@ -159,7 +159,8 @@ class FASTOADProblem(om.Problem):
             # set_val() will crash if input_var.metadata["val"] is a list, so
             # we ensure it is a numpy array
             input_var.metadata["val"] = np.asarray(input_var.metadata["val"])
-            self.set_val(input_var.name, **input_var.metadata)
+
+            self.set_val(input_var.name, val=input_var.val, units=input_var.units)
 
     def _read_inputs_without_setup_done(self):
         """

--- a/src/fastoad/openmdao/tests/test_problem.py
+++ b/src/fastoad/openmdao/tests/test_problem.py
@@ -54,6 +54,11 @@ def test_write_outputs():
     ]
 
     problem["x"] = 2.0
+    problem["z"] = [
+        5.0,
+        2.0,
+    ]  # Since version 3.17 of OpenMDAO, the np.nan input definition of z is chosen.
+
     problem.run_model()
     problem.write_outputs()
     variables = VariableIO(problem.output_file_path).read()


### PR DESCRIPTION
Resolves #427.

OpenMDAO 3.17 modifies the signature of `om.Problem.set_val()`, which caused FAST-OAD 1.3.1 to crash at problem initialization.

Also, the unit test for `FASTOADProblem.write_outputs()` needed a small fix.