### PR TITLE
Consumed fuel is now directly computed for each time step

### DIFF
--- a/src/fastoad/model_base/flight_point.py
+++ b/src/fastoad/model_base/flight_point.py
@@ -83,6 +83,7 @@ class FlightPoint:
     isa_offset: float = 0.0  #: temperature deviation from Standard Atmosphere
     ground_distance: float = 0.0  #: Covered ground distance in meters.
     mass: float = None  #: Mass in kg.
+    consumed_mass: float = 0.0  #: Consumed mass since mission start, in kg.
     true_airspeed: float = None  #: True airspeed (TAS) in m/s.
     equivalent_airspeed: float = None  #: Equivalent airspeed (EAS) in m/s.
     mach: float = None  #: Mach number.
@@ -112,6 +113,7 @@ class FlightPoint:
         altitude="m",
         ground_distance="m",
         mass="kg",
+        consumed_mass="kg",
         true_airspeed="m/s",
         equivalent_airspeed="m/s",
         mach="-",

--- a/src/fastoad/model_base/flight_point.py
+++ b/src/fastoad/model_base/flight_point.py
@@ -83,7 +83,7 @@ class FlightPoint:
     isa_offset: float = 0.0  #: temperature deviation from Standard Atmosphere
     ground_distance: float = 0.0  #: Covered ground distance in meters.
     mass: float = None  #: Mass in kg.
-    consumed_mass: float = 0.0  #: Consumed mass since mission start, in kg.
+    consumed_fuel: float = 0.0  #: Consumed fuel since mission start, in kg.
     true_airspeed: float = None  #: True airspeed (TAS) in m/s.
     equivalent_airspeed: float = None  #: Equivalent airspeed (EAS) in m/s.
     mach: float = None  #: Mach number.
@@ -113,7 +113,7 @@ class FlightPoint:
         altitude="m",
         ground_distance="m",
         mass="kg",
-        consumed_mass="kg",
+        consumed_fuel="kg",
         true_airspeed="m/s",
         equivalent_airspeed="m/s",
         mach="-",

--- a/src/fastoad/models/performances/mission/base.py
+++ b/src/fastoad/models/performances/mission/base.py
@@ -74,15 +74,12 @@ class FlightSequence(IFlightPart):
         part_start.scalarize()
 
         self.consumed_mass_before_input_weight = 0.0
-        consumed_mass = 0.0
         for part in self._sequence:
             # This check has to be done first because relative target parameters
             # will be made absolute during compute_from()
             part_has_target_mass = not (part.target.mass is None or part.target.is_relative("mass"))
 
             flight_points = part.compute_from(part_start)
-
-            consumed_mass += flight_points.iloc[0].mass - flight_points.iloc[-1].mass
 
             if isinstance(part, FlightSequence):
                 self.consumed_mass_before_input_weight += part.consumed_mass_before_input_weight
@@ -94,7 +91,7 @@ class FlightSequence(IFlightPart):
                 mass_offset = flight_points.iloc[0].mass - part_start.mass
                 for previous_flight_points in self.part_flight_points:
                     previous_flight_points.mass += mass_offset
-                self.consumed_mass_before_input_weight = float(consumed_mass)
+                self.consumed_mass_before_input_weight = flight_points.iloc[-1].consumed_fuel
 
             if len(self.part_flight_points) > 0 and len(flight_points) > 1:
                 # First point of the segment is omitted, as it is the last of previous segment.

--- a/src/fastoad/models/performances/mission/mission.py
+++ b/src/fastoad/models/performances/mission/mission.py
@@ -19,7 +19,6 @@ from dataclasses import dataclass, field
 from typing import Optional
 
 import pandas as pd
-from numpy.testing import assert_allclose
 from scipy.optimize import root_scalar
 
 from fastoad.model_base import FlightPoint
@@ -88,24 +87,6 @@ class Mission(FlightSequence):
         else:
             self._solve_cruise_distance(start)
 
-        try:
-            # Custom segment implementations may omit to update the "consumed_mass" field.
-            # It is better to check that.
-            assert_allclose(
-                self._flight_points.iloc[0].mass - self._flight_points.iloc[-1].mass,
-                self._flight_points.iloc[-1].consumed_mass,
-                atol=1e-10,
-                rtol=1e-6,
-            )
-        except AssertionError:
-            _LOGGER.warning(
-                'Inconsistency between final value of "consumed_field" (%.1f kg) '
-                "and mass difference between start and end of mission (%.1f kg). "
-                "The latter one is assumed correct. Probably some "
-                'flight segment implementation does not update "consumed_field".',
-                self._flight_points.iloc[-1].consumed_mass,
-                self._flight_points.iloc[0].mass - self._flight_points.iloc[-1].mass,
-            )
         return self._flight_points
 
     def get_reserve_fuel(self):

--- a/src/fastoad/models/performances/mission/mission.py
+++ b/src/fastoad/models/performances/mission/mission.py
@@ -55,11 +55,7 @@ class Mission(FlightSequence):
         if self._flight_points is None:
             return None
 
-        return (
-            self._flight_points.mass.iloc[0]
-            - self._flight_points.mass.iloc[-1]
-            + self.get_reserve_fuel()
-        )
+        return self._flight_points.iloc[-1].consumed_fuel + self.get_reserve_fuel()
 
     @property
     def first_route(self) -> RangedRoute:

--- a/src/fastoad/models/performances/mission/openmdao/mission_run.py
+++ b/src/fastoad/models/performances/mission/openmdao/mission_run.py
@@ -121,11 +121,8 @@ class MissionComp(om.ExplicitComponent, BaseMissionComp):
 
     def _compute_outputs(self, outputs, flight_points):
         # Final ================================================================
-        start_of_mission = FlightPoint.create(flight_points.iloc[0])
         end_of_mission = FlightPoint.create(flight_points.iloc[-1])
-        outputs[self.name_provider.NEEDED_BLOCK_FUEL.value] = (
-            start_of_mission.mass - end_of_mission.mass
-        )
+        outputs[self.name_provider.NEEDED_BLOCK_FUEL.value] = end_of_mission.consumed_fuel
         reserve_var_name = self._mission_wrapper.get_reserve_variable_name()
         if reserve_var_name in outputs:
             outputs[self.name_provider.NEEDED_BLOCK_FUEL.value] += outputs[

--- a/src/fastoad/models/performances/mission/segments/base.py
+++ b/src/fastoad/models/performances/mission/segments/base.py
@@ -1,6 +1,6 @@
 """Base classes for simulating flight segments."""
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2023 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -122,7 +122,6 @@ class AbstractFlightSegment(IFlightPart, ABC):
         However, when subclassing, the method to overload is :meth:`compute_from_start_to_target`.
         Generic reprocessing of start and target flight points is done in :meth:`compute_from`
         before calling :meth:`compute_from_start_to_target`
-
     """
 
     #: A FlightPoint instance that provides parameter values that should all be reached at the
@@ -191,8 +190,9 @@ class AbstractFlightSegment(IFlightPart, ABC):
         .. Important::
 
             When subclasssing, if you need to overload :meth:`compute_from`, you should consider
-            overriding :meth:`_compute_from` instead. Therefore, you will take benefit of the
-            preprocessing of start and target flight points that is done in :meth:`compute_from`
+            overriding :meth:`compute_from_start_to_target` instead. Therefore, you will take
+            benefit of the preprocessing of start and target flight points that is done in
+            :meth:`compute_from`.
 
 
         :param start: the initial flight point, defined for `altitude`, `mass` and speed
@@ -274,12 +274,12 @@ class AbstractFlightSegment(IFlightPart, ABC):
         """
         This method should be used whenever fuel consumption has to be stored.
 
-        It ensures that "mass" and "consumed_fuel" fields will be kep consistent.
+        It ensures that "mass" and "consumed_fuel" fields will be kept consistent.
 
         Mass can be modified using the 'fuel_consumption" argument, or the 'mass_ratio'
         argument. One of them should be provided.
 
-        :param flight_point: the FlighPoint instance where "mass" and "consumed_fuel"
+        :param flight_point: the FlightPoint instance where "mass" and "consumed_fuel"
                              fields will get new values
         :param previous: FlightPoint instance that will be the base for the computation
         :param fuel_consumption: consumed fuel, in kg, between 'previous' and 'flight_point'.

--- a/src/fastoad/models/performances/mission/segments/base.py
+++ b/src/fastoad/models/performances/mission/segments/base.py
@@ -264,6 +264,37 @@ class AbstractFlightSegment(IFlightPart, ABC):
             if getattr(flight_point, field_name) is None and not source.is_relative(field_name):
                 setattr(flight_point, field_name, getattr(source, field_name))
 
+    @staticmethod
+    def consume_fuel(
+        flight_point: FlightPoint,
+        previous: FlightPoint,
+        fuel_consumption: float = None,
+        mass_ratio: float = None,
+    ):
+        """
+        This method should be used whenever fuel consumption has to be stored.
+
+        It ensures that "mass" and "consumed_fuel" fields will be kep consistent.
+
+        Mass can be modified using the 'fuel_consumption" argument, or the 'mass_ratio'
+        argument. One of them should be provided.
+
+        :param flight_point: the FlighPoint instance where "mass" and "consumed_fuel"
+                             fields will get new values
+        :param previous: FlightPoint instance that will be the base for the computation
+        :param fuel_consumption: consumed fuel, in kg, between 'previous' and 'flight_point'.
+                                 Positive when fuel is consumed.
+        :param mass_ratio: the ratio flight_point.mass/previous.mass
+        """
+        flight_point.mass = previous.mass
+        flight_point.consumed_fuel = previous.consumed_fuel
+        if fuel_consumption is not None:
+            flight_point.mass -= fuel_consumption
+            flight_point.consumed_fuel += fuel_consumption
+        if mass_ratio is not None:
+            flight_point.mass *= mass_ratio
+            flight_point.consumed_fuel += previous.mass - flight_point.mass
+
     def _complete_speed_values(
         self, flight_point: FlightPoint, raise_error_on_missing_speeds=True
     ) -> bool:

--- a/src/fastoad/models/performances/mission/segments/registered/cruise.py
+++ b/src/fastoad/models/performances/mission/segments/registered/cruise.py
@@ -222,6 +222,7 @@ class BreguetCruiseSegment(CruiseSegment):
 
         end = deepcopy(start)
         end.mass = start.mass * cruise_mass_ratio
+        end.consumed_mass = start.consumed_mass + start.mass - end.mass
         end.ground_distance = target.ground_distance
         end.time = start.time + (end.ground_distance - start.ground_distance) / end.true_airspeed
         end.name = self.name

--- a/src/fastoad/models/performances/mission/segments/registered/cruise.py
+++ b/src/fastoad/models/performances/mission/segments/registered/cruise.py
@@ -221,8 +221,7 @@ class BreguetCruiseSegment(CruiseSegment):
         )
 
         end = deepcopy(start)
-        end.mass = start.mass * cruise_mass_ratio
-        end.consumed_mass = start.consumed_mass + start.mass - end.mass
+        self.consume_fuel(end, previous=start, mass_ratio=cruise_mass_ratio)
         end.ground_distance = target.ground_distance
         end.time = start.time + (end.ground_distance - start.ground_distance) / end.true_airspeed
         end.name = self.name

--- a/src/fastoad/models/performances/mission/segments/registered/transition.py
+++ b/src/fastoad/models/performances/mission/segments/registered/transition.py
@@ -56,6 +56,8 @@ class DummyTransitionSegment(AbstractFlightSegment):
         if end.mass is None:
             end.mass = start.mass * self.mass_ratio
 
+        end.consumed_mass = start.consumed_mass + start.mass - end.mass
+
         self.complete_flight_point_from(end, start)
         self.complete_flight_point(end)
 
@@ -64,6 +66,7 @@ class DummyTransitionSegment(AbstractFlightSegment):
         if self.reserve_mass_ratio > 0.0:
             reserve = deepcopy(end)
             reserve.mass = end.mass / (1.0 + self.reserve_mass_ratio)
+            reserve.consumed_mass = reserve.consumed_mass + end.mass - reserve.mass
             flight_points.append(reserve)
 
         return pd.DataFrame(flight_points)

--- a/src/fastoad/models/performances/mission/segments/registered/transition.py
+++ b/src/fastoad/models/performances/mission/segments/registered/transition.py
@@ -54,9 +54,9 @@ class DummyTransitionSegment(AbstractFlightSegment):
         end.name = self.name
 
         if end.mass is None:
-            end.mass = start.mass * self.mass_ratio
-
-        end.consumed_mass = start.consumed_mass + start.mass - end.mass
+            self.consume_fuel(end, previous=start, mass_ratio=self.mass_ratio)
+        else:
+            end.consumed_fuel = start.consumed_fuel + start.mass - end.mass
 
         self.complete_flight_point_from(end, start)
         self.complete_flight_point(end)
@@ -66,7 +66,9 @@ class DummyTransitionSegment(AbstractFlightSegment):
         if self.reserve_mass_ratio > 0.0:
             reserve = deepcopy(end)
             reserve.mass = end.mass / (1.0 + self.reserve_mass_ratio)
-            reserve.consumed_mass = reserve.consumed_mass + end.mass - reserve.mass
+            self.consume_fuel(
+                reserve, previous=end, mass_ratio=1.0 / (1.0 + self.reserve_mass_ratio)
+            )
             flight_points.append(reserve)
 
         return pd.DataFrame(flight_points)

--- a/src/fastoad/models/performances/mission/segments/time_step_base.py
+++ b/src/fastoad/models/performances/mission/segments/time_step_base.py
@@ -244,7 +244,7 @@ class AbstractTimeStepFlightSegment(
         next_point.isa_offset = self.isa_offset
         consumed_mass = self.propulsion.get_consumed_mass(previous, time_step)
         next_point.mass = previous.mass - consumed_mass
-        next_point.consumed_mass = previous.consumed_mass + consumed_mass
+        next_point.consumed_fuel = previous.consumed_fuel + consumed_mass
 
         next_point.time = previous.time + time_step
         next_point.ground_distance = (

--- a/src/fastoad/models/performances/mission/segments/time_step_base.py
+++ b/src/fastoad/models/performances/mission/segments/time_step_base.py
@@ -242,7 +242,10 @@ class AbstractTimeStepFlightSegment(
         next_point = FlightPoint()
 
         next_point.isa_offset = self.isa_offset
-        next_point.mass = previous.mass - self.propulsion.get_consumed_mass(previous, time_step)
+        consumed_mass = self.propulsion.get_consumed_mass(previous, time_step)
+        next_point.mass = previous.mass - consumed_mass
+        next_point.consumed_mass = previous.consumed_mass + consumed_mass
+
         next_point.time = previous.time + time_step
         next_point.ground_distance = (
             previous.ground_distance

--- a/src/fastoad/models/performances/mission/tests/test_mission.py
+++ b/src/fastoad/models/performances/mission/tests/test_mission.py
@@ -114,7 +114,7 @@ def test_mission(low_speed_polar, high_speed_polar, propulsion):
         ground_distance=100000.0,
     )
 
-    # Test mission with fixed route distances
+    # Test mission with fixed route distances ----------------------------------
     mission_1 = Mission(name="mission1")
     mission_1.extend([first_route, second_route])
 
@@ -132,8 +132,14 @@ def test_mission(low_speed_polar, high_speed_polar, propulsion):
         26953.0,
         atol=1.0,
     )
+    assert_allclose(
+        flight_points.iloc[0].mass - flight_points.iloc[-1].mass,
+        flight_points.iloc[-1].consumed_fuel,
+        atol=1e-10,
+        rtol=1e-6,
+    )
 
-    # Test mission with fixed route distances and reserve
+    # Test mission with fixed route distances and reserve ----------------------
     mission_2 = Mission(name="mission2", reserve_ratio=0.03)
     mission_2.extend([first_route, second_route])
 
@@ -152,7 +158,14 @@ def test_mission(low_speed_polar, high_speed_polar, propulsion):
         atol=1.0,
     )
 
-    # Test with objective fuel, with 2 routes
+    assert_allclose(
+        flight_points.iloc[0].mass - flight_points.iloc[-1].mass,
+        flight_points.iloc[-1].consumed_fuel,
+        atol=1e-10,
+        rtol=1e-6,
+    )
+
+    # Test with objective fuel, with 2 routes ----------------------------------
     mission_3 = Mission(
         name="mission3",
         target_fuel_consumption=20000.0,
@@ -164,7 +177,14 @@ def test_mission(low_speed_polar, high_speed_polar, propulsion):
         20000.0,
         mission_3.fuel_accuracy,
     )
-    # Test with objective fuel, when mission does not start with a route
+    assert_allclose(
+        flight_points.iloc[0].mass - flight_points.iloc[-1].mass,
+        flight_points.iloc[-1].consumed_fuel,
+        atol=1e-10,
+        rtol=1e-6,
+    )
+
+    # Test with objective fuel, when mission does not start with a route -------
     mission_4 = Mission(name="mission4", target_fuel_consumption=20000.0)
     mission_4.extend([taxi_out, first_route, second_route])
 
@@ -173,4 +193,11 @@ def test_mission(low_speed_polar, high_speed_polar, propulsion):
         flight_points.mass.iloc[0] - flight_points.mass.iloc[-1],
         20000.0,
         mission_4.fuel_accuracy,
+    )
+
+    assert_allclose(
+        flight_points.iloc[0].mass - flight_points.iloc[-1].mass,
+        flight_points.iloc[-1].consumed_fuel,
+        atol=1e-10,
+        rtol=1e-6,
     )


### PR DESCRIPTION
This PR simply adds the `consumed_fuel` column in mission csv output file.

This is done by adding this field in FlightPoint class. Though this information is somehow redundant with the `mass` field, it may prove useful to know at each step of the mission the consumed fuel without having to know what was the start mass of the aircraft.