### PR TITLE
Avoiding unnecessary setup operations

### DIFF
--- a/src/fastoad/openmdao/_utils.py
+++ b/src/fastoad/openmdao/_utils.py
@@ -27,7 +27,7 @@ from openmdao.utils.mpi import FakeComm
 T = TypeVar("T", bound=om.Problem)
 
 
-def get_problem_copy_without_mpi(problem: T) -> T:
+def get_mpi_safe_problem_copy(problem: T) -> T:
     """
     This function does a deep copy of input OpenMDAO problem while avoiding
     the crash that can occur if problem.comm is not pickle-able, like a

--- a/src/fastoad/openmdao/problem.py
+++ b/src/fastoad/openmdao/problem.py
@@ -24,7 +24,7 @@ from fastoad.io import DataFile, IVariableIOFormatter, VariableIO
 from fastoad.module_management.service_registry import RegisterSubmodel
 from fastoad.openmdao.validity_checker import ValidityDomainChecker
 from fastoad.openmdao.variables import Variable, VariableList
-from ._utils import get_problem_copy_without_mpi
+from ._utils import get_mpi_safe_problem_copy
 from .exceptions import FASTOpenMDAONanInInputFile
 from ..module_management._bundle_loader import BundleLoader
 
@@ -355,13 +355,13 @@ class ProblemAnalysis:
         """
         Gets information about inner structure of the associated problem.
         """
-        problem_copy = get_problem_copy_without_mpi(self.problem)
+        problem_copy = get_mpi_safe_problem_copy(self.problem)
         try:
             om.Problem.setup(problem_copy)
         except RuntimeError:
             self.dynamic_input_vars = self._get_undetermined_dynamic_vars(problem_copy)
 
-            problem_copy = get_problem_copy_without_mpi(self.problem)
+            problem_copy = get_mpi_safe_problem_copy(self.problem)
             self.fills_dynamically_shaped_inputs(problem_copy)
             om.Problem.setup(problem_copy)
 

--- a/src/fastoad/openmdao/variables/_util.py
+++ b/src/fastoad/openmdao/variables/_util.py
@@ -1,6 +1,6 @@
 """Utilities for VariableList."""
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2023 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -18,7 +18,7 @@ from typing import Tuple
 import numpy as np
 from openmdao.core.constants import _SetupStatus
 
-from fastoad.openmdao._utils import problem_without_mpi
+from fastoad.openmdao._utils import get_problem_copy_without_mpi
 
 
 def get_problem_variables(
@@ -44,9 +44,8 @@ def get_problem_variables(
     :return: input dict, output dict
     """
     if not problem._metadata or problem._metadata["setup_status"] < _SetupStatus.POST_SETUP:
-        with problem_without_mpi(problem) as problem_copy:
-            problem_copy.setup()
-            problem = problem_copy
+        problem = get_problem_copy_without_mpi(problem)
+        problem.setup()
 
     # Get inputs and outputs
     metadata_keys = (

--- a/src/fastoad/openmdao/variables/_util.py
+++ b/src/fastoad/openmdao/variables/_util.py
@@ -18,7 +18,7 @@ from typing import Tuple
 import numpy as np
 from openmdao.core.constants import _SetupStatus
 
-from fastoad.openmdao._utils import get_problem_copy_without_mpi
+from fastoad.openmdao._utils import get_mpi_safe_problem_copy
 
 
 def get_problem_variables(
@@ -44,7 +44,7 @@ def get_problem_variables(
     :return: input dict, output dict
     """
     if not problem._metadata or problem._metadata["setup_status"] < _SetupStatus.POST_SETUP:
-        problem = get_problem_copy_without_mpi(problem)
+        problem = get_mpi_safe_problem_copy(problem)
         problem.setup()
 
     # Get inputs and outputs

--- a/tests/integration_tests/oad_process/test_oad_process.py
+++ b/tests/integration_tests/oad_process/test_oad_process.py
@@ -2,7 +2,7 @@
 Test module for Overall Aircraft Design process
 """
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2023 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -50,12 +50,11 @@ def test_oad_process(cleanup):
 
     configurator = FASTOADProblemConfigurator(pth.join(DATA_FOLDER_PATH, "oad_process.yml"))
 
-    # Create inputs
     ref_inputs = pth.join(DATA_FOLDER_PATH, "CeRAS01_legacy.xml")
-    configurator.write_needed_inputs(ref_inputs)
+    problem = configurator.get_problem()
+    problem.write_needed_inputs(ref_inputs)
+    problem.read_inputs()
 
-    # Create problems with inputs
-    problem = configurator.get_problem(read_inputs=True)
     problem.setup()
     problem.run_model()
     problem.write_outputs()


### PR DESCRIPTION
This PR fixes some performance problems of FAST-OAD.

To get knowledge of the structure of OpenMDAO problems, a setup operation is needed. Until now, due to the several changes that were done separately, this setup operation was done almost each time information was needed, which proved to be CPU costly. 

Here the problem analysis is done in only one place, which allows to reduce to the minimum the number of setup calls. There is still one "additional" setup operation needed to analyze the problem, and possibly another one if dynamically shaped variables are inputs of the problem.

Also, `write_needed_inputs` implementation has been put back in `FASTOADPoblem` (while keeping the `FASTOADProblemConfigurator` method), which allows to spare 2 setup calls when called on the problem instance that will do the computation (when done from `FASTOADProblemConfigurator`, it is done on a separate instance).

As a result, the integration test `test_oad_process` uses now 2 setup calls, instead of 10 previously.