### PR TITLE
Issue 436 - configuration file connections with indepvarcomp

### DIFF
--- a/src/fastoad/io/configuration/tests/data/valid_sellar_with_indep.toml
+++ b/src/fastoad/io/configuration/tests/data/valid_sellar_with_indep.toml
@@ -1,0 +1,61 @@
+
+
+title = "Sellar"
+
+module_folders = [
+  "conf_sellar_example",
+  "d:/path/does/not/exist" # will only trigger a warning
+]
+
+input_file = "../results/inputs.xml"
+output_file = "../results/outputs.xml"
+
+driver = "om.ScipyOptimizeDriver(optimizer='SLSQP')"
+[model]
+    [model.indep]
+        id = "configuration_test.sellar.indeps"
+    [[model.connections]]
+        source = "system:x"
+        target = "x"
+    [[model.connections]]
+        source = "y1"
+        target = "yy1"
+    [[model.connections]]
+        source = "y2"
+        target = "yy2"
+    [model.cycle]
+        nonlinear_solver = "om.NonlinearBlockGS(iprint=1)"
+        linear_solver = "om.ScipyKrylov()"
+        [model.cycle.disc1]
+            id = "configuration_test.sellar.disc1"
+        [model.cycle.disc2]
+            id = "configuration_test.sellar.disc2"
+    [model.functions]
+        id = "configuration_test.sellar.functions"
+
+[submodels]
+    "service.function.f" = "function.f.default"
+    "service.function.g1" = "function.g1.default"
+    "service.function.g2" = "function.g2.default"
+
+[optimization]
+    [[optimization.design_variables]]
+      name = "x"
+      lower = 0
+      upper = 10
+    [[optimization.design_variables]]
+      name = "z"
+      lower = 0
+      upper = 10
+
+    [[optimization.constraints]]
+      name = "g1"
+      lower = -100
+      upper = 0
+    [[optimization.constraints]]
+      name = "g2"
+      upper = 0
+
+    [[optimization.objective]]
+      name = "f"
+

--- a/src/fastoad/io/configuration/tests/test_configuration.py
+++ b/src/fastoad/io/configuration/tests/test_configuration.py
@@ -173,32 +173,17 @@ def test_problem_definition_with_xml_ref_with_indep(cleanup):
         conf.write_needed_inputs(ref_input_data_path)
         input_data = DataFile(conf.input_file_path)
         assert len(input_data) == 2
-        assert "x" in input_data.names()
+        assert "system:x" in input_data.names()
         assert "z" in input_data.names()
 
         problem = conf.get_problem(read_inputs=True, auto_scaling=True)
         # runs evaluation without optimization loop to check that inputs are taken into account
         problem.setup()
+        # system:x is not in ref_inputs.xml
+        problem["system:x"] = 1.0
         problem.run_model()
         assert problem["f"] == pytest.approx(28.58830817, abs=1e-6)
         problem.write_outputs()
-
-        # Test with alternate submodel #########################################
-        alt_conf = FASTOADProblemConfigurator(
-            pth.join(DATA_FOLDER_PATH, "valid_sellar_alternate.%s" % extension)
-        )
-        alt_conf.input_file_path = pth.join(result_folder_path, "inputs.xml")
-        alt_conf.output_file_path = pth.join(result_folder_path, "outputs_alt.xml")
-        alt_problem = alt_conf.get_problem(read_inputs=True, auto_scaling=True)
-        # runs evaluation without optimization loop to check that inputs are taken into account
-        alt_problem.setup()
-        alt_problem.run_model()
-        alt_problem.write_outputs()
-
-        assert alt_problem["f"] == pytest.approx(0.58830817, abs=1e-6)
-        assert alt_problem["g2"] == pytest.approx(-11.94151185, abs=1e-6)
-        with pytest.raises(KeyError):
-            alt_problem["g1"]  # submodel for g1 computation has been deactivated.
 
 
 # FIXME: this test should be reworked and moved to test_problem

--- a/src/fastoad/io/configuration/tests/test_configuration.py
+++ b/src/fastoad/io/configuration/tests/test_configuration.py
@@ -156,6 +156,51 @@ def test_problem_definition_with_xml_ref(cleanup):
             alt_problem["g1"]  # submodel for g1 computation has been deactivated.
 
 
+def test_problem_definition_with_xml_ref_with_indep(cleanup):
+    """Tests what happens when writing inputs of a problem with indeps using data from existing XML file"""
+    for extension in ["toml", "yml"]:
+        clear_openmdao_registry()
+        conf = FASTOADProblemConfigurator(
+            pth.join(DATA_FOLDER_PATH, "valid_sellar_with_indep.%s" % extension)
+        )
+
+        result_folder_path = pth.join(
+            RESULTS_FOLDER_PATH, "problem_definition_with_xml_ref_with_indep"
+        )
+        conf.input_file_path = pth.join(result_folder_path, "inputs.xml")
+        conf.output_file_path = pth.join(result_folder_path, "outputs.xml")
+        ref_input_data_path = pth.join(DATA_FOLDER_PATH, "ref_inputs.xml")
+        conf.write_needed_inputs(ref_input_data_path)
+        input_data = DataFile(conf.input_file_path)
+        assert len(input_data) == 2
+        assert "x" in input_data.names()
+        assert "z" in input_data.names()
+
+        problem = conf.get_problem(read_inputs=True, auto_scaling=True)
+        # runs evaluation without optimization loop to check that inputs are taken into account
+        problem.setup()
+        problem.run_model()
+        assert problem["f"] == pytest.approx(28.58830817, abs=1e-6)
+        problem.write_outputs()
+
+        # Test with alternate submodel #########################################
+        alt_conf = FASTOADProblemConfigurator(
+            pth.join(DATA_FOLDER_PATH, "valid_sellar_alternate.%s" % extension)
+        )
+        alt_conf.input_file_path = pth.join(result_folder_path, "inputs.xml")
+        alt_conf.output_file_path = pth.join(result_folder_path, "outputs_alt.xml")
+        alt_problem = alt_conf.get_problem(read_inputs=True, auto_scaling=True)
+        # runs evaluation without optimization loop to check that inputs are taken into account
+        alt_problem.setup()
+        alt_problem.run_model()
+        alt_problem.write_outputs()
+
+        assert alt_problem["f"] == pytest.approx(0.58830817, abs=1e-6)
+        assert alt_problem["g2"] == pytest.approx(-11.94151185, abs=1e-6)
+        with pytest.raises(KeyError):
+            alt_problem["g1"]  # submodel for g1 computation has been deactivated.
+
+
 # FIXME: this test should be reworked and moved to test_problem
 def test_problem_definition_with_custom_xml(cleanup):
     """Tests what happens when writing inputs using existing XML with some unwanted var"""

--- a/src/fastoad/openmdao/variables/variable_list.py
+++ b/src/fastoad/openmdao/variables/variable_list.py
@@ -285,7 +285,7 @@ class VariableList(list):
         indep_outputs = problem.model.get_io_metadata(
             "output", metadata_keys=metadata_keys, tags="indep_var"
         )
-
+        print("Indep : \n ", indep_outputs)
         # Move outputs from IndepVarComps into inputs
         for abs_name, metadata in indep_outputs.items():
             del outputs[abs_name]
@@ -308,10 +308,7 @@ class VariableList(list):
                 # Check connections
                 for name, metadata in inputs.copy().items():
                     source_name = problem.model.get_source(name)
-                    if (
-                        not (source_name in indep_outputs or source_name.startswith("_auto_ivc."))
-                        and source_name != name
-                    ):
+                    if not (source_name.startswith("_auto_ivc.")) and source_name != name:
                         # This variable is connected to another variable of the problem: it is
                         # not an actual problem input. Let's move it to outputs.
                         del inputs[name]
@@ -326,12 +323,18 @@ class VariableList(list):
         # Manage variable promotion
         if not get_promoted_names:
             final_inputs = inputs
+
             final_outputs = outputs
         else:
             final_inputs = {
                 metadata["prom_name"]: dict(metadata, is_input=True) for metadata in inputs.values()
             }
             final_outputs = cls._get_promoted_outputs(outputs)
+
+            # Remove possible duplicates due to Indeps
+            for input_name in final_inputs:
+                if input_name in final_outputs:
+                    del final_outputs[input_name]
 
             # When variables are promoted, we may have retained a definition of the variable
             # that does not have any description, whereas a description is available in

--- a/src/fastoad/openmdao/variables/variable_list.py
+++ b/src/fastoad/openmdao/variables/variable_list.py
@@ -285,7 +285,6 @@ class VariableList(list):
         indep_outputs = problem.model.get_io_metadata(
             "output", metadata_keys=metadata_keys, tags="indep_var"
         )
-        print("Indep : \n ", indep_outputs)
         # Move outputs from IndepVarComps into inputs
         for abs_name, metadata in indep_outputs.items():
             del outputs[abs_name]

--- a/src/fastoad/openmdao/variables/variable_list.py
+++ b/src/fastoad/openmdao/variables/variable_list.py
@@ -257,7 +257,7 @@ class VariableList(list):
         :param get_promoted_names: if True, promoted names will be returned instead of absolute ones
                                    (if no promotion, absolute name will be returned)
         :param promoted_only: if True, only promoted variable names will be returned
-        :param io_status: to choose with type of variable we return ("all", "inputs, "inputs")
+        :param io_status: to choose with type of variable we return ("all", "inputs, "outputs")
         :return: VariableList instance
         """
 


### PR DESCRIPTION
This PR resolves #436. 
The issue was that `IndepVarComp` connections were ignored when analyzing connections for sorting inputs and outputs.
Thus, the variables to which they were connected were still considered as inputs and therefore added to the generated input file.