### PR TITLE
Now allowing more than 5 datasets in mass breakdown bar plot

### DIFF
--- a/src/fastoad/gui/analysis_and_plots.py
+++ b/src/fastoad/gui/analysis_and_plots.py
@@ -17,7 +17,6 @@ Defines the analysis and plotting functions for postprocessing
 from typing import Dict
 
 import numpy as np
-import plotly
 import plotly.graph_objects as go
 from openmdao.utils.units import convert_units
 from plotly.subplots import make_subplots
@@ -25,11 +24,21 @@ from plotly.subplots import make_subplots
 from fastoad.io import VariableIO
 from fastoad.openmdao.variables import VariableList
 
-# TODO: COLS is a reordered version of DEFAULT_PLOTLY_COLORS simply because issue #450 was using
-#       only even-indexed items of DEFAULT_PLOTLY_COLORS.
-#       This reordering allows to keep the same colors as before for the 5 first plots.
-#       FAST-OAD 2.0 will have to use the original order.
-COLS = plotly.colors.DEFAULT_PLOTLY_COLORS[::2] + plotly.colors.DEFAULT_PLOTLY_COLORS[1::1]
+# This color list is an attempt to mimic the default color list (the one used
+# when no color is specified). And strangely enough, it is not
+# plotly.colors.DEFAULT_PLOTLY_COLORS
+COLS = [
+    "mediumblue",
+    "red",
+    "mediumseagreen",
+    "mediumpurple",
+    "darkorange",
+    "cyan",
+    "orangered",
+    "lightgreen",
+    "pink",
+    "orange",
+]
 
 
 # pylint: disable-msg=too-many-locals

--- a/src/fastoad/gui/analysis_and_plots.py
+++ b/src/fastoad/gui/analysis_and_plots.py
@@ -307,7 +307,7 @@ def mass_breakdown_bar_plot(
         )
 
     # Same color for each aircraft configuration
-    i = int(len(fig.data) / 2)
+    i = int(len(fig.data) / 2) % 10
 
     weight_labels = ["MTOW", "OWE", "Fuel - Mission", "Payload"]
     weight_values = [mtow, owe, fuel_mission, payload]

--- a/src/fastoad/gui/analysis_and_plots.py
+++ b/src/fastoad/gui/analysis_and_plots.py
@@ -17,6 +17,7 @@ Defines the analysis and plotting functions for postprocessing
 from typing import Dict
 
 import numpy as np
+import plotly.express as px
 import plotly.graph_objects as go
 from openmdao.utils.units import convert_units
 from plotly.subplots import make_subplots
@@ -24,21 +25,7 @@ from plotly.subplots import make_subplots
 from fastoad.io import VariableIO
 from fastoad.openmdao.variables import VariableList
 
-# This color list is an attempt to mimic the default color list (the one used
-# when no color is specified). And strangely enough, it is not
-# plotly.colors.DEFAULT_PLOTLY_COLORS
-COLS = [
-    "mediumblue",
-    "red",
-    "mediumseagreen",
-    "mediumpurple",
-    "darkorange",
-    "cyan",
-    "orangered",
-    "lightgreen",
-    "pink",
-    "orange",
-]
+COLS = px.colors.qualitative.Plotly
 
 
 # pylint: disable-msg=too-many-locals

--- a/src/fastoad/gui/analysis_and_plots.py
+++ b/src/fastoad/gui/analysis_and_plots.py
@@ -2,7 +2,7 @@
 Defines the analysis and plotting functions for postprocessing
 """
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2022 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -25,7 +25,11 @@ from plotly.subplots import make_subplots
 from fastoad.io import VariableIO
 from fastoad.openmdao.variables import VariableList
 
-COLS = plotly.colors.DEFAULT_PLOTLY_COLORS
+# TODO: COLS is a reordered version of DEFAULT_PLOTLY_COLORS simply because issue #450 was using
+#       only even-indexed items of DEFAULT_PLOTLY_COLORS.
+#       This reordering allows to keep the same colors as before for the 5 first plots.
+#       FAST-OAD 2.0 will have to use the original order.
+COLS = plotly.colors.DEFAULT_PLOTLY_COLORS[::2] + plotly.colors.DEFAULT_PLOTLY_COLORS[1::1]
 
 
 # pylint: disable-msg=too-many-locals
@@ -303,7 +307,7 @@ def mass_breakdown_bar_plot(
         )
 
     # Same color for each aircraft configuration
-    i = len(fig.data)
+    i = int(len(fig.data) / 2)
 
     weight_labels = ["MTOW", "OWE", "Fuel - Mission", "Payload"]
     weight_values = [mtow, owe, fuel_mission, payload]

--- a/src/fastoad/gui/tests/test_analysis_and_plots.py
+++ b/src/fastoad/gui/tests/test_analysis_and_plots.py
@@ -47,7 +47,7 @@ def test_wing_geometry_plot():
     # Adding plots to the previous fig
     # This is a rudimentary test as plot are difficult to verify
     # The test will fail if an error is raised by the following line
-    for i in range(9):
+    for i in range(20):
         fig = wing_geometry_plot(filename, name=f"Plot {i}", fig=fig)
 
 
@@ -71,7 +71,7 @@ def test_aircraft_geometry_plot():
     # Adding plots to the previous fig
     # This is a rudimentary test as plot are difficult to verify
     # The test will fail if an error is raised by the following line
-    for i in range(9):
+    for i in range(20):
         fig = aircraft_geometry_plot(filename, name=f"Plot {i}", fig=fig)
 
 
@@ -95,7 +95,7 @@ def test_mass_breakdown_bar_plot():
     # Adding plots to the previous fig
     # This is a rudimentary test as plot are difficult to verify
     # The test will fail if an error is raised by the following line
-    for i in range(9):
+    for i in range(20):
         _ = mass_breakdown_bar_plot(filename, name=f"Plot {i}", fig=fig)
 
 

--- a/src/fastoad/gui/tests/test_analysis_and_plots.py
+++ b/src/fastoad/gui/tests/test_analysis_and_plots.py
@@ -2,7 +2,7 @@
 Tests for analysis and plots functions
 """
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2022 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -44,10 +44,11 @@ def test_wing_geometry_plot():
     # The test will fail if an error is raised by the following line
     fig = wing_geometry_plot(filename, name="First plot")
 
-    # Adding a plot to the previous fig
+    # Adding plots to the previous fig
     # This is a rudimentary test as plot are difficult to verify
     # The test will fail if an error is raised by the following line
-    fig = wing_geometry_plot(filename, name="Second plot", fig=fig)
+    for i in range(9):
+        fig = wing_geometry_plot(filename, name=f"Plot {i}", fig=fig)
 
 
 def test_aircraft_geometry_plot():
@@ -67,10 +68,11 @@ def test_aircraft_geometry_plot():
     # The test will fail if an error is raised by the following line
     fig = aircraft_geometry_plot(filename, name="First plot")
 
-    # Adding a plot to the previous fig
+    # Adding plots to the previous fig
     # This is a rudimentary test as plot are difficult to verify
     # The test will fail if an error is raised by the following line
-    fig = aircraft_geometry_plot(filename, name="Second plot", fig=fig)
+    for i in range(9):
+        fig = aircraft_geometry_plot(filename, name=f"Plot {i}", fig=fig)
 
 
 def test_mass_breakdown_bar_plot():
@@ -90,10 +92,11 @@ def test_mass_breakdown_bar_plot():
     # The test will fail if an error is raised by the following line
     fig = mass_breakdown_bar_plot(filename, name="First plot")
 
-    # Adding a plot to the previous fig
+    # Adding plots to the previous fig
     # This is a rudimentary test as plot are difficult to verify
     # The test will fail if an error is raised by the following line
-    _ = mass_breakdown_bar_plot(filename, name="Second plot", fig=fig)
+    for i in range(9):
+        _ = mass_breakdown_bar_plot(filename, name=f"Plot {i}", fig=fig)
 
 
 def test_drag_polar_plot():


### PR DESCRIPTION
Fixes #450.

The number of datasets in mass breakdown bar plot was limited to 5 due to an incorrect indexing in the list `plotly.colors.DEFAULT_PLOTLY_COLORS` (which contains 10 items).

Besides, colors in mass breakdown plot were inconsistent with colors in other plots (geometry, polar). The color list for mass breakdown bar plot is now close to the one used in other plots.