### PR TITLE
Added warning for nan values when generating inputs

### DIFF
--- a/src/fastoad/io/configuration/configuration.py
+++ b/src/fastoad/io/configuration/configuration.py
@@ -235,7 +235,7 @@ class FASTOADProblemConfigurator:
             for var in variables:
                 var.is_input = True
                 # Checking if variables have NaN values
-                if np.all(np.isnan(var.value)):
+                if np.any(np.isnan(var.value)):
                     nan_variable_names.append(var.name)
             if nan_variable_names:
                 msg = "The following variables have NaN values: %s" % nan_variable_names

--- a/src/fastoad/io/configuration/configuration.py
+++ b/src/fastoad/io/configuration/configuration.py
@@ -20,7 +20,9 @@ import os.path as pth
 from abc import ABC, abstractmethod
 from importlib.resources import open_text
 from typing import Dict
+import warnings
 
+import numpy as np
 import openmdao.api as om
 import tomlkit
 from jsonschema import validate
@@ -230,8 +232,14 @@ class FASTOADProblemConfigurator:
         if source_file_path:
             ref_vars = DataFile(source_file_path, formatter=source_formatter)
             variables.update(ref_vars, add_variables=False)
+            nan_variable_names = []
             for var in variables:
                 var.is_input = True
+                if np.all(np.isnan(var.value)):
+                    nan_variable_names.append(var.name)
+            if nan_variable_names:
+                msg = "The following variables have NaN values: %s" % nan_variable_names
+                warnings.warn(msg)
         variables.save()
 
     def get_optimization_definition(self) -> Dict:

--- a/src/fastoad/io/configuration/configuration.py
+++ b/src/fastoad/io/configuration/configuration.py
@@ -20,7 +20,6 @@ import os.path as pth
 from abc import ABC, abstractmethod
 from importlib.resources import open_text
 from typing import Dict
-import warnings
 
 import numpy as np
 import openmdao.api as om
@@ -235,11 +234,12 @@ class FASTOADProblemConfigurator:
             nan_variable_names = []
             for var in variables:
                 var.is_input = True
+                # Checking if variables have NaN values
                 if np.all(np.isnan(var.value)):
                     nan_variable_names.append(var.name)
             if nan_variable_names:
                 msg = "The following variables have NaN values: %s" % nan_variable_names
-                warnings.warn(msg)
+                _LOGGER.warning(msg)
         variables.save()
 
     def get_optimization_definition(self) -> Dict:

--- a/src/fastoad/io/configuration/configuration.py
+++ b/src/fastoad/io/configuration/configuration.py
@@ -238,8 +238,7 @@ class FASTOADProblemConfigurator:
                 if np.any(np.isnan(var.value)):
                     nan_variable_names.append(var.name)
             if nan_variable_names:
-                msg = "The following variables have NaN values: %s" % nan_variable_names
-                _LOGGER.warning(msg)
+                _LOGGER.warning("The following variables have NaN values: %s", nan_variable_names)
         variables.save()
 
     def get_optimization_definition(self) -> Dict:

--- a/src/fastoad/io/configuration/tests/data/ref_inputs_with_nan.xml
+++ b/src/fastoad/io/configuration/tests/data/ref_inputs_with_nan.xml
@@ -1,0 +1,23 @@
+<!--
+  ~ This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
+  ~ Copyright (C) 2021 ONERA & ISAE-SUPAERO
+  ~ FAST is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  -->
+
+<aircraft>
+    <x>nan</x>
+    <z units="m**2">5.0 2.0</z>
+    <y1>nan</y1><!-- If this variable is kept in the input IVC, OpenMDAO will raise an exception because it is an output of a component
+                     As it should be ignored, its NaN value should bring no harm.-->
+    <foo>nan</foo><!-- This totally unused variable is expected to be transferred in output file -->
+    <bar>42</bar><!-- This totally unused variable is expected to be transferred in output file -->
+</aircraft>

--- a/src/fastoad/io/configuration/tests/data/ref_inputs_with_nan.xml
+++ b/src/fastoad/io/configuration/tests/data/ref_inputs_with_nan.xml
@@ -14,7 +14,7 @@
   -->
 
 <aircraft>
-    <x>nan</x>
+    <x>nan</x><!-- This variable should appear in the warning for nan values -->
     <z units="m**2">5.0 2.0</z>
     <y1>nan</y1><!-- If this variable is kept in the input IVC, OpenMDAO will raise an exception because it is an output of a component
                      As it should be ignored, its NaN value should bring no harm.-->

--- a/src/fastoad/io/configuration/tests/test_configuration.py
+++ b/src/fastoad/io/configuration/tests/test_configuration.py
@@ -115,7 +115,7 @@ def test_problem_definition_correct_configuration(cleanup):
         assert conf.output_file_path == pth.join(RESULTS_FOLDER_PATH, "outputs.xml")
 
 
-def test_problem_definition_with_xml_ref(cleanup):
+def test_problem_definition_with_xml_ref(cleanup, caplog):
     """Tests what happens when writing inputs using data from existing XML file"""
     for extension in ["toml", "yml"]:
         clear_openmdao_registry()
@@ -124,7 +124,15 @@ def test_problem_definition_with_xml_ref(cleanup):
         result_folder_path = pth.join(RESULTS_FOLDER_PATH, "problem_definition_with_xml_ref")
         conf.input_file_path = pth.join(result_folder_path, "inputs.xml")
         conf.output_file_path = pth.join(result_folder_path, "outputs.xml")
+        ref_input_data_path_with_nan = pth.join(DATA_FOLDER_PATH, "ref_inputs_with_nan.xml")
         ref_input_data_path = pth.join(DATA_FOLDER_PATH, "ref_inputs.xml")
+
+        # Test that the presence of NaN values in inputs logs a warning
+        conf.write_needed_inputs(ref_input_data_path_with_nan)
+        for record in caplog.records:
+            assert record.levelname == "WARNING"
+
+        # Test normal process without NaN in inputs
         conf.write_needed_inputs(ref_input_data_path)
         input_data = DataFile(conf.input_file_path)
         assert len(input_data) == 2

--- a/src/fastoad/io/configuration/tests/test_configuration.py
+++ b/src/fastoad/io/configuration/tests/test_configuration.py
@@ -128,9 +128,12 @@ def test_problem_definition_with_xml_ref(cleanup, caplog):
         ref_input_data_path = pth.join(DATA_FOLDER_PATH, "ref_inputs.xml")
 
         # Test that the presence of NaN values in inputs logs a warning
+        caplog.clear()
         conf.write_needed_inputs(ref_input_data_path_with_nan)
-        for record in caplog.records:
-            assert record.levelname == "WARNING"
+        assert len(caplog.records) == 1
+        record = caplog.records[0]
+        assert record.levelname == "WARNING"
+        assert record.message == "The following variables have NaN values: ['x']"
 
         # Test normal process without NaN in inputs
         conf.write_needed_inputs(ref_input_data_path)

--- a/src/fastoad/openmdao/problem.py
+++ b/src/fastoad/openmdao/problem.py
@@ -159,7 +159,7 @@ class FASTOADProblem(om.Problem):
         for name in unused_variables.names():
             del input_variables[name]
 
-        nan_variable_names = [var.name for var in input_variables if np.all(np.isnan(var.value))]
+        nan_variable_names = [var.name for var in input_variables if np.any(np.isnan(var.value))]
         if nan_variable_names:
             raise FASTOpenMDAONanInInputFile(self.input_file_path, nan_variable_names)
 


### PR DESCRIPTION
This PR closes #278 by adding a warning when NaN values are encountered in the source file of `generate_inputs`.