### PR TITLE
Fixed backward compatibility of bundled missions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+Version 1.4.1
+=============
+- Fixed:
+    - Fixed backward compatibility of bundled missions. (#466)
+
 Version 1.4.0
 =============
 

--- a/src/fastoad/models/performances/mission/openmdao/resources/sizing_breguet.yml
+++ b/src/fastoad/models/performances/mission/openmdao/resources/sizing_breguet.yml
@@ -29,7 +29,10 @@ phases:
             unit: ft
             default: 35
           delta_mass: -~fuel
-          time: ~duration
+          time:
+            value: ~duration
+            unit: s
+            default: 0.0
           true_airspeed: ~V2
       - segment: mass_input
         target:

--- a/src/fastoad/models/performances/mission/openmdao/resources/sizing_mission.yml
+++ b/src/fastoad/models/performances/mission/openmdao/resources/sizing_mission.yml
@@ -33,7 +33,10 @@ phases:
             unit: ft
             default: 35
           delta_mass: -~fuel
-          time: ~duration
+          time:
+            value: ~duration
+            unit: s
+            default: 0.0
           true_airspeed: ~V2
       - segment: mass_input
         target:

--- a/src/fastoad/models/performances/mission/openmdao/tests/test_sizing_breguet.py
+++ b/src/fastoad/models/performances/mission/openmdao/tests/test_sizing_breguet.py
@@ -46,7 +46,6 @@ def test_sizing_breguet(cleanup, with_dummy_plugin_2):
     ivc.add_output("data:mission:sizing:takeoff:altitude", 0.0)
     ivc.add_output("data:mission:sizing:takeoff:V2", 0.0, units="m/s")
     ivc.add_output("data:mission:sizing:takeoff:fuel", 0.0, units="kg")
-    ivc.add_output("data:mission:sizing:takeoff:duration", 0, units="s")
     ivc.add_output("data:mission:sizing:taxi_out:thrust_rate", 0)
     ivc.add_output("data:mission:sizing:taxi_out:duration", 0, units="s")
     ivc.add_output("data:geometry:wing:area", 0.0, units="m**2")

--- a/src/fastoad/models/performances/mission/openmdao/tests/test_sizing_mission.py
+++ b/src/fastoad/models/performances/mission/openmdao/tests/test_sizing_mission.py
@@ -42,7 +42,6 @@ def test_sizing_mission(cleanup, with_dummy_plugin_2):
     ivc.add_output("data:mission:sizing:takeoff:altitude", 0.0)
     ivc.add_output("data:mission:sizing:takeoff:V2", 80.0, units="m/s")
     ivc.add_output("data:mission:sizing:takeoff:fuel", 80.0, units="kg")
-    ivc.add_output("data:mission:sizing:takeoff:duration", 0, units="s")
     ivc.add_output("data:mission:sizing:taxi_out:thrust_rate", 0.3)
     ivc.add_output("data:mission:sizing:climb:thrust_rate", 0.9)
     ivc.add_output("data:mission:sizing:descent:thrust_rate", 0.05)


### PR DESCRIPTION
In version 1.4.0, bundled missions now require the takeoff duration as mandatory input, which was not the case before.
This is fixed now.