### PR TITLE
Now accepting upper case distribution names for plugins

### DIFF
--- a/src/conftest.py
+++ b/src/conftest.py
@@ -2,7 +2,7 @@
     Basic settings for tests
 """
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2022 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2023 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -246,7 +246,8 @@ def with_dummy_plugins():
     """
     _setup()
     dummy_dist_1 = Mock(importlib_metadata.Distribution)
-    dummy_dist_1.name = "dummy-dist-1"
+    # Here we intentionally use an unconventional name (upper case, with underscore)
+    dummy_dist_1.name = "DUMMY_DIST-1"
     dummy_dist_2 = Mock(importlib_metadata.Distribution)
     dummy_dist_2.name = "dummy-dist-2"
     dummy_dist_3 = Mock(importlib_metadata.Distribution)

--- a/src/fastoad/_utils/dicts.py
+++ b/src/fastoad/_utils/dicts.py
@@ -1,0 +1,63 @@
+"""
+Module for dict-related operations
+"""
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
+#  Copyright (C) 2023 ONERA & ISAE-SUPAERO
+#  FAST is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from abc import ABC, abstractmethod
+from typing import Any, Iterable, Mapping, TypeVar
+
+
+_KT = TypeVar("_KT", bound=Any)
+_VT = TypeVar("_VT", bound=Any)
+
+
+class AbstractNormalizedDict(ABC, dict):
+    """
+    Dictionary where keys are normalized using :meth:`normalize`.
+
+    Example::
+
+        >>> class DictWithLowerCaseKeys(AbstractNormalizedDict):
+        >>>     @staticmethod
+        >>>     def normalize(key):
+        >>>         return key.lower()
+    """
+
+    @abstractmethod
+    def normalize(self, key):
+        """Redefine this function when subclassing to define your key normalization."""
+        return key
+
+    def __init__(self, seq=None, **kwargs):
+        kwargs = {self.normalize(key): value for key, value in kwargs.items()}
+        if seq:
+            if isinstance(seq, Mapping):
+                seq = {self.normalize(key): value for key, value in seq.items()}
+            elif isinstance(seq, Iterable):
+                seq = [(self.normalize(key), value) for key, value in seq]
+            super().__init__(seq, **kwargs)
+        else:
+            super().__init__(**kwargs)
+
+    def __getitem__(self, __key: str) -> _VT:
+        return super().__getitem__(self.normalize(__key))
+
+    def __setitem__(self, __key: str, __value: _VT) -> None:
+        super().__setitem__(self.normalize(__key), __value)
+
+    def __delitem__(self, __key: _KT) -> None:
+        super().__delitem__(self.normalize(__key))
+
+    def __contains__(self, __o: object) -> bool:
+        return super().__contains__(self.normalize(__o))

--- a/src/fastoad/_utils/tests/test_dicts.py
+++ b/src/fastoad/_utils/tests/test_dicts.py
@@ -1,0 +1,45 @@
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
+#  Copyright (C) 2023 ONERA & ISAE-SUPAERO
+#  FAST is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from ..dicts import AbstractNormalizedDict
+
+
+class DictWithLowerCaseKeys(AbstractNormalizedDict):
+    @staticmethod
+    def normalize(key):
+        return key.lower()
+
+
+def test_normalized_dict():
+
+    for d in [
+        DictWithLowerCaseKeys({"Aa": "Aa", "bB": "bB"}),
+        DictWithLowerCaseKeys(Aa="Aa", bB="bB"),
+        DictWithLowerCaseKeys([("Aa", "Aa"), ("bB", "bB")]),
+        DictWithLowerCaseKeys([("Aa", "Aa")], bB="bB"),
+    ]:
+        print(d)
+
+        assert list(d.keys()) == ["aa", "bb"]
+        assert list(d.values()) == ["Aa", "bB"]
+
+        d["cC"] = "cC"
+        assert list(d.keys()) == ["aa", "bb", "cc"]
+        assert list(d.values()) == ["Aa", "bB", "cC"]
+
+        del d["bb"]
+        assert list(d.keys()) == ["aa", "cc"]
+        assert list(d.values()) == ["Aa", "cC"]
+
+        assert "aa" in d
+        assert "Aa" in d

--- a/src/fastoad/constants.py
+++ b/src/fastoad/constants.py
@@ -1,6 +1,6 @@
 """Definition of globally used constants."""
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2023 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -70,11 +70,13 @@ class RangeCategory(Enum):
     Definition of lower and upper limits of aircraft range categories, in Nautical Miles.
 
     can be used like::
+
         >>> range_value = 800.
         >>> range_value in RangeCategory.SHORT
         True
 
-    which is equivalent to:
+    which is equivalent to::
+
         >>>  RangeCategory.SHORT.min() <= range_value <= RangeCategory.SHORT.max()
     """
 

--- a/src/fastoad/module_management/tests/test_plugins.py
+++ b/src/fastoad/module_management/tests/test_plugins.py
@@ -20,14 +20,14 @@ from .._plugins import FastoadLoader, SubPackageNames
 from ..exceptions import (
     FastBundleLoaderUnknownFactoryNameError,
     FastNoAvailableConfigurationFileError,
+    FastNoAvailableSourceDataFileError,
     FastNoDistPluginError,
     FastSeveralConfigurationFilesError,
     FastSeveralDistPluginsError,
+    FastSeveralSourceDataFilesError,
     FastUnknownConfigurationFileError,
     FastUnknownDistPluginError,
-    FastNoAvailableSourceDataFileError,
     FastUnknownSourceDataFileError,
-    FastSeveralSourceDataFilesError,
 )
 from ..service_registry import RegisterService
 
@@ -140,7 +140,9 @@ def test_get_plugin_configuration_file_list(with_dummy_plugins):
     def extract_info(file_list):
         return {(item.name, item.plugin_name) for item in file_list}
 
-    file_list = FastoadLoader().get_configuration_file_list("dummy-dist-1")
+    # Provided distribution name is intentionally upper case with underscores.
+    # Should be treated as "dummy-dist-1".
+    file_list = FastoadLoader().get_configuration_file_list("DUMMY_DIST_1")
     assert extract_info(file_list) == {("dummy_conf_1-1.yml", "test_plugin_1")}
 
     file_list = FastoadLoader().get_configuration_file_list("dummy-dist-2")
@@ -162,7 +164,9 @@ def test_get_plugin_source_data_file_list(with_dummy_plugins):
     def extract_info(file_list):
         return {(item.name, item.plugin_name) for item in file_list}
 
-    file_list = FastoadLoader().get_source_data_file_list("dummy-dist-1")
+    # Provided distribution name is intentionally upper case with underscores.
+    # Should be treated as "dummy-dist-1".
+    file_list = FastoadLoader().get_source_data_file_list("DUMMY_DIST-1")
     assert extract_info(file_list) == {("dummy_source_data_4-1.xml", "test_plugin_4")}
 
     file_list = FastoadLoader().get_source_data_file_list("dummy-dist-2")
@@ -209,7 +213,9 @@ def test_get_plugin_notebook_folder_list_with_plugins(with_dummy_plugins):
         ("dummy-dist-1", "tests.dummy_plugins.dist_1.dummy_plugin_4.notebooks"),
         ("dummy-dist-3", "tests.dummy_plugins.dist_3.dummy_plugin_5.notebooks"),
     }
-    folder_list = FastoadLoader().get_notebook_folder_list("dummy-dist-1")
+    # Provided distribution name is intentionally upper case with underscores.
+    # Should be treated as "dummy-dist-1".
+    folder_list = FastoadLoader().get_notebook_folder_list("DUMMY-dist_1")
     assert extract_info(folder_list) == {
         ("dummy-dist-1", "tests.dummy_plugins.dist_1.dummy_plugin_1.notebooks"),
         ("dummy-dist-1", "tests.dummy_plugins.dist_1.dummy_plugin_4.notebooks"),


### PR DESCRIPTION
When installed from PyPI, Python package names are generally in lower case with hyphens, even if the official package is upper case (e.g. FAST-OAD-CS25).

Nevertheless, when installed in development mode using `pip install .`, the same package can be seen in `pip list` in its original form, that can contain upper case and underscores.

[PEP 426](https://peps.python.org/pep-0426/#name) clearly states that such difference should have no impact :

> All comparisons of distribution names MUST be case insensitive, and MUST consider hyphens and underscores to be equivalent.

Therefore, this PR makes sure that the distribution name of FAST-OAD plugins can be available in lower/upper case with hyphens or underscores without any impact.
