### PR TITLE
Fix for validity domain checker

### DIFF
--- a/src/fastoad/openmdao/tests/openmdao_sellar_example/disc1.py
+++ b/src/fastoad/openmdao/tests/openmdao_sellar_example/disc1.py
@@ -1,6 +1,6 @@
 """Sellar discipline 1"""
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -15,7 +15,10 @@
 import numpy as np
 import openmdao.api as om
 
+from ...validity_checker import ValidityDomainChecker
 
+
+@ValidityDomainChecker({"x": (-1, 1)})  # This validity domain should not apply
 class Disc1(om.ExplicitComponent):
     """An OpenMDAO component to encapsulate Disc1 discipline"""
 
@@ -42,3 +45,35 @@ class Disc1(om.ExplicitComponent):
         y2 = inputs["y2"]
 
         outputs["y1"] = z1 ** 2 + z2 + x1 - 0.2 * y2
+
+
+@ValidityDomainChecker({"x": (0, 4)})  # This validity domain should apply in case 1
+class Disc1Bis(om.ExplicitComponent):
+    """An OpenMDAO component to encapsulate Disc1 discipline"""
+
+    def setup(self):
+        self.add_input("x", val=2.0, desc="input x")  # NaN as default for testing connexion check
+        self.add_input("z", val=[5, 2], desc="", units="m**2")  # for testing non-None units
+        self.add_input("y2", val=1.0, desc="variable y2")  # for testing input description capture
+
+        self.add_output("y1", val=1.0, desc="variable y1")  # for testing output description capture
+
+    def setup_partials(self):
+        self.declare_partials("*", "*", method="fd")
+
+    def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
+        """
+        Evaluates the equation
+        y1 = z1**2 + z2 + x1 - 0.2*y2
+        """
+        z1 = inputs["z"][0]
+        z2 = inputs["z"][1]
+        x1 = inputs["x"]
+        y2 = inputs["y2"]
+
+        outputs["y1"] = z1 ** 2 + z2 + x1 - 0.2 * y2
+
+
+@ValidityDomainChecker({"x": (0, 1)})  # This validity domain should apply in case 2
+class Disc1Ter(Disc1Bis):
+    """Same component with different validity domain."""

--- a/src/fastoad/openmdao/tests/test_validity_checker.py
+++ b/src/fastoad/openmdao/tests/test_validity_checker.py
@@ -79,7 +79,7 @@ def test_register_checks_instantiation(cleanup):
         ]
     )
 
-    records = ValidityDomainChecker.check_variables(variables)
+    records = ValidityDomainChecker.check_variables(variables, activated_only=False)
     assert [
         (
             rec.variable_name,
@@ -116,7 +116,7 @@ def test_register_checks_instantiation(cleanup):
         ]
     )
 
-    records = ValidityDomainChecker.check_variables(variables)
+    records = ValidityDomainChecker.check_variables(variables, activated_only=False)
     assert [
         (
             rec.variable_name,
@@ -152,7 +152,7 @@ def test_register_checks_instantiation(cleanup):
         ]
     )
 
-    records = ValidityDomainChecker.check_variables(variables)
+    records = ValidityDomainChecker.check_variables(variables, activated_only=False)
     assert [
         (
             rec.variable_name,
@@ -243,13 +243,7 @@ def test_sellar(caplog):
     model.add_subsystem("sellar_discipline_1", Disc1Bis(), ["*"])
     model.add_subsystem("sellar_discipline_2", Disc2(), ["*"])
 
-    model.nonlinear_solver = om.NonlinearBlockGS()
-    model.nonlinear_solver.options["iprint"] = 2
-    model.nonlinear_solver.options["maxiter"] = 25
-    model.nonlinear_solver.options["rtol"] = 1e-5
-
     problem.setup()
-
     problem.run_model()
     assert 'Variable "x" out of bound' not in caplog.text
 
@@ -260,12 +254,6 @@ def test_sellar(caplog):
     model.add_subsystem("sellar_discipline_1", Disc1Ter(), ["*"])
     model.add_subsystem("sellar_discipline_2", Disc2(), ["*"])
 
-    model.nonlinear_solver = om.NonlinearBlockGS()
-    model.nonlinear_solver.options["iprint"] = 2
-    model.nonlinear_solver.options["maxiter"] = 25
-    model.nonlinear_solver.options["rtol"] = 1e-5
-
     problem.setup()
-
     problem.run_model()
     assert 'Variable "x" out of bound: value [2.] is over upper limit ( 1 )' in caplog.text

--- a/src/fastoad/openmdao/validity_checker.py
+++ b/src/fastoad/openmdao/validity_checker.py
@@ -241,7 +241,9 @@ class ValidityDomainChecker:
     @classmethod
     def _update_problem_limit_definitions(cls, problem: om.Problem):
         """
-        Updates limit definitions using variable declarations of provided OpenMDAO system.
+        Updates limit definitions using variable declarations of provided OpenMDAO problem.
+
+        Ensures limit definitions of encountered components are activated.
 
         problem.setup() must have been run.
 

--- a/src/fastoad/openmdao/validity_checker.py
+++ b/src/fastoad/openmdao/validity_checker.py
@@ -71,7 +71,7 @@ class ValidityDomainChecker:
     .. code-block::
 
         @ValidityDomainChecker
-        class MyComponent(om.explicitComponent):
+        class MyComponent(om.ExplicitComponent):
             ...
 
     The above code will check values against lower and upper bounds that have
@@ -89,7 +89,7 @@ class ValidityDomainChecker:
                 "a:variable:with:upper:bound:only": (None, 4.2),
             },
         )
-        class MyComponent(om.explicitComponent):
+        class MyComponent(om.ExplicitComponent):
             ...
 
     The defined domain limits supersedes lower and upper bounds from

--- a/src/fastoad/openmdao/validity_checker.py
+++ b/src/fastoad/openmdao/validity_checker.py
@@ -166,7 +166,7 @@ class ValidityDomainChecker:
         cls._update_problem_limit_definitions(problem)
 
         variables = VariableList.from_problem(problem)
-        records = cls.check_variables(variables)
+        records = cls.check_variables(variables, activated_only=True)
         cls.log_records(records)
         return records
 
@@ -178,7 +178,7 @@ class ValidityDomainChecker:
         Check values of provided variables against registered limits.
 
         :param variables:
-        :param ignore_deactivated:
+        :param activated_only: if True, only activated checkers are considered.
         :return: the list of checks
         """
         records: List[CheckRecord] = []


### PR DESCRIPTION
This PR resolves #509.

As soon as a component was decorated with `ValidityDomainChecker`, it was included in the final check, regardless of the presence of the component in the run problem.

A flag is now added to activate or not the checks by component.
