### PR TITLE
Base class for cycle groups

### DIFF
--- a/src/fastoad/api.py
+++ b/src/fastoad/api.py
@@ -1,6 +1,6 @@
 """This module gathers key FAST-OAD classes and functions for convenient import."""
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2023 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -18,12 +18,12 @@
 # The comment below prevents PyCharm from "optimizing" (i.e. removing) these imports.
 # noinspection PyUnresolvedReferences
 from fastoad.cmd.api import (
-    get_plugin_information,
-    generate_notebooks,
     evaluate_problem,
     generate_configuration_file,
-    generate_source_data_file,
     generate_inputs,
+    generate_notebooks,
+    generate_source_data_file,
+    get_plugin_information,
     list_modules,
     list_variables,
     optimization_viewer,
@@ -34,54 +34,13 @@ from fastoad.cmd.api import (
 )
 
 # noinspection PyUnresolvedReferences
-from fastoad.io.configuration import FASTOADProblemConfigurator
-
-# noinspection PyUnresolvedReferences
-from fastoad.openmdao.problem import FASTOADProblem
-
-# noinspection PyUnresolvedReferences
-from fastoad.io import DataFile
-
-# noinspection PyUnresolvedReferences
-from fastoad.openmdao.variables import Variable, VariableList
-
-# noinspection PyUnresolvedReferences
-from fastoad.model_base import Atmosphere, AtmosphereSI, FlightPoint
-
-# noinspection PyUnresolvedReferences
-from fastoad.module_management.service_registry import (
-    RegisterOpenMDAOSystem,
-    RegisterPropulsion,
-    RegisterSpecializedService,
-    RegisterSubmodel,
-)
-
-# noinspection PyUnresolvedReferences
-from fastoad.model_base.propulsion import IOMPropulsionWrapper
-
-# noinspection PyUnresolvedReferences
-from fastoad.openmdao.validity_checker import ValidityDomainChecker
-
-# noinspection PyUnresolvedReferences
-from fastoad.model_base.datacls import MANDATORY_FIELD
-
-# noinspection PyUnresolvedReferences
-from fastoad.models.performances.mission.segments.base import (
-    IFlightPart,
-    AbstractFlightSegment,
-    RegisterSegment,
-)
-
-# noinspection PyUnresolvedReferences
-from fastoad.models.performances.mission.segments.time_step_base import (
-    AbstractTimeStepFlightSegment,
-    AbstractManualThrustSegment,
-    AbstractRegulatedThrustSegment,
-    AbstractFixedDurationSegment,
-    AbstractGroundSegment,
-    AbstractTakeOffSegment,
-    AbstractPolarModifier,
-    FlightSegment,
+from fastoad.gui.analysis_and_plots import (
+    aircraft_geometry_plot,
+    drag_polar_plot,
+    mass_breakdown_bar_plot,
+    mass_breakdown_sun_plot,
+    payload_range_plot,
+    wing_geometry_plot,
 )
 
 # noinspection PyUnresolvedReferences
@@ -94,11 +53,55 @@ from fastoad.gui.optimization_viewer import OptimizationViewer
 from fastoad.gui.variable_viewer import VariableViewer
 
 # noinspection PyUnresolvedReferences
-from fastoad.gui.analysis_and_plots import (
-    aircraft_geometry_plot,
-    drag_polar_plot,
-    mass_breakdown_bar_plot,
-    mass_breakdown_sun_plot,
-    wing_geometry_plot,
-    payload_range_plot,
+from fastoad.io import DataFile
+
+# noinspection PyUnresolvedReferences
+from fastoad.io.configuration import FASTOADProblemConfigurator
+
+# noinspection PyUnresolvedReferences
+from fastoad.model_base import Atmosphere, AtmosphereSI, FlightPoint
+
+# noinspection PyUnresolvedReferences
+from fastoad.model_base.datacls import MANDATORY_FIELD
+
+# noinspection PyUnresolvedReferences
+from fastoad.model_base.propulsion import IOMPropulsionWrapper
+
+# noinspection PyUnresolvedReferences
+from fastoad.models.performances.mission.segments.base import (
+    AbstractFlightSegment,
+    IFlightPart,
+    RegisterSegment,
 )
+
+# noinspection PyUnresolvedReferences
+from fastoad.models.performances.mission.segments.time_step_base import (
+    AbstractFixedDurationSegment,
+    AbstractGroundSegment,
+    AbstractManualThrustSegment,
+    AbstractPolarModifier,
+    AbstractRegulatedThrustSegment,
+    AbstractTakeOffSegment,
+    AbstractTimeStepFlightSegment,
+    FlightSegment,
+)
+
+# noinspection PyUnresolvedReferences
+from fastoad.module_management.service_registry import (
+    RegisterOpenMDAOSystem,
+    RegisterPropulsion,
+    RegisterSpecializedService,
+    RegisterSubmodel,
+)
+
+# noinspection PyUnresolvedReferences
+from fastoad.openmdao.base_model_classes import CycleGroup
+
+# noinspection PyUnresolvedReferences
+from fastoad.openmdao.problem import FASTOADProblem
+
+# noinspection PyUnresolvedReferences
+from fastoad.openmdao.validity_checker import ValidityDomainChecker
+
+# noinspection PyUnresolvedReferences
+from fastoad.openmdao.variables import Variable, VariableList

--- a/src/fastoad/io/configuration/resources/configuration.json
+++ b/src/fastoad/io/configuration/resources/configuration.json
@@ -141,17 +141,7 @@
     "model_options": {
       "type": "object",
       "additionalProperties": {
-        "additionalProperties": {
-          "anyOf": [
-            {
-              "not": {
-                "type": [
-                  "object"
-                ]
-              }
-            }
-          ]
-        }
+        "additionalProperties": true
       }
     },
     "model": {

--- a/src/fastoad/io/configuration/tests/data/conf_sellar_example/disc1.py
+++ b/src/fastoad/io/configuration/tests/data/conf_sellar_example/disc1.py
@@ -24,7 +24,7 @@ class RegisteredDisc1(BasicDisc1):
 
     def initialize(self):
         # These options have no effect and are used for checks
-        self.options.declare("dummy_disc1_option", types=bool, default=True)
+        self.options.declare("dummy_disc1_option", types=dict, default={})
         self.options.declare("dummy_generic_option", types=str, default="")
 
     def setup(self):

--- a/src/fastoad/io/configuration/tests/data/valid_sellar.toml
+++ b/src/fastoad/io/configuration/tests/data/valid_sellar.toml
@@ -31,8 +31,10 @@ driver = "om.ScipyOptimizeDriver(optimizer='SLSQP')"
 
 [model_options."*"]
   dummy_f_option = 10
-  dummy_disc1_option = false
   dummy_generic_option = "it works"
+[model_options."*".dummy_disc1_option]
+    a = 1
+    b = 2
 [model_options."cycle.*"]
   dummy_generic_option = "it works here also"
 

--- a/src/fastoad/io/configuration/tests/data/valid_sellar.yml
+++ b/src/fastoad/io/configuration/tests/data/valid_sellar.yml
@@ -29,7 +29,9 @@ model:
 model_options:
   "*":
     dummy_f_option: 10
-    dummy_disc1_option: false
+    dummy_disc1_option:
+      a: 1
+      b: 2
     dummy_generic_option: "it works"
   "cycle.*":
     dummy_generic_option: "it works here also"

--- a/src/fastoad/io/configuration/tests/data/valid_sellar_alternate.toml
+++ b/src/fastoad/io/configuration/tests/data/valid_sellar_alternate.toml
@@ -31,8 +31,10 @@ driver = "om.ScipyOptimizeDriver(optimizer='SLSQP')"
 
 [model_options."*"]
   dummy_f_option = 10  # has no effect in this alternate version
-  dummy_disc1_option = false
   dummy_generic_option = "it works"
+[model_options."*".dummy_disc1_option]
+    a = 10
+    b = 20
 [model_options."cycle.*"]
   dummy_generic_option = "it works here also"
 

--- a/src/fastoad/io/configuration/tests/data/valid_sellar_alternate.yml
+++ b/src/fastoad/io/configuration/tests/data/valid_sellar_alternate.yml
@@ -28,7 +28,9 @@ model:
 model_options:
   "*":
     dummy_f_option: 10   # has no effect in this alternate version
-    dummy_disc1_option: false
+    dummy_disc1_option:
+      a: 10
+      b: 20
     dummy_generic_option: "it works"
   "cycle.*":
     dummy_generic_option: "it works here also"

--- a/src/fastoad/io/configuration/tests/test_configuration.py
+++ b/src/fastoad/io/configuration/tests/test_configuration.py
@@ -147,7 +147,7 @@ def test_problem_definition_with_xml_ref(cleanup, caplog):
         # check the global way to set options
         assert problem.model.functions.f.options["dummy_f_option"] == 10
         assert problem.model.functions.f.options["dummy_generic_option"] == "it works"
-        assert problem.model.cycle.disc1.options["dummy_disc1_option"] is False
+        assert problem.model.cycle.disc1.options["dummy_disc1_option"] == {"a": 1, "b": 2}
         assert problem.model.cycle.disc1.options["dummy_generic_option"] == "it works here also"
 
         # runs evaluation without optimization loop to check that inputs are taken into account
@@ -169,7 +169,7 @@ def test_problem_definition_with_xml_ref(cleanup, caplog):
         with pytest.raises(KeyError):
             _ = alt_problem.model.functions.f.options["dummy_f_option"]
         assert alt_problem.model.functions.f.options["dummy_generic_option"] == "it works"
-        assert alt_problem.model.cycle.disc1.options["dummy_disc1_option"] is False
+        assert alt_problem.model.cycle.disc1.options["dummy_disc1_option"] == {"a": 10, "b": 20}
         assert alt_problem.model.cycle.disc1.options["dummy_generic_option"] == "it works here also"
 
         alt_problem.run_model()

--- a/src/fastoad/openmdao/base_model_classes.py
+++ b/src/fastoad/openmdao/base_model_classes.py
@@ -1,0 +1,42 @@
+"""
+Convenience classes to be used in OpenMDAO components
+"""
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
+#  FAST is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import openmdao.api as om
+
+
+class CycleGroup(om.Group):
+    """
+    Use this class as a base class if your model should contain a NonlinearBlockGS solver.
+
+    This class defines standard options to control the solvers.
+
+    Please be sure to call the `super()` method when using initialize() and setup()
+    in the derived class.
+    """
+
+    def initialize(self):
+        super().initialize()
+        self.options.declare("use_inner_solver", types=bool, default=True)
+        self.options.declare(
+            "NLGS_options", types=dict, default={}, desc="options for NonlinearBlockGS"
+        )
+        self.options.declare("DS_options", types=dict, default={}, desc="options for DirectSolver")
+
+    def setup(self):
+        if self.options["use_inner_solver"]:
+            self.nonlinear_solver = om.NonlinearBlockGS(**self.options["NLGS_options"])
+            self.linear_solver = om.DirectSolver(**self.options["DS_options"])
+        super().setup()


### PR DESCRIPTION
This PR adds a base class for groups that contain a NLGS solver.

It is a way to standardize the control of inner solvers through options, making it easy to control all of them at once using `model_options` in configuration file.

This PR also allows having a dict as option value, which is the way solver options will be set from the configuration file.