### PR TITLE
Datafile enhancement

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -2,6 +2,7 @@ name: Build PyPI package and Binder image
 
 on:
   workflow_dispatch:
+  workflow_call:
   release:
     types: [ published ]
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,6 @@ on:
     tags-ignore:
       - '**'
 
-
 jobs:
   tests:
     runs-on: ${{ matrix.os }}
@@ -18,33 +17,21 @@ jobs:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+
+      - name: Install poetry
+        run: pipx install poetry
+
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
-
-      - name: Install Poetry
-        run: curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python
-        shell: bash
-
-      - name: Poetry path
-        run: echo "$HOME/.poetry/bin" >> $GITHUB_PATH
-        shell: bash
-
-      - name: Sets unique cache directory for Poetry
-        run: poetry config cache-dir ~/poetry_cache
-        shell: bash
-
-      - uses: actions/cache@v2
-        if: ${{ ! startsWith(runner.os, 'Windows') }} # With time, caching on Windows eventually ends crashing.
-        with:
-          path: ~/poetry_cache
-          key: ${{ runner.os }}-Py${{ matrix.python-version }}-pypoetry-${{ hashFiles('**/poetry.lock') }}
+          cache: 'poetry'
 
       - name: Activate environment and install dependencies
-        run: poetry install
-        shell: bash
+        run: |
+          poetry env use ${{ matrix.python-version }}
+          poetry install
 
       - name: Check with Black
         run: |
@@ -84,6 +71,6 @@ jobs:
         shell: bash
 
       - name: Notebook tests
-#        if: ${{ github.event_name == 'pull_request' || contains(github.event.head_commit.message, '[test nb]') || github.ref == 'refs/heads/master' }}
+        #        if: ${{ github.event_name == 'pull_request' || contains(github.event.head_commit.message, '[test nb]') || github.ref == 'refs/heads/master' }}
         run: poetry run pytest --no-cov --nbval-lax -p no:python src/fastoad/notebooks
         shell: bash

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,8 @@
 name: Tests
 
 on:
+  workflow_dispatch:
+  workflow_call:
   push:
     branches:
       - '**'

--- a/.github/workflows/watchman_tests.yml
+++ b/.github/workflows/watchman_tests.yml
@@ -10,7 +10,7 @@ on:
     # The branches below must be a subset of the branches above
     branches: [ master ]
   schedule:
-    - cron: '12 5 * * *'
+    - cron: '12 4 * * *'
 
 
 jobs:
@@ -22,9 +22,9 @@ jobs:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/watchman_tests.yml
+++ b/.github/workflows/watchman_tests.yml
@@ -4,6 +4,8 @@ name: Watchman Tests
 # It will warn developers if any update of a dependency broke something.
 
 on:
+  workflow_dispatch:
+  workflow_call:
   push:
     branches: [ master ]
   pull_request:

--- a/docs/documentation/data.xml
+++ b/docs/documentation/data.xml
@@ -1,0 +1,17 @@
+<FASTOAD_model>
+  <data>
+    <geometry>
+      <wing>
+        <area units="m**2">150.0</area>
+      </wing>
+    </geometry>
+    <weight>
+      <fuselage>
+        <mass units="kg">10000.0</mass>
+        <CG>
+          <x units="m">20.0</x>
+        </CG>
+      </fuselage>
+    </weight>
+  </data>
+</FASTOAD_model>

--- a/docs/documentation/variables.rst
+++ b/docs/documentation/variables.rst
@@ -50,7 +50,24 @@ File format
 
 For writing input and output files, FAST-OAD relies on the path in the variable names.
 
-For example, for the three variables above, the matching XML file will be:
+For instance, the variable name :code:`data:geometry:wing:area` will be split according
+to colons :code:`:` and each part of the name will become a level in the XML hierarchy:
+
+.. code-block:: xml
+
+        <data>
+            <geometry>
+                <wing>
+                    <area units="m**2">
+                        150.0
+                    </area>
+                </wing>
+            </geometry>
+        </data>
+
+
+A complete file that would contain the three above-mentioned variables will be as following:
+
 
 .. code-block:: xml
 
@@ -76,6 +93,12 @@ For example, for the three variables above, the matching XML file will be:
 
     Units are given as a string according to
     `OpenMDAO units definitions <http://openmdao.org/twodocs/versions/latest/features/units.html>`_
+
+.. note::
+
+    XML requires a unique root element for containing all other ones. Its name can be
+    freely chose, but it is `FASTOAD_model` in files written by FAST-OAD
+
 
 FAST-OAD API
 ************
@@ -126,6 +149,28 @@ Provided that above file is named :code:`data.xml`, following commands apply:
     >>> datafile.file_path  # The object is now associated to the new path
     './new_data.xml'
 
+After running these lines of code, the generated file :code:`new_data.xml` contains:
+
+.. code-block:: xml
+
+    <FASTOAD_model>
+        <data>
+            <geometry>
+                <fuselage>
+                    <length units="m">35.0</length>
+                </fuselage>
+                <wing>
+                    <area units="m**2">120.0</area>
+                    <mass units="kg">10500.0</mass>
+                </wing>
+            </geometry>
+            <weight>
+                <fuselage>
+                    <mass units="kg">10000.0</mass>
+                </fuselage>
+            </weight>
+        </data>
+    </FASTOAD_model>
 
 
 

--- a/src/fastoad/io/tests/test_data_file.py
+++ b/src/fastoad/io/tests/test_data_file.py
@@ -47,21 +47,34 @@ class DummyFormatter(IVariableIOFormatter):
 
 
 def test_DataFile(cleanup):
+    variables_ref = VariableList([Variable("data:foo", value=5), Variable("data:bar", value=10)])
+
     file_path = pth.join(RESULTS_FOLDER_PATH, "dummy_data_file.xml")
     with pytest.raises(FileNotFoundError) as exc_info:
         _ = DataFile(file_path)
     assert exc_info.value.args[0] == f'File "{file_path}" is unavailable for reading.'
 
-    variables_1 = DataFile(file_path, load_data=False)
-    assert len(variables_1) == 0
+    data_file_1 = DataFile(file_path, load_data=False)
+    assert len(data_file_1) == 0
 
-    variables_1.update(
-        VariableList([Variable("data:foo", value=5), Variable("data:bar", value=10)]),
+    data_file_1.update(
+        variables_ref,
         add_variables=True,
     )
-    variables_1.save()
+    data_file_1.save()
 
-    variables_2 = DataFile(file_path)
-    assert len(variables_2) == 2
+    data_file_2 = DataFile(file_path)
+    assert len(data_file_2) == 2
 
-    assert set(variables_2) == set(variables_1)
+    assert set(data_file_2) == set(variables_ref)
+
+    # Test from_* methods
+    ivc = variables_ref.to_ivc()
+    data_file_3 = DataFile.from_ivc(ivc)
+    assert isinstance(data_file_3, DataFile)
+    assert set(data_file_3) == set(variables_ref)
+
+    df = variables_ref.to_dataframe()
+    data_file_4 = DataFile.from_dataframe(df)
+    assert isinstance(data_file_4, DataFile)
+    assert set(data_file_4) == set(variables_ref)

--- a/src/fastoad/io/tests/test_data_file.py
+++ b/src/fastoad/io/tests/test_data_file.py
@@ -1,5 +1,5 @@
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2022 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -46,9 +46,13 @@ class DummyFormatter(IVariableIOFormatter):
         self.variables.update(variables, add_variables=True)
 
 
-def test(cleanup):
+def test_DataFile(cleanup):
     file_path = pth.join(RESULTS_FOLDER_PATH, "dummy_data_file.xml")
-    variables_1 = DataFile(file_path)
+    with pytest.raises(FileNotFoundError) as exc_info:
+        _ = DataFile(file_path)
+    assert exc_info.value.args[0] == f'File "{file_path}" is unavailable for reading.'
+
+    variables_1 = DataFile(file_path, load_data=False)
     assert len(variables_1) == 0
 
     variables_1.update(

--- a/src/fastoad/io/tests/test_data_file.py
+++ b/src/fastoad/io/tests/test_data_file.py
@@ -54,14 +54,18 @@ def test_DataFile(cleanup):
         _ = DataFile(file_path)
     assert exc_info.value.args[0] == f'File "{file_path}" is unavailable for reading.'
 
-    data_file_1 = DataFile(file_path, load_data=False)
+    data_file_1 = DataFile()
     assert len(data_file_1) == 0
 
     data_file_1.update(
         variables_ref,
         add_variables=True,
     )
-    data_file_1.save()
+    assert data_file_1.file_path is None
+    with pytest.raises(FileNotFoundError):
+        _ = data_file_1.save()
+    data_file_1.save_as(file_path)
+    assert data_file_1.file_path == file_path
 
     data_file_2 = DataFile(file_path)
     assert len(data_file_2) == 2

--- a/src/fastoad/io/variable_io.py
+++ b/src/fastoad/io/variable_io.py
@@ -1,5 +1,5 @@
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2022 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -11,8 +11,8 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import os.path as pth
 from fnmatch import fnmatchcase
+from os.path import isfile
 from typing import IO, List, Sequence, Union
 
 from fastoad.openmdao.variables import VariableList
@@ -49,6 +49,8 @@ class VariableIO:
         :param ignore: List of variable names that should be ignored when reading.
         :return: an VariableList instance where outputs have been defined using provided source
         """
+        if isinstance(self.data_source, str) and not isfile(self.data_source):
+            raise FileNotFoundError(f'File "{self.data_source}" is unavailable for reading.')
         variables = self.formatter.read_variables(self.data_source)
         used_variables = self._filter_variables(variables, only=only, ignore=ignore)
         return used_variables
@@ -133,11 +135,12 @@ class DataFile(VariableList):
         :param file_path: the file path where data will be loaded and saved.
         :param formatter: a class that determines the file format to be used. Defaults to FAST-OAD
                           native format. See :class:`VariableIO` for more information.
-        :param load_data: if True and if file exists, its content will be loaded at instantiation.
+        :param load_data: if True, file is expected to exist and its content will be loaded at
+                          instantiation.
         """
         super().__init__()
         self._variable_io = VariableIO(file_path, formatter)
-        if pth.exists(file_path) and load_data:
+        if load_data:
             self.load()
 
     @property

--- a/src/fastoad/io/variable_io.py
+++ b/src/fastoad/io/variable_io.py
@@ -130,18 +130,34 @@ class DataFile(VariableList):
     :meth:`save` methods.
     """
 
-    def __init__(self, file_path: str, formatter: IVariableIOFormatter = None, load_data=True):
+    def __init__(
+        self,
+        data_source: Union[str, IO, list] = None,
+        formatter: IVariableIOFormatter = None,
+        load_data=True,
+    ):
         """
-        :param file_path: the file path where data will be loaded and saved.
-        :param formatter: a class that determines the file format to be used. Defaults to FAST-OAD
+        If variable list is specified for data_source, :attr:`file_path` will have to be set before
+        using :method:`save`.
+
+        :param data_source: Can be the file path where data will be loaded and saved, or a list of
+                            :class:`~fastoad.openmdao.variables.Variable` instances that will
+                            be used for initialization (or a
+                            :class:`~fastoad.openmdao.variables.VariableList` instance).
+        :param formatter: (ignored if data_source is not an I/O stream nor a file path)
+                          a class that determines the file format to be used. Defaults to FAST-OAD
                           native format. See :class:`VariableIO` for more information.
-        :param load_data: if True, file is expected to exist and its content will be loaded at
+        :param load_data: (ignored if data_source is not an I/O stream nor a file path)
+                          if True, file is expected to exist and its content will be loaded at
                           instantiation.
         """
         super().__init__()
-        self._variable_io = VariableIO(file_path, formatter)
-        if load_data:
-            self.load()
+        if isinstance(data_source, (str, IO)):
+            self._variable_io = VariableIO(data_source, formatter)
+            if load_data:
+                self.load()
+        if isinstance(data_source, list):
+            self.update(data_source)
 
     @property
     def file_path(self) -> str:

--- a/src/fastoad/openmdao/variables/variable_list.py
+++ b/src/fastoad/openmdao/variables/variable_list.py
@@ -84,7 +84,7 @@ class VariableList(list):
         else:
             super().append(var)
 
-    def update(self, other_var_list: "VariableList", add_variables: bool = True):
+    def update(self, other_var_list: list, add_variables: bool = True):
         """
         Uses variables in other_var_list to update the current VariableList instance.
 
@@ -163,7 +163,7 @@ class VariableList(list):
         :param var_dict:
         :return: a VariableList instance
         """
-        variables = VariableList()
+        variables = cls()
 
         for var_name, metadata in dict(var_dict).items():
             variables.append(Variable(var_name, **metadata))
@@ -178,7 +178,7 @@ class VariableList(list):
         :param ivc: an IndepVarComp instance
         :return: a VariableList instance
         """
-        variables = VariableList()
+        variables = cls()
 
         ivc = deepcopy(ivc)
         om.Problem(ivc).setup()  # Need setup to have get_io_metadata working
@@ -230,7 +230,7 @@ class VariableList(list):
                     pass
             return Variable(**var_as_dict)
 
-        return VariableList([_get_variable(row) for row in df[column_names].values])
+        return cls([_get_variable(row) for row in df[column_names].values])
 
     @classmethod
     def from_problem(
@@ -346,8 +346,8 @@ class VariableList(list):
                             final[prom_name]["desc"] = metadata["desc"]
 
         # Conversion to VariableList instances
-        input_vars = VariableList.from_dict(final_inputs)
-        output_vars = VariableList.from_dict(final_outputs)
+        input_vars = cls.from_dict(final_inputs)
+        output_vars = cls.from_dict(final_outputs)
 
         # Use computed value instead of initial ones, if asked for, and if problem has been run.
         # Note: using problem.get_val() if problem has not been run may lead to unexpected

--- a/src/fastoad/openmdao/variables/variable_list.py
+++ b/src/fastoad/openmdao/variables/variable_list.py
@@ -30,30 +30,47 @@ from .variable import METADATA_TO_IGNORE, Variable
 
 class VariableList(list):
     """
-    Class for storing OpenMDAO variables
+    Class for storing OpenMDAO variables.
 
-    A list of Variable instances, but items can also be accessed through variable names.
+    A list of :class:`~fastoad.openmdao.variables.variable.Variable` instances, but items can
+    also be accessed through variable names. It also has utilities to be converted from/to some
+    other data structures (python dict, OpenMDAO IndepVarComp, pandas DataFrame)
 
-    There are 2 ways for adding a variable::
+    See documentation of :class:`~fastoad.openmdao.variables.variable.Variable` to see how to
+    manipulate each element.
 
-        # Assuming these Python variables are ready
+    There are several ways for adding variables::
+
+        # Assuming these Python variables are ready...
         var_1 = Variable('var/1', value=0.)
         metadata_2 = {'value': 1., 'units': 'm'}
 
-        # ... a VariableList instance can be populated like this
-        vars = VariableList()
-        vars.append(var_1)              # Adds directly a Variable instance
-        vars['var/2'] = metadata_2      # Adds the variable with given name and given metadata
+        # ... a VariableList instance can be populated like this:
+        vars_A = VariableList()
+        vars_A.append(var_1)              # Adds directly a Variable instance
+        vars_A['var/2'] = metadata_2      # Adds the variable with given name and given metadata
+
+    Note:
+        Adding a Variable instance with a name that is already in the VariableList instance
+        will replace the previous Variable instance instead of adding a new one.
+
+    .. code:: python
+
+        # It is also possible to instantiate a VariableList instance from another VariableList
+        # instance or a simple list of Variable instances
+        vars_B = VariableList(vars_A)
+        vars_C = VariableList([var_1])
+
+        # An existing VariableList instance can also receive the content of another VariableList
+        # instance.
+        vars_C.update(vars_A)             # variables in vars_A will overwrite variables with same
+                                          # name in vars_C
 
     After that, following equalities are True::
 
-        print( var_1 in vars )
-        print( 'var/1' in vars.names() )
-        print( 'var/2' in vars.names() )
-
-    Note:
-        Adding a Variable instance that has a name that is already in the VariableList instance
-        will replace the previous Variable instance instead of adding a new one.
+        print( var_1 in vars_A )
+        print( 'var/1' in vars_A.names() )
+        print( 'var/2' in vars_A.names() )
     """
 
     def names(self) -> List[str]:

--- a/src/fastoad/openmdao/variables/variable_list.py
+++ b/src/fastoad/openmdao/variables/variable_list.py
@@ -357,10 +357,11 @@ class VariableList(list):
             # possible descriptions.
             for metadata in itertools.chain(inputs.values(), outputs.values()):
                 prom_name = metadata["prom_name"]
-                if metadata["desc"]:
-                    for final in final_inputs, final_outputs:
-                        if prom_name in final and not final[prom_name]["desc"]:
-                            final[prom_name]["desc"] = metadata["desc"]
+                if not metadata["desc"]:
+                    continue
+                for final in final_inputs, final_outputs:
+                    if prom_name in final and not final[prom_name]["desc"]:
+                        final[prom_name]["desc"] = metadata["desc"]
 
         # Conversion to VariableList instances
         input_vars = cls.from_dict(final_inputs)


### PR DESCRIPTION
This PR aims at easing a bit the usage of DataFile class:
- fixes #421 and #429
- allows instantiating a DataFile with no argument or from list of a Variable instances
- adds the `save_as()` method
- adds a documentation section about usage of DataFile (preview [here](https://fast-oad.readthedocs.io/en/datafile-enhancement/documentation/variables.html#fast-oad-api))

BTW, I changed a bit the GitHub workflows to take advantage of the cache management of the `setup-python` action, that works for Poetry (bye bye `actions/cache`). I used this branch as a sandbox to test it.

Finally, since CodeClimate was nagging me with a "two many nested control flows" in the dreaded `VariableList.from_problem()` method (just because I slightly modified it to fix issue 421), I decided to comply by simply using a [guard clause](https://en.wikipedia.org/wiki/Guard_(computer_science)).