### PR TITLE
Fixed : mission definitions incorrectly had to contain a route

### DIFF
--- a/src/fastoad/models/performances/mission/openmdao/base.py
+++ b/src/fastoad/models/performances/mission/openmdao/base.py
@@ -2,7 +2,7 @@
 Base classes for mission-related OpenMDAO components.
 """
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2023 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -140,9 +140,12 @@ class BaseMissionComp(System, metaclass=ABCMeta):
         return self._mission_wrapper.mission_name
 
     @property
-    def first_route_name(self) -> str:
+    def first_route_name(self) -> Optional[str]:
         """The name of first route (and normally the main one) in the mission."""
-        return self._mission_wrapper.get_route_names()[0]
+        try:
+            return self._mission_wrapper.get_route_names()[0]
+        except IndexError:
+            return None
 
     @staticmethod
     def get_mission_definition(

--- a/src/fastoad/models/performances/mission/openmdao/mission.py
+++ b/src/fastoad/models/performances/mission/openmdao/mission.py
@@ -2,7 +2,7 @@
 FAST-OAD model for mission computation.
 """
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2023 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -137,16 +137,17 @@ class OMMission(om.Group, BaseMissionComp, NeedsOWE):
                 promotes=["*"],
             )
 
-        self.add_subsystem(
-            "specific_burned_fuel",
-            SpecificBurnedFuelComputation(
-                name_provider=self.name_provider,
-                mission_name=self.mission_name,
-                first_route_name=self.first_route_name,
-                payload_variable=self._get_payload_variable(),
-            ),
-            promotes=["*"],
-        )
+        if self.first_route_name is not None:
+            self.add_subsystem(
+                "specific_burned_fuel",
+                SpecificBurnedFuelComputation(
+                    name_provider=self.name_provider,
+                    mission_name=self.mission_name,
+                    first_route_name=self.first_route_name,
+                    payload_variable=self._get_payload_variable(),
+                ),
+                promotes=["*"],
+            )
 
     @property
     def flight_points(self) -> pd.DataFrame:

--- a/src/fastoad/models/performances/mission/openmdao/tests/data/test_mission.xml
+++ b/src/fastoad/models/performances/mission/openmdao/tests/data/test_mission.xml
@@ -186,6 +186,20 @@
                     <duration units="s">143.</duration>
                 </taxi_out>
             </fuel_as_objective>
+            <without_route>
+                <payload units="kg">15000.0</payload>
+                <takeoff>
+                    <altitude units="m" is_input="True">
+                        0.0<!--altitude at takeoff in sizing mission--></altitude>
+                    <fuel units="kg">
+                        95.0<!--mass of consumed fuel during takeoff phase in sizing mission--></fuel>
+                </takeoff>
+                <max_CL>0.65</max_CL>
+                <taxi_out>
+                    <thrust_rate>0.3</thrust_rate>
+                    <duration units="s">143.</duration>
+                </taxi_out>
+            </without_route>
         </mission>
         <weight>
             <aircraft>

--- a/src/fastoad/models/performances/mission/openmdao/tests/data/test_mission.yml
+++ b/src/fastoad/models/performances/mission/openmdao/tests/data/test_mission.yml
@@ -254,3 +254,11 @@ missions:
       - reserve:
           ref: main_route_optimal
           multiplier: 0.03
+  without_route:
+    parts:
+      - phase: start
+      - phase: taxi_out
+      - phase: takeoff
+      - phase: initial_climb
+      - phase: climb
+      - phase: descent

--- a/src/fastoad/models/performances/mission/openmdao/tests/test_mission.py
+++ b/src/fastoad/models/performances/mission/openmdao/tests/test_mission.py
@@ -466,3 +466,28 @@ def test_mission_group_with_CL_limitation(cleanup, with_dummy_plugin_2):
     assert_allclose(CL_end_cruise, 0.45, atol=1e-3)
     assert_allclose(altitude_end_climb, 9821.85, atol=1e-1)
     assert_allclose(altitude_end_cruise, 10343.68, atol=1e-1)
+
+
+def test_mission_group_without_route(cleanup, with_dummy_plugin_2):
+    input_file_path = pth.join(DATA_FOLDER_PATH, "test_mission.xml")
+    ivc = DataFile(input_file_path).to_ivc()
+
+    problem = run_system(
+        OMMission(
+            propulsion_id="test.wrapper.propulsion.dummy_engine",
+            out_file=pth.join(RESULTS_FOLDER_PATH, "without_route_mission_group.csv"),
+            use_initializer_iteration=False,
+            mission_file_path=pth.join(DATA_FOLDER_PATH, "test_mission.yml"),
+            mission_name="without_route",
+            adjust_fuel=True,
+            reference_area_variable="data:geometry:aircraft:reference_area",
+            add_solver=True,
+        ),
+        ivc,
+    )
+    assert_allclose(
+        problem["data:mission:without_route:consumed_fuel_before_input_weight"], 195.4, atol=0.1
+    )
+    assert_allclose(problem["data:mission:without_route:ZFW"], 55000.0, atol=1.0)
+    assert_allclose(problem["data:mission:without_route:needed_block_fuel"], 1136.8, atol=1.0)
+    assert_allclose(problem["data:mission:without_route:block_fuel"], 1136.8, atol=1.0)


### PR DESCRIPTION
Now possible to define a mission that does not contain any route.

In this case, the "specific burned fuel" is not computed, since it is based on range of main route.