### PR TITLE
Simple Multistart

### DIFF
--- a/src/fastoad/cmd/api.py
+++ b/src/fastoad/cmd/api.py
@@ -720,10 +720,6 @@ def _run_multistart(problem: FASTOADProblem, conf: FASTOADProblemConfigurator):
                 criterion = optimization_option.get("criterion")
             else:
                 criterion = None
-            # if optimization_option.get("num_proc") is not None:
-            #     num_proc = optimization_option.get("num_proc")
-            # else:
-            #     num_proc = 1
 
     design_variables = conf._get_design_vars()
     num_design_var = len(design_variables.values())
@@ -768,14 +764,7 @@ def _run_multistart(problem: FASTOADProblem, conf: FASTOADProblemConfigurator):
 
     successfull_problems = []
 
-    # with Pool(num_proc) as pool:
-    #     processed = pool.map(
-    #         lambda item: _run_sample(
-    #             item, problem=problem, successfull_problems=successfull_problems
-    #         ),
-    #         samples,
-    #     )
-
+    # TODO: Implement multiprocessing to parallelize the evaluation of each sample
     for sample in samples:
         _run_sample(sample, problem=problem, successfull_problems=successfull_problems)
 

--- a/src/fastoad/cmd/api.py
+++ b/src/fastoad/cmd/api.py
@@ -24,12 +24,14 @@ from collections import defaultdict
 from collections.abc import Iterable
 from time import time
 from typing import Dict, IO, List, Union
+import copy
 
 import openmdao.api as om
 import pandas as pd
 from IPython import InteractiveShell
 from IPython.display import HTML, clear_output, display
 from tabulate import tabulate
+from pyDOE2 import lhs
 
 import fastoad.openmdao.whatsopt
 from fastoad._utils.files import make_parent_dir
@@ -599,7 +601,21 @@ def _run_problem(
         problem.run_model()
         problem.optim_failed = False  # Actually, we don't know
     else:
-        problem.optim_failed = problem.run_driver()
+        optimization_options = conf._get_optimization_options()
+        if optimization_options:
+            for optimization_option in optimization_options:
+                if optimization_option.get("multistart"):
+                    multistart = True
+                else:
+                    multistart = False
+            if multistart:
+                problem = _run_multistart(problem, conf=conf)
+                # TODO: check that at least one sample converged
+                problem.optim_failed = False
+            else:
+                problem.optim_failed = problem.run_driver()
+        else:
+            problem.optim_failed = problem.run_driver()
     end_time = time()
     computation_time = round(end_time - start_time, 2)
 
@@ -688,3 +704,81 @@ def variable_viewer(file_path: str, file_formatter: IVariableIOFormatter = None,
 
         handle = display(HTML(table.to_html()))
     return handle
+
+
+def _run_multistart(problem: FASTOADProblem, conf: FASTOADProblemConfigurator):
+
+    optimization_options = conf._get_optimization_options()
+    for optimization_option in optimization_options:
+        # Retrieving options for multistart
+        if optimization_option.get("multistart"):
+            if optimization_option.get("samples") is not None:
+                samples = optimization_option.get("samples")
+            else:
+                samples = None
+            if optimization_option.get("criterion") is not None:
+                criterion = optimization_option.get("criterion")
+            else:
+                criterion = None
+            # if optimization_option.get("num_proc") is not None:
+            #     num_proc = optimization_option.get("num_proc")
+            # else:
+            #     num_proc = 1
+
+    design_variables = conf._get_design_vars()
+    num_design_var = len(design_variables.values())
+    num_samples = samples
+
+    objectives = conf._get_objectives()
+
+    doe = lhs(num_design_var, samples=num_samples, criterion=criterion)
+
+    samples = []
+    for i in range(num_samples):
+        sample = {}
+        for j in range(num_design_var):
+            dv = list(design_variables.values())
+            name = dv[j]["name"]
+            lower = dv[j]["lower"]
+            upper = dv[j]["upper"]
+            # Key = name, value = initial value
+            sample[name] = doe[i][j] * (upper - lower) + lower
+        samples.append(sample)
+
+    # We do not consider multiobjective, therefore take the first
+    objective_name = list(objectives.values())[0]["name"]
+
+    def _run_sample(sample, problem=None, successfull_problems=None):
+        # TODO: check new way to copy Problem
+        problem_copy = copy.deepcopy(problem)
+        problem_copy.setup()
+
+        # Set initial values of design variables
+        for name, value in sample.items():
+            problem_copy.set_val(name, val=value)
+
+        # Run the problem
+        failed_to_converge = problem_copy.run_driver()
+
+        # Keep only the problems that converged correctly
+        if not failed_to_converge:
+            successfull_problems.append(
+                tuple([problem_copy.get_val(name=objective_name), problem_copy])
+            )
+
+    successfull_problems = []
+
+    # with Pool(num_proc) as pool:
+    #     processed = pool.map(
+    #         lambda item: _run_sample(
+    #             item, problem=problem, successfull_problems=successfull_problems
+    #         ),
+    #         samples,
+    #     )
+
+    for sample in samples:
+        _run_sample(sample, problem=problem, successfull_problems=successfull_problems)
+
+    # Find the best result
+    min_objective = min(successfull_problems, key=lambda t: t[0])
+    return min_objective[1]

--- a/src/fastoad/cmd/tests/data/sellar.yml
+++ b/src/fastoad/cmd/tests/data/sellar.yml
@@ -18,11 +18,6 @@ model:
     id: cmd_test.sellar.functions
 
 optimization:
-  options:
-    - multistart: true
-      samples: 10
-      criterion: maximin
-      num_proc: 4
   design_variables:
     - name: x
       lower: 0

--- a/src/fastoad/cmd/tests/data/sellar.yml
+++ b/src/fastoad/cmd/tests/data/sellar.yml
@@ -18,6 +18,11 @@ model:
     id: cmd_test.sellar.functions
 
 optimization:
+  options:
+    - multistart: true
+      samples: 10
+      criterion: maximin
+      num_proc: 4
   design_variables:
     - name: x
       lower: 0

--- a/src/fastoad/cmd/tests/data/sellar_newton_multistart.yml
+++ b/src/fastoad/cmd/tests/data/sellar_newton_multistart.yml
@@ -1,0 +1,39 @@
+title: Sellar
+
+module_folders:
+  - ./cmd_sellar_example
+
+input_file: ../results/inputs.xml
+output_file: ../results/outputs.xml
+
+driver: om.ScipyOptimizeDriver(optimizer='SLSQP', tol=1e-8)
+model:
+  group:
+    nonlinear_solver: om.NewtonSolver(maxiter=20, solve_subsystems=False)
+    disc1:
+      id: cmd_test.sellar.disc1
+    disc2:
+      id: cmd_test.sellar.disc2
+  functions:
+    id: cmd_test.sellar.functions
+
+optimization:
+  options:
+    - multistart: true
+      samples: 10
+      criterion: maximin
+      num_proc: 4
+  design_variables:
+    - name: x
+      lower: 0
+      upper: 10
+    - name: z
+      lower: 0
+      upper: 10
+  constraints:
+    - name: g1
+      upper: 0
+    - name: g2
+      upper: 0
+  objective:
+    - name: f

--- a/src/fastoad/cmd/tests/test_api.py
+++ b/src/fastoad/cmd/tests/test_api.py
@@ -34,6 +34,7 @@ from ..exceptions import (
 DATA_FOLDER_PATH = pth.join(pth.dirname(__file__), "data")
 RESULTS_FOLDER_PATH = pth.join(pth.dirname(__file__), "results")
 CONFIGURATION_FILE_PATH = pth.join(DATA_FOLDER_PATH, "sellar.yml")
+MULTISTART_CONFIGURATION_FILE_PATH = pth.join(DATA_FOLDER_PATH, "sellar_newton_multistart.yml")
 
 
 @pytest.fixture(scope="module")
@@ -335,6 +336,15 @@ def test_optimize_problem(cleanup):
     with pytest.raises(FastPathExistsError):
         api.optimize_problem(CONFIGURATION_FILE_PATH, False)
     problem = api.optimize_problem(CONFIGURATION_FILE_PATH, True)
+
+    assert problem["f"] == pytest.approx(3.18339395, abs=1e-8)
+
+
+def test_multistart_optimization_problem(cleanup):
+    api.generate_inputs(
+        MULTISTART_CONFIGURATION_FILE_PATH, pth.join(DATA_FOLDER_PATH, "inputs.xml"), overwrite=True
+    )
+    problem = api.optimize_problem(MULTISTART_CONFIGURATION_FILE_PATH, True)
 
     assert problem["f"] == pytest.approx(3.18339395, abs=1e-8)
 

--- a/src/fastoad/io/configuration/resources/configuration.json
+++ b/src/fastoad/io/configuration/resources/configuration.json
@@ -144,6 +144,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "options": {
+          "type": "array"
+        },
         "design_variables": {
           "type": "array",
           "items": {


### PR DESCRIPTION
This PR aims at providing a multistart optimization feature configurable from the configuration file.
The Design of Experiment method used is a Latin Hypercube Sampling method.
Here is an example of the syntax in the optimization section of the configuration file:
```yaml
optimization:
  options:
    - multistart: true
      samples: 10
      criterion: maximin
      num_proc: 4
  design_variables:
    - name: x
      lower: 0
      upper: 10
    - name: z
      lower: 0
      upper: 10
  constraints:
    - name: g1
      upper: 0
    - name: g2
      upper: 0
  objective:
    - name: f
```

The `num_proc` field is the number of processors to use for multiprocessing but is not yet used and will be implemented in a later PR.