### PR TITLE
Setting group options from configuration file

### DIFF
--- a/docs/documentation/usage.rst
+++ b/docs/documentation/usage.rst
@@ -158,6 +158,10 @@ Problem definition
 
 .. code:: yaml
 
+    model:
+      nonlinear_solver: om.NonlinearBlockGS(maxiter=100, atol=1e-2)
+      linear_solver: om.DirectSolver()
+
       # Components can be put in sub-groups
       subgroup:
 
@@ -202,14 +206,21 @@ Problem definition
 Components of the model can be modules, or sub-groups. They are defined as a sub-section of
 :code:`model:`. Sub-sections and sub-components can be freely named by user.
 
-A sub-group gathers several modules and can be set with its own solvers to resolve cycles it may contains.
+A sub-group gathers several modules and/or other sub-groups and can be set with its own solvers
+to resolve cycles it may contains, using keys :code:`linear_solver` and :code:`nonlinear_solver`,
+like :code:`model` (that is merely the root group).
 
 Here above, a sub-group with geometric, weight, handling-qualities and aerodynamic modules is defined and
 internal solvers are activated. Performance and wing area computation modules are set apart.
 
-A module is defined by its :code:`id:` key that refers to the module registered name, but additional keys can be
-used, depending on the options of the module. The list of available options of a module is
-available through the :code:`list_modules` sub-command (see :ref:`get-module-list`).
+A module is defined by its :code:`id:` key that refers to the module registered name.
+
+Additional keys can be used in :code:`model`, sub-groups and modules. They are interpreted
+as option settings:
+
+- For :code:`model` and sub-groups, the OpenMDAO options for Group class apply.
+- For FAST-OAD modules, the list of available options is available through the :code:`list_modules`
+  sub-command (see :ref:`get-module-list`).
 
 
 Optimization settings

--- a/src/fastoad/io/configuration/resources/configuration.json
+++ b/src/fastoad/io/configuration/resources/configuration.json
@@ -5,6 +5,9 @@
   "description": "Schema for FAST-OAD configuration files",
   "type": "object",
   "definitions": {
+    "option": {
+      "$comment": "Setting of an OpenMDAO option"
+    },
     "component": {
       "$comment": "Definition of an OpenMDAO component/FAST-OAD module",
       "type": "object",
@@ -27,6 +30,9 @@
           },
           {
             "$ref": "#/definitions/component"
+          },
+          {
+            "$ref": "#/definitions/option"
           }
         ]
       },
@@ -137,7 +143,10 @@
     },
     "submodels": {
       "additionalProperties": {
-        "type": ["string", "null"]
+        "type": [
+          "string",
+          "null"
+        ]
       }
     },
     "optimization": {
@@ -169,7 +178,10 @@
           }
         }
       },
-      "required": ["design_variables", "objective"]
+      "required": [
+        "design_variables",
+        "objective"
+      ]
     }
   },
   "required": [

--- a/src/fastoad/io/configuration/tests/data/valid_sellar.toml
+++ b/src/fastoad/io/configuration/tests/data/valid_sellar.toml
@@ -12,6 +12,7 @@ output_file = "../results/outputs.xml"
 
 driver = "om.ScipyOptimizeDriver(optimizer='SLSQP')"
 [model]
+    assembled_jac_type = "csc"  # Tests the ability to set options for groups
     [[model.connections]]
         source = "y1"
         target = "yy1"

--- a/src/fastoad/io/configuration/tests/data/valid_sellar.yml
+++ b/src/fastoad/io/configuration/tests/data/valid_sellar.yml
@@ -9,6 +9,7 @@ output_file: ../results/outputs.xml
 
 driver: om.ScipyOptimizeDriver(optimizer='SLSQP')
 model:
+  assembled_jac_type: csc  # Tests the ability to set options for groups
   connections:
     - source: y1
       target: yy1

--- a/src/fastoad/io/configuration/tests/data/valid_sellar_alternate.toml
+++ b/src/fastoad/io/configuration/tests/data/valid_sellar_alternate.toml
@@ -12,6 +12,7 @@ output_file = "../results/outputs.xml"
 
 driver = "om.ScipyOptimizeDriver(optimizer='SLSQP')"
 [model]
+    assembled_jac_type = "dense"  # Tests the ability to set options for groups
     [[model.connections]]
         source = "y1"
         target = "yy1"

--- a/src/fastoad/io/configuration/tests/data/valid_sellar_alternate.yml
+++ b/src/fastoad/io/configuration/tests/data/valid_sellar_alternate.yml
@@ -9,6 +9,7 @@ output_file: ../results/outputs.xml
 
 driver: om.ScipyOptimizeDriver(optimizer='SLSQP')
 model:
+  assembled_jac_type: dense  # Tests the ability to set options for groups
   connections:
     - source: y1
       target: yy1

--- a/src/fastoad/io/configuration/tests/test_configuration.py
+++ b/src/fastoad/io/configuration/tests/test_configuration.py
@@ -2,7 +2,7 @@
 Test module for configuration.py
 """
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -146,6 +146,7 @@ def test_problem_definition_with_xml_ref(cleanup, caplog):
         # runs evaluation without optimization loop to check that inputs are taken into account
         problem.setup()
         problem.run_model()
+        assert problem.model.options["assembled_jac_type"] == "csc"
         assert problem["f"] == pytest.approx(28.58830817, abs=1e-6)
         problem.write_outputs()
 
@@ -161,6 +162,7 @@ def test_problem_definition_with_xml_ref(cleanup, caplog):
         alt_problem.run_model()
         alt_problem.write_outputs()
 
+        assert alt_problem.model.options["assembled_jac_type"] == "dense"
         assert alt_problem["f"] == pytest.approx(0.58830817, abs=1e-6)
         assert alt_problem["g2"] == pytest.approx(-11.94151185, abs=1e-6)
         with pytest.raises(KeyError):


### PR DESCRIPTION
This PR allows setting values of options for an OpenMDAO group.

In particular, it will allow using the `auto_order` feature introduced by OpenMDAO 3.28.

As for FAST-OAD modules, options can be set simply by a `<key>: <value>` in the corresponding section.

This is a bit inconsistent with the settings of `linear_solver `and `nonlinear_solver`, that are attributes and not options, and will yet be at the same level in the configuration file. But it looked like it was worth privileging the consistency with the setting of module options.

Documentation has been updated and can be previewed [here](https://fast-oad.readthedocs.io/en/group-options/documentation/usage.html#problem-definition).