### PR TITLE
Added documentation for source data file generation

### DIFF
--- a/docs/documentation/custom_modules/add_plugin.rst
+++ b/docs/documentation/custom_modules/add_plugin.rst
@@ -12,13 +12,13 @@ you may want to share them with other users, which can be done in two ways:
     - Packaging your code as a FAST-OAD plugin and have them install it through :code:`pip`
       or equivalent. This is the subject of current chapter.
 
-A FAST-OAD plugin can provide additional FAST-OAD modules, Jupyter notebooks and configuration files:
+A FAST-OAD plugin can provide additional FAST-OAD modules, Jupyter notebooks, configuration files and source data files:
 
     - plugin-provided FAST-OAD modules are usable in :ref:`configuration files <configuration-file>`,
       and can be :ref:`listed<get-module-list>` and :ref:`used<configuration-file-problem-definition>`
       in the same way as native modules.
-    - Command line can be used by users to retrieve :ref:`notebooks<python-usage>` and
-      :ref:`configuration files<generate-conf-file>`.
+    - Command line can be used by users to retrieve :ref:`notebooks<python-usage>`,
+      :ref:`configuration files<generate-conf-file>` and :ref:`source data files<generate-source-data_file>`.
 
 Plugin structure
 ################
@@ -37,12 +37,17 @@ In your source folder, a typical plugin structure would be like this::
     │       ├── __init__.py
     │       └── some_more_code.py
     └── notebooks/
+    │   ├── __init__.py
+    │   ├── any_data/
+    │   │   ├── __init__.py
+    │   │   └── some_data.xml
+    │   ├── awesome_notebook.ipynb
+    │   └── good_notebook.ipynb
+    └── source_data_files
         ├── __init__.py
-        ├── any_data/
-        │   ├── __init__.py
-        │   └── some_data.xml
-        ├── awesome_notebook.ipynb
-        └── good_notebook.ipynb
+        ├── source_data_file_1.xml
+        ├── source_data_file_2.xml
+        └── source_data_file_3.xml
 
 As shown above, the expected structure is composed of Python **packages**, i.e. every folder should
 contain a :code:`__init__.py` file, **even if it contains only non-Python files** (e.g. data for notebooks).
@@ -58,6 +63,7 @@ Expected folders in a plugin package are:
       or API method :meth:`~fastoad.cmd.api.generate_configuration_file`.
     - :code:`notebooks`: contains any number of Jupyter notebooks and associated data, that will
       be made available to users through :ref:`command line<python-usage>`.
+    - :code:`source_data_files`: contains only source data files in XML format. As for the :code:`configurations` package, no sub-folder is allowed. These source data files will be usable through :ref:`command line<generate-source-data_file>` or API method :meth:`~fastoad.cmd.api.generate_source_data_file`.
 
 Any of these folders is optional. Any other folder will be ignored.
 
@@ -104,7 +110,7 @@ that your project structure contains::
     └── ...
 
 As previously stated, your folder :code:`src/star_trek/drives` does not have to contain all of the
-folders :code:`models`, :code:`configurations` nor :code:`notebooks`.
+folders :code:`models`, :code:`configurations`, :code:`notebooks` nor :code:`source_data_files`.
 
 Assuming you project contains the package :code:`star_trek.drives` that contains
 models you want to share, you can declare your plugin in your :code:`pyproject.toml`

--- a/docs/documentation/custom_modules/add_plugin.rst
+++ b/docs/documentation/custom_modules/add_plugin.rst
@@ -36,7 +36,7 @@ In your source folder, a typical plugin structure would be like this::
     │   └── some_subpackage/
     │       ├── __init__.py
     │       └── some_more_code.py
-    └── notebooks/
+    ├── notebooks/
     │   ├── __init__.py
     │   ├── any_data/
     │   │   ├── __init__.py

--- a/docs/documentation/usage.rst
+++ b/docs/documentation/usage.rst
@@ -399,7 +399,7 @@ your new input files with:
 
     $ fastoad gen_inputs my_conf.yml my_ref_values.xml
 
-If you are using the configuration file provided by the gen_conf sub-command (see :ref:`how to generate a configuration file<generate-conf-file>`), you may download our `CeRAS01_baseline.xml <https://github.com/fast-aircraft-design/FAST-OAD/raw/v0.1a/src/fastoad/notebooks/tutorial/data/CeRAS01_baseline.xml>`_ and use it as source for generating your input file. You may also generate a source data file using the appropriate command (see :ref:`how to generate a source data file<generate-source-data_file>`)
+If you are using the configuration file provided by the gen_conf sub-command (see :ref:`generate-conf-file`), you may download our `CeRAS01_baseline.xml <https://github.com/fast-aircraft-design/FAST-OAD/raw/v0.1a/src/fastoad/notebooks/tutorial/data/CeRAS01_baseline.xml>`_ and use it as source for generating your input file. You may also generate a source data file using the appropriate command (see :ref:`generate-source-data_file`)
 
 .. _generate-source-data_file:
 

--- a/docs/documentation/usage.rst
+++ b/docs/documentation/usage.rst
@@ -399,8 +399,23 @@ your new input files with:
 
     $ fastoad gen_inputs my_conf.yml my_ref_values.xml
 
-If you are using the configuration file provided by the gen_conf sub-command (see :ref`Generate conf file`), you may download our `CeRAS01_baseline.xml <https://github.com/fast-aircraft-design/FAST-OAD/raw/v0.1a/src/fastoad/notebooks/tutorial/data/CeRAS01_baseline.xml>`_ and use it as source for generating your input file.
+If you are using the configuration file provided by the gen_conf sub-command (see :ref:`how to generate a configuration file<generate-conf-file>`), you may download our `CeRAS01_baseline.xml <https://github.com/fast-aircraft-design/FAST-OAD/raw/v0.1a/src/fastoad/notebooks/tutorial/data/CeRAS01_baseline.xml>`_ and use it as source for generating your input file. You may also generate a source data file using the appropriate command (see :ref:`how to generate a source data file<generate-source-data_file>`)
 
+.. _generate-source-data_file:
+
+How to generate a source data file
+==================================
+
+As for the configuration file, FAST-OAD can provide a source data file usable for the generation of your input file.
+
+.. code:: shell-session
+
+    $ fastoad gen_source_data_file my_source_data_file.xml --from_package my_plugin_package --source sample_source_data_file_1.xml
+
+This copies the file :code:`sample_source_data_file_1.xml` provided by installed package
+:code:`my_plugin_package` to file :code:`my_source_data_file.xml`.
+
+The remarks made in section :ref:`how to generate a configuration file<generate-conf-file>` on options :code:`--from_package` and :code:`--source` remain valid when generating a source data file.
 
 .. _view-problem:
 


### PR DESCRIPTION
A documentation on the commands introduced in PR #477 was forgotten and consequently added here. I propose to put the section on source file generation after the section on the generation of input because this is where source file are first mentionned as a way to "fill" an input file. Additionally a reference to a former section was not working, it should be fixed.