### PR TITLE
Updated dependency to FAST-OAD_CS25

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -344,14 +344,14 @@ test = ["pytest (>=6)"]
 
 [[package]]
 name = "fast-oad-cs25"
-version = "0.1.3"
+version = "0.1.4"
 description = "FAST-OAD_CS25 is a FAST-OAD plugin with CS25/FAR25-related models."
 category = "dev"
 optional = false
 python-versions = ">=3.7,<4.0"
 
 [package.dependencies]
-fast-oad-core = ">=1.3.0,<2.0.0"
+fast-oad-core = ">=1.4.1,<2.0.0"
 numpy = ">=1.21.0,<2.0.0"
 openmdao = ">=3.10,<4.0"
 pandas = ">=1.1.0,<2.0.0"
@@ -1951,7 +1951,7 @@ mpi4py = ["mpi4py"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "6cc2f9e82e2dde70b8075ae679aae879d45813781968f06b412ac69894be6ff7"
+content-hash = "fd3d636cf1104af53827e3dbd36def0aa33eb923edddf62db90ed17399078ca2"
 
 [metadata.files]
 aenum = [
@@ -2201,8 +2201,8 @@ exceptiongroup = [
     {file = "exceptiongroup-1.1.0.tar.gz", hash = "sha256:bcb67d800a4497e1b404c2dd44fca47d3b7a5e5433dbab67f96c1a685cdfdf23"},
 ]
 fast-oad-cs25 = [
-    {file = "FAST-OAD-CS25-0.1.3.tar.gz", hash = "sha256:9c8c6ec4e269de1d08dd662cd1e7c2d9d67db8fcf77a24f05ca9d1c0d745aae4"},
-    {file = "FAST_OAD_CS25-0.1.3-py3-none-any.whl", hash = "sha256:da9ad9a0bcc75fee02d6cdd5516f8428f0f8298dd24b11f7c93c78f23a57b041"},
+    {file = "FAST-OAD-CS25-0.1.4.tar.gz", hash = "sha256:804cab005e5d2a33599fe45f96303c549ea926635995abed5ab8ba20d4300e18"},
+    {file = "FAST_OAD_CS25-0.1.4-py3-none-any.whl", hash = "sha256:96b172c3dda2548c7f25779c15af62c37e3207ba5ff0e8404959cce00f9dba49"},
 ]
 fastjsonschema = [
     {file = "fastjsonschema-2.16.2-py3-none-any.whl", hash = "sha256:21f918e8d9a1a4ba9c22e09574ba72267a6762d47822db9add95f6454e51cc1c"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "FAST-OAD-core"
-version = "1.3.0" # This version number is overwritten by GitHub packaging workflow but setting 1.3 here will allow installation of CS25 models in development mode
+version = "1.4.1" # This version number is overwritten by GitHub packaging workflow but setting 1.3 here will allow installation of CS25 models in development mode
 description = "FAST-OAD is a framework for performing rapid Overall Aircraft Design"
 readme = "README.md"
 authors = [
@@ -72,7 +72,7 @@ mpi4py = {version = "^3", optional = true}
 mpi4py = ["mpi4py"]
 
 [tool.poetry.dev-dependencies]
-fast-oad-cs25 = "0.*"
+fast-oad-cs25 = ">=0.1.4"
 pytest = "^7.2"
 pytest-cov = "^4.0"
 coverage = { extras = ["toml"], version = "^7.0" }

--- a/release/pyproject.toml
+++ b/release/pyproject.toml
@@ -42,7 +42,7 @@ classifiers = [
 # doing again the commit including changes in docs/requirements.txt will succeed.
 python = "^3.7"
 fast-oad-core = "^1.3.0"
-fast-oad-cs25 = "0.*"
+fast-oad-cs25 = ">=0.1.4"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
Notebooks in `fast-oad-cs25` plugin have been adapted to the slight changes in mission model from FAST-OAD 1.4. Installation of version 0.1.4 of `fast-oad-cs25` requires `fast-oad-core` 1.4.1, which is Ok.

But currently, updating `fast-oad` does not trigger the update of fast-oad-cs25, hence CS25 notebooks have some problems in mass breakdown plots.

This is fixed by current PR by making `fast-oad` requiring at least `fast-oad-cs25` 0.1.4.