### PR TITLE
Pathlib usage

### DIFF
--- a/src/conftest.py
+++ b/src/conftest.py
@@ -2,7 +2,7 @@
     Basic settings for tests
 """
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2023 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -17,8 +17,8 @@
 # Note: this file has to be put in src/, not in project root folder, to ensure that
 # `pytest src` will run OK after a `pip install .`
 
-import os.path as pth
 import sys
+from pathlib import Path
 from platform import system
 from shutil import which
 from typing import List, Optional
@@ -27,16 +27,14 @@ from unittest.mock import Mock
 import pytest
 import wrapt
 
+from fastoad._utils.files import as_path
+
 if sys.version_info >= (3, 10):
     import importlib.metadata as importlib_metadata
 else:
     import importlib_metadata
 
 from fastoad.module_management._plugins import FastoadLoader, MODEL_PLUGIN_ID
-
-DATA_FOLDER_PATH = pth.join(pth.dirname(__file__), "data")
-RESULTS_FOLDER_PATH = pth.join(pth.dirname(__file__), "api", "results")
-CONFIGURATION_FILE_PATH = pth.join(DATA_FOLDER_PATH, "sellar.yml")
 
 
 @pytest.fixture(autouse=True)
@@ -51,7 +49,7 @@ def no_xfoil_skip(request, xfoil_path):
 
 
 @pytest.fixture
-def xfoil_path() -> Optional[str]:
+def xfoil_path() -> Optional[Path]:
     """
     On a system that is not Windows, a XFOIL executable with name "xfoil" can
     be put in "<project_root>/tests/xfoil_exe/".
@@ -63,19 +61,19 @@ def xfoil_path() -> Optional[str]:
         # On Windows, we use the embedded executable
         return None
 
-    path = pth.abspath(pth.join("tests/xfoil_exe", "xfoil"))
-    if pth.exists(path):
+    path = Path("tests/xfoil_exe", "xfoil").resolve()
+    if path.exists():
         # If there is a local xfoil, use it
         return path
 
     # Otherwise, use one that is in PATH, if it exists
-    return which("xfoil")
+    return as_path(which("xfoil"))
 
 
 @pytest.fixture
-def plugin_root_path() -> str:
+def plugin_root_path() -> Path:
     """Returns the path to dummy plugins, for check purpose."""
-    return pth.abspath("tests/dummy_plugins")
+    return (Path(__file__).parent.parent / "tests" / "dummy_plugins").resolve()
 
 
 @pytest.fixture

--- a/src/fastoad/_utils/files.py
+++ b/src/fastoad/_utils/files.py
@@ -1,9 +1,8 @@
 """
 Convenience functions for file and directories
 """
-
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -15,12 +14,37 @@ Convenience functions for file and directories
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import os
-import os.path as pth
+from os import PathLike
+from pathlib import Path
+from typing import Union, overload
 
 
-def make_parent_dir(path: str):
+@overload
+def as_path(path: None) -> None:
+    ...
+
+
+@overload
+def as_path(path: Union[str, PathLike]) -> Path:
+    ...
+
+
+def as_path(path):
+    """
+    :param path:
+    :return: `path` itself if `path` is a Path,
+             or a Path object from `path` if possible,
+             or None otherwise.
+    """
+    if isinstance(path, Path):
+        return path
+
+    try:
+        return Path(path)
+    except TypeError:
+        return None
+
+
+def make_parent_dir(path: Union[str, PathLike]):
     """Ensures parent directory of provided path exists or is created"""
-    dirname = pth.abspath(pth.dirname(path))
-    if not pth.exists(dirname):
-        os.makedirs(dirname)
+    as_path(path).parent.mkdir(parents=True, exist_ok=True)

--- a/src/fastoad/_utils/resource_management/tests/test_contents.py
+++ b/src/fastoad/_utils/resource_management/tests/test_contents.py
@@ -1,5 +1,5 @@
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2022 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -11,7 +11,7 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import os.path as pth
+from pathlib import Path
 
 from ..contents import PackageReader
 
@@ -23,7 +23,7 @@ def test_get_package_contents():
     assert not reader.is_module
     assert not reader.has_error
 
-    assert pth.basename(__file__) in reader.contents
+    assert Path(__file__).name in reader.contents
     assert "__init__.py" in reader.contents
     assert "resources" in reader.contents
 

--- a/src/fastoad/_utils/resource_management/tests/test_copy.py
+++ b/src/fastoad/_utils/resource_management/tests/test_copy.py
@@ -1,5 +1,5 @@
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -11,33 +11,32 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import os.path as pth
+import shutil
 from filecmp import dircmp
-from glob import glob
-from shutil import rmtree
+from pathlib import Path
 
 import pytest
 
 from . import resources
 from ..copy import copy_resource_folder
 
-RESOURCE_FOLDER_PATH = pth.join(pth.dirname(__file__), "resources")
-RESULTS_FOLDER_PATH = pth.join(pth.dirname(__file__), "results")
+RESOURCE_FOLDER_PATH = Path(__file__).parent / "resources"
+RESULTS_FOLDER_PATH = Path(__file__).parent / "results"
 
 
 @pytest.fixture(scope="module")
 def cleanup():
-    rmtree(RESULTS_FOLDER_PATH, ignore_errors=True)
+    shutil.rmtree(RESULTS_FOLDER_PATH, ignore_errors=True)
 
 
 def test_copy_resource_folder_from_str(cleanup):
-    destination_folder = pth.join(RESULTS_FOLDER_PATH, "test_from_str")
+    destination_folder = RESULTS_FOLDER_PATH / "test_from_str"
     copy_resource_folder("fastoad._utils.resource_management.tests.resources", destination_folder)
     _check_files(destination_folder)
 
 
 def test_copy_resource_folder_from_str_with_exclusion(cleanup):
-    destination_folder = pth.join(RESULTS_FOLDER_PATH, "test_from_str_with_exclusion")
+    destination_folder = RESULTS_FOLDER_PATH / "test_from_str_with_exclusion"
     excluded = ["__init__.py"]
     copy_resource_folder(
         "fastoad._utils.resource_management.tests.resources", destination_folder, exclude=excluded
@@ -46,13 +45,13 @@ def test_copy_resource_folder_from_str_with_exclusion(cleanup):
 
 
 def test_copy_resource_folder_from_package(cleanup):
-    destination_folder = pth.join(RESULTS_FOLDER_PATH, "test_from_module")
+    destination_folder = RESULTS_FOLDER_PATH / "test_from_module"
     copy_resource_folder(resources, destination_folder)
     _check_files(destination_folder)
 
 
 def test_copy_resource_folder_from_package_with_exclusion(cleanup):
-    destination_folder = pth.join(RESULTS_FOLDER_PATH, "test_from_str_with_exclusion")
+    destination_folder = RESULTS_FOLDER_PATH / "test_from_str_with_exclusion"
     excluded = ["__init__.py"]
     copy_resource_folder(resources, destination_folder, exclude=excluded)
     _check_files(destination_folder, excluded)
@@ -63,4 +62,4 @@ def _check_files(destination_folder, excluded=None):
 
     if excluded:
         for name in excluded:
-            assert not glob(pth.join(destination_folder, "**", name), recursive=True)
+            assert not next(destination_folder.rglob(name), False)

--- a/src/fastoad/cmd/cli_utils.py
+++ b/src/fastoad/cmd/cli_utils.py
@@ -1,6 +1,6 @@
 """Utility functions for CLI interface."""
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2022 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -47,7 +47,7 @@ def out_file_option(func):
     )(overwrite_option(func))
 
 
-def manage_overwrite(func: Callable, filename_func: Callable = None, **kwargs):
+def manage_overwrite(func: Callable, **kwargs):
     """
     Runs `func`, that is expected to write a file, with provided keyword arguments `args`.
 
@@ -57,30 +57,26 @@ def manage_overwrite(func: Callable, filename_func: Callable = None, **kwargs):
 
     :param func: callable that will do the operation and is expected to return
                  the path of written element.
-    :param filename_func: a function that provides the name of written file, given the
-                          value returned by func
     :param kwargs: keyword arguments for func
     :return: True if the file has been written,
     """
     written = False
     try:
-        written = _run_func(func, filename_func, **kwargs)
+        written = _run_write_func(func, **kwargs)
 
     except FastPathExistsError as exc:
         if click.confirm(f'"{exc.args[1]}" already exists. Do you want to overwrite it?'):
             kwargs["overwrite"] = True
-            written = _run_func(func, filename_func, **kwargs)
+            written = _run_write_func(func, **kwargs)
         else:
             click.echo("Operation cancelled.")
 
     return written
 
 
-def _run_func(func: Callable, filename_func: Callable = None, **kwargs):
+def _run_write_func(func: Callable, **kwargs):
     result = func(**kwargs)
     if result:
-        if filename_func:
-            result = filename_func(result)
         click.echo(f'"{result}" has been written.')
         return True
 

--- a/src/fastoad/cmd/tests/test_api.py
+++ b/src/fastoad/cmd/tests/test_api.py
@@ -2,7 +2,7 @@
 Tests for basic API
 """
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2023 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -15,10 +15,9 @@ Tests for basic API
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import os
-import os.path as pth
 import shutil
 from filecmp import cmp
-from shutil import rmtree
+from pathlib import Path
 
 import pytest
 
@@ -31,51 +30,51 @@ from ..exceptions import (
     FastPathExistsError,
 )
 
-DATA_FOLDER_PATH = pth.join(pth.dirname(__file__), "data")
-RESULTS_FOLDER_PATH = pth.join(pth.dirname(__file__), "results")
-CONFIGURATION_FILE_PATH = pth.join(DATA_FOLDER_PATH, "sellar.yml")
+DATA_FOLDER_PATH = Path(__file__).parent / "data"
+RESULTS_FOLDER_PATH = Path(__file__).parent / "results"
+CONFIGURATION_FILE_PATH = DATA_FOLDER_PATH / "sellar.yml"
 
 
 @pytest.fixture(scope="module")
 def cleanup():
-    rmtree(RESULTS_FOLDER_PATH, ignore_errors=True)
+    shutil.rmtree(RESULTS_FOLDER_PATH, ignore_errors=True)
 
     # Need to clean up variable descriptions because it is manipulated in other tests.
-    Variable.read_variable_descriptions(pth.dirname(fastoad.models.__file__), update_existing=False)
+    Variable.read_variable_descriptions(Path(fastoad.models.__file__).parent, update_existing=False)
 
 
 def test_generate_notebooks_with_no_notebook(cleanup, with_dummy_plugin_2, plugin_root_path):
-    target_path = pth.join(RESULTS_FOLDER_PATH, "notebooks_noplugin")
+    target_path = Path(RESULTS_FOLDER_PATH, "notebooks_noplugin")
 
     with pytest.raises(FastNoAvailableNotebookError):
         api.generate_notebooks(target_path)
 
 
 def test_generate_notebooks_with_one_plugin(cleanup, with_dummy_plugin_1, plugin_root_path):
-    target_path = pth.join(RESULTS_FOLDER_PATH, "notebooks_1plugin")
+    target_path = RESULTS_FOLDER_PATH / "notebooks_1plugin"
 
     api.generate_notebooks(target_path)
-    assert pth.isfile(pth.join(target_path, "notebook_1.ipynb"))
+    assert (target_path / "notebook_1.ipynb").is_file()
 
 
 def test_generate_notebooks_with_one_dist_plugin(
     cleanup, with_dummy_plugin_distribution_1, plugin_root_path
 ):
-    target_path = pth.join(RESULTS_FOLDER_PATH, "notebooks_1dist")
+    target_path = RESULTS_FOLDER_PATH / "notebooks_1dist"
 
-    api.generate_notebooks(target_path)
-    assert pth.isfile(pth.join(target_path, "test_plugin_1", "notebook_1.ipynb"))
-    assert pth.isfile(pth.join(target_path, "test_plugin_4", "notebook_1.ipynb"))
-    assert pth.isdir(pth.join(target_path, "test_plugin_4", "data"))
-    assert pth.isfile(pth.join(target_path, "test_plugin_4", "data", "dummy_file.txt"))
+    api.generate_notebooks(target_path.as_posix())
+    assert (target_path / "test_plugin_1" / "notebook_1.ipynb").is_file()
+    assert (target_path / "test_plugin_4" / "notebook_1.ipynb").is_file()
+    assert (target_path / "test_plugin_4" / "data").is_dir()
+    assert (target_path / "test_plugin_4" / "data" / "dummy_file.txt").is_file()
 
 
 def test_generate_notebooks(cleanup, with_dummy_plugins, plugin_root_path):
-    target_path = pth.join(RESULTS_FOLDER_PATH, "notebooks")
+    target_path = RESULTS_FOLDER_PATH / "notebooks"
 
     # Test distribution specification
     api.generate_notebooks(target_path, distribution_name="dummy-dist-3")
-    assert pth.isfile(pth.join(target_path, "notebook_2.ipynb"))
+    assert (target_path / "notebook_2.ipynb").is_file()
 
     # Test overwrite
     with pytest.raises(FastPathExistsError):
@@ -83,23 +82,21 @@ def test_generate_notebooks(cleanup, with_dummy_plugins, plugin_root_path):
 
     # ... without specifying distribution
     api.generate_notebooks(target_path, overwrite=True)
-    assert pth.isfile(pth.join(target_path, "dummy-dist-1", "test_plugin_1", "notebook_1.ipynb"))
-    assert pth.isfile(pth.join(target_path, "dummy-dist-1", "test_plugin_4", "notebook_1.ipynb"))
-    assert pth.isdir(pth.join(target_path, "dummy-dist-1", "test_plugin_4", "data"))
-    assert pth.isfile(
-        pth.join(target_path, "dummy-dist-1", "test_plugin_4", "data", "dummy_file.txt")
-    )
+    assert (target_path / "dummy-dist-1" / "test_plugin_1" / "notebook_1.ipynb").is_file()
+    assert (target_path / "dummy-dist-1" / "test_plugin_4" / "notebook_1.ipynb").is_file()
+    assert (target_path / "dummy-dist-1" / "test_plugin_4" / "data").is_dir()
+    assert (target_path / "dummy-dist-1" / "test_plugin_4" / "data" / "dummy_file.txt").is_file()
 
-    assert not pth.exists(pth.join(target_path, "dummy-dist-2"))
+    assert not (target_path / "dummy-dist-2").exists()
 
-    assert pth.isfile(pth.join(target_path, "dummy-dist-3", "notebook_2.ipynb"))
+    assert (target_path / "dummy-dist-3" / "notebook_2.ipynb").is_file()
 
 
 def test_generate_user_file(cleanup, with_dummy_plugins, plugin_root_path):
     # Tests that exceptions are correctly raised. The tests on other issues and on the expected
     # results will be tested with each type of user file.
 
-    text_file_path = pth.join(RESULTS_FOLDER_PATH, "unknown_user_file_type.xml")
+    text_file_path = RESULTS_FOLDER_PATH / "unknown_user_file_type.xml"
 
     # Test with wrong type of user file, should fail regardless of distribution
     with pytest.raises(AttributeError):
@@ -120,13 +117,13 @@ def test_generate_user_file(cleanup, with_dummy_plugins, plugin_root_path):
 
 
 def test_generate_configuration_file_plugin_1(cleanup, with_dummy_plugins, plugin_root_path):
-    configuration_file_path = pth.join(RESULTS_FOLDER_PATH, "from_plugin_1.yml")
+    configuration_file_path = RESULTS_FOLDER_PATH / "from_plugin_1.yml"
 
     # No conf file specified because the dist has only one
     api.generate_configuration_file(
         configuration_file_path, overwrite=False, distribution_name="dummy-dist-1"
     )
-    original_file = pth.join(
+    original_file = Path(
         plugin_root_path, "dist_1", "dummy_plugin_1", "configurations", "dummy_conf_1-1.yml"
     )
     assert cmp(configuration_file_path, original_file)
@@ -144,7 +141,7 @@ def test_generate_configuration_file_plugin_1(cleanup, with_dummy_plugins, plugi
 
 
 def test_generate_configuration_file_plugin_1_alone(cleanup, with_dummy_plugin_1):
-    configuration_file_path = pth.join(RESULTS_FOLDER_PATH, "from_plugin_1.yml")
+    configuration_file_path = RESULTS_FOLDER_PATH / "from_plugin_1.yml"
 
     # No plugin specified, only one plugin is available
     api.generate_configuration_file(configuration_file_path, overwrite=True)
@@ -153,14 +150,14 @@ def test_generate_configuration_file_plugin_1_alone(cleanup, with_dummy_plugin_1
 def test_generate_configuration_file_plugin_1_and_3(
     cleanup, with_dummy_plugin_distribution_1_and_3
 ):
-    configuration_file_path = pth.join(RESULTS_FOLDER_PATH, "from_plugin_1_again.yml")
+    configuration_file_path = RESULTS_FOLDER_PATH / "from_plugin_1_again.yml"
 
     # No plugin specified, several plugins available, but only one with a conf file
     api.generate_configuration_file(configuration_file_path, overwrite=True)
 
 
 def test_generate_configuration_file_plugin_2(cleanup, with_dummy_plugins, plugin_root_path):
-    configuration_file_path = pth.join(RESULTS_FOLDER_PATH, "from_plugin_2.yml")
+    configuration_file_path = RESULTS_FOLDER_PATH / "from_plugin_2.yml"
     api.generate_configuration_file(
         configuration_file_path,
         overwrite=True,
@@ -169,13 +166,13 @@ def test_generate_configuration_file_plugin_2(cleanup, with_dummy_plugins, plugi
     )
 
     # As conf file names are unique, it is possible to omit distribution_name
-    configuration_file_path = pth.join(RESULTS_FOLDER_PATH, "from_plugin_2_again.yml")
+    configuration_file_path = RESULTS_FOLDER_PATH / "from_plugin_2_again.yml"
     api.generate_configuration_file(
         configuration_file_path,
         overwrite=True,
         sample_file_name="dummy_conf_2-1.yml",
     )
-    original_file = pth.join(
+    original_file = Path(
         plugin_root_path, "dist_2", "dummy_plugin_2", "configurations", "dummy_conf_2-1.yml"
     )
     assert cmp(configuration_file_path, original_file)
@@ -194,20 +191,20 @@ def test_generate_configuration_file_plugin_2(cleanup, with_dummy_plugins, plugi
         distribution_name="dummy-dist-2",
         sample_file_name="dummy_conf_3-2.yaml",
     )
-    original_file = pth.join(
+    original_file = Path(
         plugin_root_path, "dist_2", "dummy_plugin_3", "configurations", "dummy_conf_3-2.yaml"
     )
     assert cmp(configuration_file_path, original_file)
 
 
 def test_generate_source_data_file_plugin_4(cleanup, with_dummy_plugins, plugin_root_path):
-    source_data_file_path = pth.join(RESULTS_FOLDER_PATH, "from_plugin_4.xml")
+    source_data_file_path = RESULTS_FOLDER_PATH / "from_plugin_4.xml"
 
     # No conf file specified because the dist has only one
     api.generate_source_data_file(
         source_data_file_path, overwrite=False, distribution_name="dummy-dist-1"
     )
-    original_file = pth.join(
+    original_file = Path(
         plugin_root_path,
         "dist_1",
         "dummy_plugin_4",
@@ -229,21 +226,21 @@ def test_generate_source_data_file_plugin_4(cleanup, with_dummy_plugins, plugin_
 
 
 def test_generate_source_data_file_plugin_4_alone(cleanup, with_dummy_plugin_4):
-    source_data_file_path = pth.join(RESULTS_FOLDER_PATH, "from_plugin_4.xml")
+    source_data_file_path = RESULTS_FOLDER_PATH / "from_plugin_4.xml"
 
     # No plugin specified, only one plugin is available
     api.generate_source_data_file(source_data_file_path, overwrite=True)
 
 
 def test_generate_source_data_file_plugin_1_and_3(cleanup, with_dummy_plugin_distribution_1_and_3):
-    source_data_file_path = pth.join(RESULTS_FOLDER_PATH, "from_plugin_4_again.xml")
+    source_data_file_path = RESULTS_FOLDER_PATH / "from_plugin_4_again.xml"
 
     # No plugin specified, several plugins available, but only one with a conf file
     api.generate_source_data_file(source_data_file_path, overwrite=True)
 
 
 def test_generate_source_data_file_plugin_5(cleanup, with_dummy_plugins, plugin_root_path):
-    source_data_file_path = pth.join(RESULTS_FOLDER_PATH, "from_plugin_3.xml")
+    source_data_file_path = RESULTS_FOLDER_PATH / "from_plugin_3.xml"
     api.generate_source_data_file(
         source_data_file_path,
         overwrite=True,
@@ -252,13 +249,13 @@ def test_generate_source_data_file_plugin_5(cleanup, with_dummy_plugins, plugin_
     )
 
     # As source data file names are unique, it is possible to omit distribution_name
-    source_data_file_path = pth.join(RESULTS_FOLDER_PATH, "from_plugin_3_again.xml")
+    source_data_file_path = RESULTS_FOLDER_PATH / "from_plugin_3_again.xml"
     api.generate_source_data_file(
         source_data_file_path,
         overwrite=True,
         sample_file_name="dummy_source_data_3-1.xml",
     )
-    original_file = pth.join(
+    original_file = Path(
         plugin_root_path,
         "dist_2",
         "dummy_plugin_3",
@@ -281,7 +278,7 @@ def test_generate_source_data_file_plugin_5(cleanup, with_dummy_plugins, plugin_
         distribution_name="dummy-dist-2",
         sample_file_name="dummy_source_data_3-2.xml",
     )
-    original_file = pth.join(
+    original_file = Path(
         plugin_root_path,
         "dist_2",
         "dummy_plugin_3",
@@ -292,10 +289,10 @@ def test_generate_source_data_file_plugin_5(cleanup, with_dummy_plugins, plugin_
 
 
 def test_generate_inputs(cleanup):
-    input_file_path = api.generate_inputs(CONFIGURATION_FILE_PATH, overwrite=False)
-    assert input_file_path == pth.join(RESULTS_FOLDER_PATH, "inputs.xml")
-    assert pth.exists(input_file_path)
-    data = DataFile(input_file_path)
+    input_file_path = Path(api.generate_inputs(CONFIGURATION_FILE_PATH, overwrite=False))
+    assert input_file_path == RESULTS_FOLDER_PATH / "inputs.xml"
+    assert input_file_path.exists()
+    data = DataFile(input_file_path.as_posix())
     assert len(data) == 2
     assert "x" in data.names() and "z" in data.names()
 
@@ -307,104 +304,110 @@ def test_generate_inputs(cleanup):
     with pytest.raises(FastPathExistsError):
         api.generate_inputs(CONFIGURATION_FILE_PATH, overwrite=False)
 
-    input_file_path = api.generate_inputs(
-        CONFIGURATION_FILE_PATH, pth.join(DATA_FOLDER_PATH, "inputs.xml"), overwrite=True
+    input_file_path = Path(
+        api.generate_inputs(
+            CONFIGURATION_FILE_PATH, DATA_FOLDER_PATH / "inputs.xml", overwrite=True
+        )
     )
 
-    assert input_file_path == pth.join(RESULTS_FOLDER_PATH, "inputs.xml")
-    assert pth.exists(input_file_path)
-    data = DataFile(input_file_path)
+    assert input_file_path == RESULTS_FOLDER_PATH / "inputs.xml"
+    assert input_file_path.exists()
+    data = DataFile(input_file_path.as_posix())
     assert len(data) == 2
     assert "x" in data.names() and "z" in data.names()
 
     # We test without source data file to see if variable description in "desc" kwargs
     # is captured (issue #319)
-    input_file_path = api.generate_inputs(CONFIGURATION_FILE_PATH, overwrite=True)
-    assert input_file_path == pth.join(RESULTS_FOLDER_PATH, "inputs.xml")
-    assert pth.exists(input_file_path)
-    data = DataFile(input_file_path)
+    input_file_path = Path(api.generate_inputs(CONFIGURATION_FILE_PATH, overwrite=True))
+    assert input_file_path == RESULTS_FOLDER_PATH / "inputs.xml"
+    assert input_file_path.exists()
+    data = DataFile(input_file_path.as_posix())
     assert len(data) == 2
     assert "x" in data.names() and "z" in data.names()
 
 
 def test_list_modules(cleanup):
+    conf_file_path = CONFIGURATION_FILE_PATH.as_posix()
+
     # Run with stdout output (no test)
     api.list_modules()
-    api.list_modules(CONFIGURATION_FILE_PATH, verbose=True)
-    api.list_modules(CONFIGURATION_FILE_PATH, verbose=False)
+    api.list_modules(conf_file_path, verbose=True)
+    api.list_modules(conf_file_path, verbose=False)
 
     # Run with file output (test file existence)
-    out_file = pth.join(RESULTS_FOLDER_PATH, "list_modules.txt")
-    assert not pth.exists(out_file)
-    api.list_modules(CONFIGURATION_FILE_PATH, out_file)
+    out_file = RESULTS_FOLDER_PATH / "list_modules.txt"
+    assert not out_file.exists()
+    api.list_modules(conf_file_path, out_file.as_posix())
     with pytest.raises(FastPathExistsError):
-        api.list_modules(CONFIGURATION_FILE_PATH, out_file)
-    api.list_modules(CONFIGURATION_FILE_PATH, out_file, overwrite=True)
+        api.list_modules(conf_file_path, out_file.as_posix())
+    api.list_modules(conf_file_path, out_file.as_posix(), overwrite=True)
 
-    assert pth.exists(out_file)
+    assert out_file.exists()
 
     #
     # Run with file output (test file existence)
-    source_folder = pth.join(DATA_FOLDER_PATH, "cmd_sellar_example")
+    source_folder = (DATA_FOLDER_PATH / "cmd_sellar_example").as_posix()
 
     # Run with file output with folders (test file existence)
-    out_file = pth.join(RESULTS_FOLDER_PATH, "list_modules_with_folder.txt")
-    assert not pth.exists(out_file)
-    api.list_modules(source_folder, out_file)
+    out_file = RESULTS_FOLDER_PATH / "list_modules_with_folder.txt"
+    assert not out_file.exists()
+    api.list_modules(source_folder, out_file.as_posix())
     with pytest.raises(FastPathExistsError):
-        api.list_modules(source_folder, out_file)
+        api.list_modules(source_folder, out_file.as_posix())
 
     # Testing with single folder
-    api.list_modules(source_folder, out_file, overwrite=True)
+    api.list_modules(source_folder, out_file.as_posix(), overwrite=True)
 
-    assert pth.exists(out_file)
+    assert out_file.exists()
 
     # Testing with list of folders
     source_folder = [source_folder]
-    api.list_modules(source_folder, out_file, overwrite=True)
+    api.list_modules(source_folder, out_file.as_posix(), overwrite=True)
 
-    assert pth.exists(out_file)
+    assert out_file.exists()
 
 
 def test_list_variables(cleanup):
+    conf_file_path = CONFIGURATION_FILE_PATH.as_posix()
+
     # Run with stdout output (no test)
-    api.list_variables(CONFIGURATION_FILE_PATH)
+    api.list_variables(conf_file_path)
 
     # Run with file output (test file existence)
-    out_file_path = pth.join(RESULTS_FOLDER_PATH, "list_variables.txt")
-    assert not pth.exists(out_file_path)
-    api.list_variables(CONFIGURATION_FILE_PATH, out=out_file_path)
+    out_file_path = RESULTS_FOLDER_PATH / "list_variables.txt"
+    assert not out_file_path.exists()
+    api.list_variables(conf_file_path, out=out_file_path.as_posix())
     with pytest.raises(FastPathExistsError):
-        api.list_variables(CONFIGURATION_FILE_PATH, out=out_file_path)
-    api.list_variables(CONFIGURATION_FILE_PATH, out=out_file_path, overwrite=True)
-    assert pth.exists(out_file_path)
+        api.list_variables(conf_file_path, out=out_file_path.as_posix())
+    api.list_variables(conf_file_path, out=out_file_path.as_posix(), overwrite=True)
+    assert out_file_path.exists()
 
-    ref_file_path = pth.join(DATA_FOLDER_PATH, "ref_list_variables.txt")
+    ref_file_path = DATA_FOLDER_PATH / "ref_list_variables.txt"
     assert cmp(ref_file_path, out_file_path)
 
     # Test with variable_description.txt format
     api.list_variables(
-        CONFIGURATION_FILE_PATH,
-        out=out_file_path,
+        conf_file_path,
+        out=out_file_path.as_posix(),
         overwrite=True,
         tablefmt="var_desc",
     )
-    assert pth.exists(out_file_path)
-    ref_file_path = pth.join(
-        DATA_FOLDER_PATH, "ref_list_variables_with_variable_descriptions_format.txt"
+    assert out_file_path.exists()
+    ref_file_path = DATA_FOLDER_PATH.joinpath(
+        "ref_list_variables_with_variable_descriptions_format.txt"
     )
     assert cmp(ref_file_path, out_file_path)
 
 
 def test_write_n2(cleanup):
 
-    n2_file_path = pth.join(RESULTS_FOLDER_PATH, "other_n2.html")
+    n2_file_path = RESULTS_FOLDER_PATH / "other_n2.html"
     api.write_n2(CONFIGURATION_FILE_PATH, n2_file_path)
     # Running again without forcing overwrite of outputs will make it fail
     with pytest.raises(FastPathExistsError):
         api.write_n2(CONFIGURATION_FILE_PATH, n2_file_path, False)
     api.write_n2(CONFIGURATION_FILE_PATH, n2_file_path, True)
-    assert pth.exists(n2_file_path)
+    assert n2_file_path.exists()
 
 
 @pytest.mark.skipif(
@@ -413,23 +416,23 @@ def test_write_n2(cleanup):
 )
 def test_write_xdsm(cleanup):
     # By default, XDSM file will be generated in same folder as configuration file
-    default_xdsm_file_path = pth.join(DATA_FOLDER_PATH, "xdsm.html")
+    default_xdsm_file_path = DATA_FOLDER_PATH / "xdsm.html"
     api.write_xdsm(CONFIGURATION_FILE_PATH, overwrite=True, dry_run=True)
-    assert pth.exists(default_xdsm_file_path)
+    assert default_xdsm_file_path.exists()
     os.remove(default_xdsm_file_path)
 
-    xdsm_file_path = pth.join(RESULTS_FOLDER_PATH, "other_xdsm.html")
+    xdsm_file_path = RESULTS_FOLDER_PATH / "other_xdsm.html"
     api.write_xdsm(CONFIGURATION_FILE_PATH, xdsm_file_path)
     # Running again without forcing overwrite of outputs will make it fail
     with pytest.raises(FastPathExistsError):
         api.write_xdsm(CONFIGURATION_FILE_PATH, xdsm_file_path, overwrite=False, dry_run=True)
     api.write_xdsm(CONFIGURATION_FILE_PATH, xdsm_file_path, overwrite=True, dry_run=True)
-    assert pth.exists(xdsm_file_path)
+    assert xdsm_file_path.exists()
 
 
 def test_evaluate_problem(cleanup):
     api.generate_inputs(
-        CONFIGURATION_FILE_PATH, pth.join(DATA_FOLDER_PATH, "inputs.xml"), overwrite=True
+        CONFIGURATION_FILE_PATH, (DATA_FOLDER_PATH / "inputs.xml").as_posix(), overwrite=True
     )
     api.evaluate_problem(CONFIGURATION_FILE_PATH, False)
     # Running again without forcing overwrite of outputs will make it fail
@@ -439,15 +442,12 @@ def test_evaluate_problem(cleanup):
     assert problem["f"] == pytest.approx(32.56910089, abs=1e-8)
 
     # Move output file because it will be overwritten by the optim test
-    shutil.move(
-        pth.join(RESULTS_FOLDER_PATH, "outputs.xml"),
-        pth.join(RESULTS_FOLDER_PATH, "outputs_eval.xml"),
-    )
+    (RESULTS_FOLDER_PATH / "outputs.xml").rename(RESULTS_FOLDER_PATH / "outputs_eval.xml")
 
 
 def test_optimize_problem(cleanup):
     api.generate_inputs(
-        CONFIGURATION_FILE_PATH, pth.join(DATA_FOLDER_PATH, "inputs.xml"), overwrite=True
+        CONFIGURATION_FILE_PATH, (DATA_FOLDER_PATH / "inputs.xml").as_posix(), overwrite=True
     )
     api.optimize_problem(CONFIGURATION_FILE_PATH, False)
     # Running again without forcing overwrite of outputs will make it fail
@@ -460,7 +460,7 @@ def test_optimize_problem(cleanup):
 
 def test_optimization_viewer(cleanup):
     api.generate_inputs(
-        CONFIGURATION_FILE_PATH, pth.join(DATA_FOLDER_PATH, "inputs.xml"), overwrite=True
+        CONFIGURATION_FILE_PATH, (DATA_FOLDER_PATH / "inputs.xml").as_posix(), overwrite=True
     )
 
     # Before a run
@@ -474,7 +474,7 @@ def test_optimization_viewer(cleanup):
 
 def test_variable_viewer(cleanup):
 
-    file_path = pth.join(DATA_FOLDER_PATH, "short_inputs.xml")
+    file_path = (DATA_FOLDER_PATH / "short_inputs.xml").as_posix()
 
     # Using default file formatter
     api.variable_viewer(file_path)

--- a/src/fastoad/cmd/tests/test_cli.py
+++ b/src/fastoad/cmd/tests/test_cli.py
@@ -1,5 +1,5 @@
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2022 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -11,10 +11,9 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import os
-import os.path as pth
+import shutil
 from filecmp import cmp
-from shutil import rmtree
+from pathlib import Path
 
 import pandas as pd
 import pytest
@@ -22,14 +21,14 @@ from click.testing import CliRunner
 
 from fastoad.cmd.cli import NOTEBOOK_FOLDER_NAME, fast_oad
 
-DATA_FOLDER_PATH = pth.join(pth.dirname(__file__), "data")
-RESULTS_FOLDER_PATH = pth.join(pth.dirname(__file__), "results", "cli")
+DATA_FOLDER_PATH = Path(__file__).parent / "data"
+RESULTS_FOLDER_PATH = Path(__file__).parent / "results" / Path(__file__).stem
 
 
 @pytest.fixture(scope="module")
 def cleanup():
-    rmtree(RESULTS_FOLDER_PATH, ignore_errors=True)
-    os.makedirs(RESULTS_FOLDER_PATH)  # needed for CliRunner.isolated_filesystem()
+    shutil.rmtree(RESULTS_FOLDER_PATH, ignore_errors=True)
+    RESULTS_FOLDER_PATH.mkdir(parents=True)
 
 
 def test_plugin_info_no_plugin(with_no_plugin):
@@ -88,10 +87,10 @@ def test_gen_conf_one_plugin(cleanup, with_dummy_plugin_1, plugin_root_path):
             fast_oad,
             ["gen_conf", "my_conf.yml"],
         )
-        original_file = pth.join(
-            plugin_root_path, "dist_1", "dummy_plugin_1", "configurations", "dummy_conf_1-1.yml"
+        original_file = (
+            plugin_root_path / "dist_1" / "dummy_plugin_1" / "configurations" / "dummy_conf_1-1.yml"
         )
-        assert cmp(pth.join(temp_dir, "my_conf.yml"), original_file)
+        assert cmp(Path(temp_dir, "my_conf.yml"), original_file)
         assert not result.exception
         assert result.exit_code == 0
         assert result.output.endswith("has been written.\n")
@@ -208,10 +207,10 @@ def test_gen_conf_several_plugin(cleanup, with_dummy_plugins, plugin_root_path):
         assert not result.exception
         assert result.exit_code == 0
         assert result.output.endswith("has been written.\n")
-        original_file = pth.join(
-            plugin_root_path, "dist_1", "dummy_plugin_1", "configurations", "dummy_conf_1-1.yml"
+        original_file = (
+            plugin_root_path / "dist_1" / "dummy_plugin_1" / "configurations" / "dummy_conf_1-1.yml"
         )
-        assert cmp(pth.join(temp_dir, "my_conf.yml"), original_file)
+        assert cmp(Path(temp_dir, "my_conf.yml"), original_file)
 
         # ----------------------------------------------------------------------
         result = runner.invoke(
@@ -221,10 +220,14 @@ def test_gen_conf_several_plugin(cleanup, with_dummy_plugins, plugin_root_path):
         assert not result.exception
         assert result.exit_code == 0
         assert result.output.endswith("has been written.\n")
-        original_file = pth.join(
-            plugin_root_path, "dist_2", "dummy_plugin_3", "configurations", "dummy_conf_3-2.yaml"
+        original_file = (
+            plugin_root_path
+            / "dist_2"
+            / "dummy_plugin_3"
+            / "configurations"
+            / "dummy_conf_3-2.yaml"
         )
-        assert cmp(pth.join(temp_dir, "my_conf.yml"), original_file)
+        assert cmp(Path(temp_dir, "my_conf.yml"), original_file)
 
 
 def test_gen_source_data_file_no_plugin(with_no_plugin):
@@ -243,14 +246,14 @@ def test_gen_source_data_file_one_plugin(cleanup, with_dummy_plugin_4, plugin_ro
             fast_oad,
             ["gen_source_data_file", "my_source.xml"],
         )
-        original_file = pth.join(
-            plugin_root_path,
-            "dist_1",
-            "dummy_plugin_4",
-            "source_data_files",
-            "dummy_source_data_4-1.xml",
+        original_file = (
+            plugin_root_path
+            / "dist_1"
+            / "dummy_plugin_4"
+            / "source_data_files"
+            / "dummy_source_data_4-1.xml"
         )
-        assert cmp(pth.join(temp_dir, "my_source.xml"), original_file)
+        assert cmp(Path(temp_dir, "my_source.xml"), original_file)
         assert not result.exception
         assert result.exit_code == 0
         assert result.output.endswith("has been written.\n")
@@ -406,14 +409,14 @@ def test_gen_source_data_several_plugin(cleanup, with_dummy_plugins, plugin_root
         assert not result.exception
         assert result.exit_code == 0
         assert result.output.endswith("has been written.\n")
-        original_file = pth.join(
-            plugin_root_path,
-            "dist_1",
-            "dummy_plugin_4",
-            "source_data_files",
-            "dummy_source_data_4-1.xml",
+        original_file = (
+            plugin_root_path
+            / "dist_1"
+            / "dummy_plugin_4"
+            / "source_data_files"
+            / "dummy_source_data_4-1.xml"
         )
-        assert cmp(pth.join(temp_dir, "my_source.xml"), original_file)
+        assert cmp(Path(temp_dir, "my_source.xml"), original_file)
 
         # ----------------------------------------------------------------------
         result = runner.invoke(
@@ -431,14 +434,14 @@ def test_gen_source_data_several_plugin(cleanup, with_dummy_plugins, plugin_root
         assert not result.exception
         assert result.exit_code == 0
         assert result.output.endswith("has been written.\n")
-        original_file = pth.join(
-            plugin_root_path,
-            "dist_2",
-            "dummy_plugin_3",
-            "source_data_files",
-            "dummy_source_data_3-2.xml",
+        original_file = (
+            plugin_root_path
+            / "dist_2"
+            / "dummy_plugin_3"
+            / "source_data_files"
+            / "dummy_source_data_3-2.xml"
         )
-        assert cmp(pth.join(temp_dir, "my_source.xml"), original_file)
+        assert cmp(Path(temp_dir, "my_source.xml"), original_file)
 
 
 def test_create_notebooks_with_no_notebook(cleanup, with_dummy_plugin_2, plugin_root_path):
@@ -455,30 +458,30 @@ def test_create_notebooks_with_1_distribution(
 ):
     runner = CliRunner()
     with runner.isolated_filesystem(temp_dir=RESULTS_FOLDER_PATH) as temp_dir:
-        notebook_folder = pth.join(temp_dir, NOTEBOOK_FOLDER_NAME)
+        notebook_folder = Path(temp_dir, NOTEBOOK_FOLDER_NAME)
 
         # Test basic run =======================================================
         result = runner.invoke(fast_oad, ["notebooks"])
         assert not result.exception
         assert result.exit_code == 0
         assert result.output.startswith(f'"{notebook_folder}" has been written')
-        assert pth.isdir(notebook_folder)
-        assert pth.isfile(pth.join(notebook_folder, "test_plugin_1", "notebook_1.ipynb"))
-        assert pth.isfile(pth.join(notebook_folder, "test_plugin_4", "notebook_1.ipynb"))
-        assert pth.isdir(pth.join(temp_dir, NOTEBOOK_FOLDER_NAME, "test_plugin_4", "data"))
+        assert notebook_folder.exists()
+        assert (notebook_folder / "test_plugin_1" / "notebook_1.ipynb").is_file()
+        assert (notebook_folder / "test_plugin_4" / "notebook_1.ipynb").is_file()
+        assert Path(temp_dir, NOTEBOOK_FOLDER_NAME, "test_plugin_4", "data").is_dir()
 
     with runner.isolated_filesystem(temp_dir=RESULTS_FOLDER_PATH) as temp_dir:
-        notebook_folder = pth.join(temp_dir, NOTEBOOK_FOLDER_NAME)
+        notebook_folder = Path(temp_dir, NOTEBOOK_FOLDER_NAME)
 
         # Test basic run with package specification ============================
         result = runner.invoke(fast_oad, ["notebooks", "--from_package", "dummy-dist-1"])
         assert not result.exception
         assert result.exit_code == 0
         assert result.output.startswith(f'"{notebook_folder}" has been written')
-        assert pth.isdir(notebook_folder)
-        assert pth.isfile(pth.join(notebook_folder, "test_plugin_1", "notebook_1.ipynb"))
-        assert pth.isfile(pth.join(notebook_folder, "test_plugin_4", "notebook_1.ipynb"))
-        assert pth.isdir(pth.join(temp_dir, NOTEBOOK_FOLDER_NAME, "test_plugin_4", "data"))
+        assert notebook_folder.is_dir()
+        assert (notebook_folder / "test_plugin_1" / "notebook_1.ipynb").is_file()
+        assert (notebook_folder / "test_plugin_4" / "notebook_1.ipynb").is_file()
+        assert Path(temp_dir, NOTEBOOK_FOLDER_NAME, "test_plugin_4", "data").is_dir()
 
         # ----------------------------------------------------------------------
         result = runner.invoke(fast_oad, ["notebooks", "--from_package", "unknown-dist"])
@@ -505,46 +508,42 @@ def test_create_notebooks_with_1_distribution(
         assert not result.exception
         assert result.exit_code == 0
         assert (
-            f'"{pth.join(temp_dir, "my_path", NOTEBOOK_FOLDER_NAME)}" has been written'
-            in result.output
+            f'"{Path(temp_dir, "my_path", NOTEBOOK_FOLDER_NAME)}" has been written' in result.output
         )
 
 
 def test_create_notebooks_with_plugins(cleanup, with_dummy_plugins, plugin_root_path):
     runner = CliRunner()
     with runner.isolated_filesystem(temp_dir=RESULTS_FOLDER_PATH) as temp_dir:
-        notebook_folder = pth.join(temp_dir, NOTEBOOK_FOLDER_NAME)
+        notebook_folder = Path(temp_dir, NOTEBOOK_FOLDER_NAME)
 
         # Test basic run =======================================================
         result = runner.invoke(fast_oad, ["notebooks"])
         assert not result.exception
         assert result.exit_code == 0
-        assert pth.isdir(notebook_folder)
-        assert pth.isfile(
-            pth.join(notebook_folder, "dummy-dist-1", "test_plugin_1", "notebook_1.ipynb")
-        )
-        assert pth.isfile(
-            pth.join(notebook_folder, "dummy-dist-1", "test_plugin_4", "notebook_1.ipynb")
-        )
-        assert pth.isdir(
-            pth.join(temp_dir, NOTEBOOK_FOLDER_NAME, "dummy-dist-1", "test_plugin_4", "data")
-        )
+        assert notebook_folder.is_dir()
+        assert (notebook_folder / "dummy-dist-1" / "test_plugin_1" / "notebook_1.ipynb").is_file()
 
-        assert pth.isdir(pth.join(notebook_folder, "dummy-dist-3"))
-        assert pth.isfile(pth.join(notebook_folder, "dummy-dist-3", "notebook_2.ipynb"))
+        assert (notebook_folder / "dummy-dist-1" / "test_plugin_4" / "notebook_1.ipynb").is_file()
+        assert Path(
+            temp_dir, NOTEBOOK_FOLDER_NAME, "dummy-dist-1", "test_plugin_4", "data"
+        ).is_dir()
+
+        assert (notebook_folder / "dummy-dist-3").is_dir()
+        assert (notebook_folder / "dummy-dist-3" / "notebook_2.ipynb").is_file()
 
     with runner.isolated_filesystem(temp_dir=RESULTS_FOLDER_PATH) as temp_dir:
-        notebook_folder = pth.join(temp_dir, NOTEBOOK_FOLDER_NAME)
+        notebook_folder = Path(temp_dir, NOTEBOOK_FOLDER_NAME)
 
         # Test basic run with package specification ============================
         result = runner.invoke(fast_oad, ["notebooks", "-p", "dummy-dist-1"])
         assert not result.exception
         assert result.exit_code == 0
         assert result.output.startswith(f'"{notebook_folder}" has been written')
-        assert pth.isdir(notebook_folder)
-        assert pth.isfile(pth.join(notebook_folder, "test_plugin_1", "notebook_1.ipynb"))
-        assert pth.isfile(pth.join(notebook_folder, "test_plugin_4", "notebook_1.ipynb"))
-        assert pth.isdir(pth.join(temp_dir, NOTEBOOK_FOLDER_NAME, "test_plugin_4", "data"))
+        assert notebook_folder.is_dir()
+        assert (notebook_folder / "test_plugin_1" / "notebook_1.ipynb").is_file()
+        assert (notebook_folder / "test_plugin_4" / "notebook_1.ipynb").is_file()
+        assert Path(temp_dir, NOTEBOOK_FOLDER_NAME, "test_plugin_4", "data").is_dir()
 
         # ----------------------------------------------------------------------
         result = runner.invoke(fast_oad, ["notebooks", "-p", "unknown-dist"])

--- a/src/fastoad/gui/tests/test_analysis_and_plots.py
+++ b/src/fastoad/gui/tests/test_analysis_and_plots.py
@@ -2,7 +2,7 @@
 Tests for analysis and plots functions
 """
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2022 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -14,18 +14,18 @@ Tests for analysis and plots functions
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import os.path as pth
+from pathlib import Path
 
 from .. import (
     aircraft_geometry_plot,
     drag_polar_plot,
     mass_breakdown_bar_plot,
     mass_breakdown_sun_plot,
-    wing_geometry_plot,
     payload_range_plot,
+    wing_geometry_plot,
 )
 
-DATA_FOLDER_PATH = pth.join(pth.dirname(__file__), "data")
+DATA_FOLDER_PATH = Path(__file__).parent / "data"
 
 
 def test_wing_geometry_plot():
@@ -33,7 +33,7 @@ def test_wing_geometry_plot():
     Basic tests for testing the plotting.
     """
 
-    filename = pth.join(DATA_FOLDER_PATH, "problem_outputs.xml")
+    filename = (DATA_FOLDER_PATH / "problem_outputs.xml").as_posix()
 
     # First plot
     # This is a rudimentary test as plot are difficult to verify
@@ -57,7 +57,7 @@ def test_aircraft_geometry_plot():
     Basic tests for testing the plotting.
     """
 
-    filename = pth.join(DATA_FOLDER_PATH, "problem_outputs.xml")
+    filename = (DATA_FOLDER_PATH / "problem_outputs.xml").as_posix()
 
     # First plot
     # This is a rudimentary test as plot are difficult to verify
@@ -81,7 +81,7 @@ def test_mass_breakdown_bar_plot():
     Basic tests for testing the plotting.
     """
 
-    filename = pth.join(DATA_FOLDER_PATH, "problem_outputs.xml")
+    filename = (DATA_FOLDER_PATH / "problem_outputs.xml").as_posix()
 
     # First plot
     # This is a rudimentary test as plot are difficult to verify
@@ -105,7 +105,7 @@ def test_drag_polar_plot():
     Basic tests for testing the plotting.
     """
 
-    filename = pth.join(DATA_FOLDER_PATH, "problem_outputs.xml")
+    filename = (DATA_FOLDER_PATH / "problem_outputs.xml").as_posix()
 
     # First plot
     # This is a rudimentary test as plot are difficult to verify
@@ -118,7 +118,7 @@ def test_mass_breakdown_sun_plot():
     Basic tests for testing the plotting.
     """
 
-    filename = pth.join(DATA_FOLDER_PATH, "problem_outputs.xml")
+    filename = (DATA_FOLDER_PATH / "problem_outputs.xml").as_posix()
 
     # First plot
     # This is a rudimentary test as plot are difficult to verify
@@ -131,7 +131,7 @@ def test_payload_range_plot():
     Basic tests for testing the plotting.
     """
 
-    filename = pth.join(DATA_FOLDER_PATH, "problem_outputs.xml")
+    filename = (DATA_FOLDER_PATH / "problem_outputs.xml").as_posix()
 
     # First plot
     # This is a rudimentary test as plot are difficult to verify

--- a/src/fastoad/gui/tests/test_mission_viewer.py
+++ b/src/fastoad/gui/tests/test_mission_viewer.py
@@ -2,7 +2,7 @@
 Tests for FAST-OAD mission viewer
 """
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -14,28 +14,21 @@ Tests for FAST-OAD mission viewer
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import os.path as pth
-from shutil import rmtree
+from pathlib import Path
 
 import pandas as pd
 import pytest
 
 from ..mission_viewer import MissionViewer
 
-DATA_FOLDER_PATH = pth.join(pth.dirname(__file__), "data")
-RESULTS_FOLDER_PATH = pth.join(pth.dirname(__file__), "results")
+DATA_FOLDER_PATH = Path(__file__).parent / "data"
 
 
-@pytest.fixture(scope="module")
-def cleanup():
-    rmtree(RESULTS_FOLDER_PATH, ignore_errors=True)
-
-
-def test_mission_viewer(cleanup):
+def test_mission_viewer():
     """
     Basic tests for testing the mission viewer.
     """
-    filename = pth.join(DATA_FOLDER_PATH, "flight_points.csv")
+    filename = (DATA_FOLDER_PATH / "flight_points.csv").as_posix()
 
     mission_viewer = MissionViewer()
 
@@ -48,5 +41,5 @@ def test_mission_viewer(cleanup):
 
     # Testing with existing .yml
     with pytest.raises(TypeError):
-        filename = pth.join(DATA_FOLDER_PATH, "valid_sellar.yml")
+        filename = (DATA_FOLDER_PATH / "valid_sellar.yml").as_posix()
         mission_viewer.add_mission(filename, name="Mission 2")

--- a/src/fastoad/gui/tests/test_optimization_viewer.py
+++ b/src/fastoad/gui/tests/test_optimization_viewer.py
@@ -2,7 +2,7 @@
 Tests for FAST-OAD optimization viewer
 """
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -14,9 +14,8 @@ Tests for FAST-OAD optimization viewer
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import os.path as pth
-from os import makedirs
-from shutil import copyfile, rmtree
+import shutil
+from pathlib import Path
 
 import pytest
 
@@ -25,21 +24,20 @@ from fastoad.io.configuration.configuration import FASTOADProblemConfigurator
 from .. import OptimizationViewer
 from ..exceptions import FastMissingFile
 
-DATA_FOLDER_PATH = pth.join(pth.dirname(__file__), "data")
-RESULTS_FOLDER_PATH = pth.join(pth.dirname(__file__), "results")
+DATA_FOLDER_PATH = Path(__file__).parent / "data"
+RESULTS_FOLDER_PATH = Path(__file__).parent / "results"
 
 
 @pytest.fixture(scope="module")
 def cleanup():
-    rmtree(RESULTS_FOLDER_PATH, ignore_errors=True)
-    makedirs(RESULTS_FOLDER_PATH)
+    shutil.rmtree(RESULTS_FOLDER_PATH, ignore_errors=True)
 
 
 def test_optimization_viewer_load(cleanup):
     """
     Basic tests for testing the OptimizationViewer load method.
     """
-    filename = pth.join(DATA_FOLDER_PATH, "valid_sellar.yml")
+    filename = (DATA_FOLDER_PATH / "valid_sellar.yml").as_posix()
 
     # The problem has not yet been run
     problem_configuration = FASTOADProblemConfigurator(filename)
@@ -50,7 +48,7 @@ def test_optimization_viewer_load(cleanup):
     with pytest.raises(FastMissingFile):
         optim_viewer.load(problem_configuration)
 
-    api.generate_inputs(filename, pth.join(DATA_FOLDER_PATH, "inputs.xml"), overwrite=True)
+    api.generate_inputs(filename, DATA_FOLDER_PATH / "inputs.xml", overwrite=True)
 
     # Input file exist
     optim_viewer.load(problem_configuration)
@@ -66,16 +64,16 @@ def test_optimization_viewer_save(cleanup):
     """
     Basic tests for testing the OptimizationViewer save method.
     """
-    filename = pth.join(DATA_FOLDER_PATH, "valid_sellar.yml")
-    new_filename = pth.join(RESULTS_FOLDER_PATH, "new_valid_sellar.yml")
-    copyfile(filename, new_filename)
+    filename = DATA_FOLDER_PATH / "valid_sellar.yml"
+    new_filename = RESULTS_FOLDER_PATH / "new_valid_sellar.yml"
+    shutil.copy(filename, new_filename)
 
     # Loading new file
     problem_configuration = FASTOADProblemConfigurator(new_filename)
 
     optim_viewer = OptimizationViewer()
 
-    api.generate_inputs(new_filename, pth.join(DATA_FOLDER_PATH, "inputs.xml"), overwrite=True)
+    api.generate_inputs(new_filename, DATA_FOLDER_PATH / "inputs.xml", overwrite=True)
 
     # Load new file
     optim_viewer.load(problem_configuration)
@@ -93,14 +91,14 @@ def test_optimization_viewer_display(cleanup):
     """
     Basic tests for testing the OptimizationViewer load method.
     """
-    filename = pth.join(DATA_FOLDER_PATH, "valid_sellar.yml")
+    filename = DATA_FOLDER_PATH / "valid_sellar.yml"
 
     # The problem has not yet been ran
     problem_configuration = FASTOADProblemConfigurator(filename)
 
     optim_viewer = OptimizationViewer()
 
-    api.generate_inputs(filename, pth.join(DATA_FOLDER_PATH, "inputs.xml"), overwrite=True)
+    api.generate_inputs(filename, DATA_FOLDER_PATH / "inputs.xml", overwrite=True)
 
     optim_viewer.load(problem_configuration)
     optim_viewer.display()

--- a/src/fastoad/gui/tests/test_variable_viewer.py
+++ b/src/fastoad/gui/tests/test_variable_viewer.py
@@ -2,7 +2,7 @@
 Tests for FAST-OAD variable viewer
 """
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -14,22 +14,42 @@ Tests for FAST-OAD variable viewer
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import os.path as pth
+import shutil
+from pathlib import Path
 
 import pandas as pd
+import pytest
 from pandas.util.testing import assert_frame_equal
 
 from .. import VariableViewer
 
-DATA_FOLDER_PATH = pth.join(pth.dirname(__file__), "data")
-RESULTS_FOLDER_PATH = pth.join(pth.dirname(__file__), "results")
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
+#  FAST is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+DATA_FOLDER_PATH = Path(__file__).parent / "data"
+RESULTS_FOLDER_PATH = Path(__file__).parent / "results"
+
+
+@pytest.fixture(scope="module")
+def cleanup():
+    shutil.rmtree(RESULTS_FOLDER_PATH, ignore_errors=True)
 
 
 def test_variable_reader_display():
     """
     Basic tests for testing the VariableReader display method.
     """
-    filename = pth.join(DATA_FOLDER_PATH, "problem_outputs.xml")
+    filename = (DATA_FOLDER_PATH / "problem_outputs.xml").as_posix()
 
     # pylint: disable=invalid-name # that's a common naming
     df = VariableViewer()
@@ -97,7 +117,7 @@ def test_variable_reader_load():
 
     ref_df = ref_df.reset_index(drop=True)
 
-    filename = pth.join(DATA_FOLDER_PATH, "light_data.xml")
+    filename = (DATA_FOLDER_PATH / "light_data.xml").as_posix()
 
     # Testing file to df
     variable_viewer = VariableViewer()
@@ -166,7 +186,7 @@ def test_variable_reader_save():
 
     ref_df = ref_df.reset_index(drop=True)
 
-    filename = pth.join(RESULTS_FOLDER_PATH, "light_data.xml")
+    filename = (RESULTS_FOLDER_PATH / "light_data.xml").as_posix()
 
     # Testing file to df
     variable_viewer = VariableViewer()

--- a/src/fastoad/io/tests/test_data_file.py
+++ b/src/fastoad/io/tests/test_data_file.py
@@ -1,5 +1,5 @@
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2023 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -11,8 +11,8 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import os.path as pth
-from shutil import rmtree
+import shutil
+from pathlib import Path
 from typing import IO, Union
 
 import openmdao.api as om
@@ -22,13 +22,12 @@ from .. import IVariableIOFormatter
 from ..variable_io import DataFile
 from ...openmdao.variables import Variable, VariableList
 
-DATA_FOLDER_PATH = pth.join(pth.dirname(__file__), "data")
-RESULTS_FOLDER_PATH = pth.join(pth.dirname(__file__), "results")
+RESULTS_FOLDER_PATH = Path(__file__).parent / "results" / Path(__file__).stem
 
 
 @pytest.fixture(scope="module")
 def cleanup():
-    rmtree(RESULTS_FOLDER_PATH, ignore_errors=True)
+    shutil.rmtree(RESULTS_FOLDER_PATH, ignore_errors=True)
 
 
 @pytest.fixture(scope="module")
@@ -54,7 +53,7 @@ class DummyFormatter(IVariableIOFormatter):
 
 
 def test_datafile_save_read(cleanup, variables_ref):
-    file_path = pth.join(RESULTS_FOLDER_PATH, "dummy_data_file.xml")
+    file_path = (RESULTS_FOLDER_PATH / "dummy_data_file.xml").as_posix()
     with pytest.raises(FileNotFoundError) as exc_info:
         _ = DataFile(file_path)
     assert exc_info.value.args[0] == f'File "{file_path}" is unavailable for reading.'

--- a/src/fastoad/io/xml/tests/test_translator.py
+++ b/src/fastoad/io/xml/tests/test_translator.py
@@ -2,7 +2,7 @@
 Test module for translator.py
 """
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -14,17 +14,19 @@ Test module for translator.py
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import os.path as pth
+from pathlib import Path
 
 import pytest
 
 from ..exceptions import (
-    FastXpathTranslatorInconsistentLists,
     FastXpathTranslatorDuplicates,
-    FastXpathTranslatorXPathError,
+    FastXpathTranslatorInconsistentLists,
     FastXpathTranslatorVariableError,
+    FastXpathTranslatorXPathError,
 )
 from ..translator import VarXpathTranslator
+
+DATA_FOLDER_PATH = Path(__file__).parent / "data"
 
 
 def test_translator_with_set():
@@ -80,7 +82,7 @@ def test_translator_with_set():
 def test_translator_with_read():
     """Tests VarXpathTranslator using read() for providing translation data"""
 
-    data_file = pth.join(pth.dirname(__file__), "data", "custom_translation.txt")
+    data_file = DATA_FOLDER_PATH / "custom_translation.txt"
     translator = VarXpathTranslator()
     translator.read_translation_table(data_file)
 

--- a/src/fastoad/io/xml/tests/test_variable_io_legacy.py
+++ b/src/fastoad/io/xml/tests/test_variable_io_legacy.py
@@ -2,7 +2,7 @@
 Test module for variable_io_legacy.py
 """
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -14,8 +14,8 @@ Test module for variable_io_legacy.py
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import os.path as pth
-from shutil import rmtree
+import shutil
+from pathlib import Path
 
 import pytest
 from numpy.testing import assert_allclose
@@ -23,25 +23,36 @@ from numpy.testing import assert_allclose
 from .. import VariableLegacy1XmlFormatter
 from ... import VariableIO
 
-DATA_FOLDER_PATH = pth.join(pth.dirname(__file__), "data")
-RESULTS_FOLDER_PATH = pth.join(
-    pth.dirname(__file__), "results", pth.splitext(pth.basename(__file__))[0]
-)
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
+#  FAST is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+DATA_FOLDER_PATH = Path(__file__).parent / "data"
+RESULTS_FOLDER_PATH = Path(__file__).parent / "results" / Path(__file__).stem
 
 
 @pytest.fixture(scope="module")
 def cleanup():
-    rmtree(RESULTS_FOLDER_PATH, ignore_errors=True)
+    shutil.rmtree(RESULTS_FOLDER_PATH, ignore_errors=True)
 
 
 def test_legacy1(cleanup):
     """Tests class OMLegacy1XmlIO"""
-    result_folder = pth.join(RESULTS_FOLDER_PATH, "legacy1_xml")
+    result_folder = RESULTS_FOLDER_PATH / "legacy1_xml"
 
     # test read ---------------------------------------------------------------
-    filename = pth.join(DATA_FOLDER_PATH, "CeRAS01_baseline.xml")
+    filename = DATA_FOLDER_PATH / "CeRAS01_baseline.xml"
 
-    xml_read = VariableIO(filename, formatter=VariableLegacy1XmlFormatter())
+    xml_read = VariableIO(filename.as_posix(), formatter=VariableLegacy1XmlFormatter())
     var_list = xml_read.read()
 
     entry_count = len(var_list)
@@ -58,12 +69,12 @@ def test_legacy1(cleanup):
     assert var_list["data:geometry:wing:wetted_area"].units == "m**2"
 
     # test write ---------------------------------------------------------------
-    new_filename = pth.join(result_folder, "CeRAS01_baseline.xml")
-    xml_write = VariableIO(new_filename, formatter=VariableLegacy1XmlFormatter())
+    new_filename = result_folder / "CeRAS01_baseline.xml"
+    xml_write = VariableIO(new_filename.as_posix(), formatter=VariableLegacy1XmlFormatter())
     xml_write.write(var_list)
 
     # check by reading without conversion table
     # -> this will give the actual number of entries in the file
-    xml_check = VariableIO(new_filename)
+    xml_check = VariableIO(new_filename.as_posix())
     check_vars = xml_check.read()
     assert len(check_vars) == entry_count

--- a/src/fastoad/models/performances/mission/mission_definition/mission_builder/tests/test_mission_builder.py
+++ b/src/fastoad/models/performances/mission/mission_definition/mission_builder/tests/test_mission_builder.py
@@ -1,5 +1,5 @@
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2023 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -11,8 +11,8 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import os.path as pth
 from dataclasses import dataclass
+from pathlib import Path
 from unittest.mock import Mock
 
 import numpy as np
@@ -38,7 +38,7 @@ from ....segments.registered.start import Start
 from ....segments.registered.taxi import TaxiSegment
 from ....segments.registered.transition import DummyTransitionSegment
 
-DATA_FOLDER_PATH = pth.join(pth.dirname(__file__), "data")
+DATA_FOLDER_PATH = Path(__file__).parent / "data"
 
 
 # For this class, we purposely use the deprecated inheritance mechanism
@@ -75,7 +75,7 @@ def test_input_definition_units():
 
 def test_initialization():
     mission_builder = MissionBuilder(
-        pth.join(DATA_FOLDER_PATH, "mission.yml"),
+        (DATA_FOLDER_PATH / "mission.yml").as_posix(),
         propulsion=Mock(IPropulsion),
         reference_area=100.0,
     )
@@ -99,7 +99,7 @@ def test_initialization():
 
 def test_get_input_weight_variable_name():
     mission_builder = MissionBuilder(
-        pth.join(DATA_FOLDER_PATH, "mission.yml"),
+        (DATA_FOLDER_PATH / "mission.yml").as_posix(),
         propulsion=Mock(IPropulsion),
         reference_area=100.0,
     )
@@ -114,7 +114,7 @@ def test_get_input_weight_variable_name():
 
 def test_inputs():
     mission_builder = MissionBuilder(
-        pth.join(DATA_FOLDER_PATH, "mission.yml"),
+        (DATA_FOLDER_PATH / "mission.yml").as_posix(),
         propulsion=Mock(IPropulsion),
         reference_area=100.0,
     )
@@ -181,7 +181,7 @@ def test_inputs():
 
 
 def test_build():
-    mission_definition = MissionDefinition(pth.join(DATA_FOLDER_PATH, "mission.yml"))
+    mission_definition = MissionDefinition(DATA_FOLDER_PATH / "mission.yml")
     mission_builder = MissionBuilder(
         mission_definition, propulsion=Mock(IPropulsion), reference_area=100.0
     )
@@ -313,7 +313,7 @@ def test_build():
 
 
 def test_get_route_ranges():
-    mission_definition = MissionDefinition(pth.join(DATA_FOLDER_PATH, "mission.yml"))
+    mission_definition = MissionDefinition(DATA_FOLDER_PATH / "mission.yml")
     mission_builder = MissionBuilder(
         mission_definition, propulsion=Mock(IPropulsion), reference_area=100.0
     )
@@ -351,7 +351,7 @@ def test_get_route_ranges():
 
 def test_get_reserve():
     mission_builder = MissionBuilder(
-        pth.join(DATA_FOLDER_PATH, "mission.yml"),
+        (DATA_FOLDER_PATH / "mission.yml").as_posix(),
         propulsion=Mock(IPropulsion),
         reference_area=100.0,
     )

--- a/src/fastoad/models/performances/mission/mission_definition/tests/test_schema.py
+++ b/src/fastoad/models/performances/mission/mission_definition/tests/test_schema.py
@@ -1,5 +1,5 @@
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2022 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -11,16 +11,16 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import os.path as pth
 from collections import OrderedDict
+from pathlib import Path
 
 from ..schema import MissionDefinition
 
-DATA_FOLDER_PATH = pth.join(pth.dirname(__file__), "data")
+DATA_FOLDER_PATH = Path(__file__).parent / "data"
 
 
 def test_schema():
-    obtained_dict = MissionDefinition(pth.join(DATA_FOLDER_PATH, "mission.yml"))
+    obtained_dict = MissionDefinition(DATA_FOLDER_PATH / "mission.yml")
 
     # As we use Python 3.7+, Python dictionaries are ordered, but they are still
     # considered equal when the order of key differs.

--- a/src/fastoad/models/performances/mission/openmdao/tests/test_mission.py
+++ b/src/fastoad/models/performances/mission/openmdao/tests/test_mission.py
@@ -11,9 +11,8 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-
-import os.path as pth
-from shutil import rmtree
+import shutil
+from pathlib import Path
 
 import pytest
 from numpy.testing import assert_allclose
@@ -26,15 +25,13 @@ from ..mission_run import AdvancedMissionComp
 from ..mission_wrapper import MissionWrapper
 from ...mission_definition.exceptions import FastMissionFileMissingMissionNameError
 
-DATA_FOLDER_PATH = pth.join(pth.dirname(__file__), "data")
-RESULTS_FOLDER_PATH = pth.join(
-    pth.dirname(__file__), "results", pth.splitext(pth.basename(__file__))[0]
-)
+DATA_FOLDER_PATH = Path(__file__).parent / "data"
+RESULTS_FOLDER_PATH = Path(__file__).parent / "results" / Path(__file__).stem
 
 
 @pytest.fixture(scope="module")
 def cleanup():
-    rmtree(RESULTS_FOLDER_PATH, ignore_errors=True)
+    shutil.rmtree(RESULTS_FOLDER_PATH, ignore_errors=True)
 
 
 def plot_flight(flight_points, fig_filename):
@@ -86,23 +83,24 @@ def plot_flight(flight_points, fig_filename):
     labels = [l.get_label() for l in lines]
     plt.legend(lines, labels, loc=0)
 
-    plt.savefig(pth.join(RESULTS_FOLDER_PATH, fig_filename))
+    plt.savefig(RESULTS_FOLDER_PATH / fig_filename)
     plt.close()
 
 
 def test_mission_component(cleanup, with_dummy_plugin_2):
     # Also checking behavior when is_sizing is True
 
-    input_file_path = pth.join(DATA_FOLDER_PATH, "test_mission.xml")
-    ivc = DataFile(input_file_path).to_ivc()
+    input_file_path = DATA_FOLDER_PATH / "test_mission.xml"
+    ivc = DataFile(input_file_path.as_posix()).to_ivc()
 
     problem = run_system(
         AdvancedMissionComp(
             propulsion_id="test.wrapper.propulsion.dummy_engine",
-            out_file=pth.join(RESULTS_FOLDER_PATH, "mission.csv"),
+            out_file=(RESULTS_FOLDER_PATH / "mission.csv").as_posix(),
             use_initializer_iteration=False,
             mission_file_path=MissionWrapper(
-                pth.join(DATA_FOLDER_PATH, "test_mission.yml"), mission_name="operational"
+                (DATA_FOLDER_PATH / "test_mission.yml").as_posix(),
+                mission_name="operational",
             ),
             reference_area_variable="data:geometry:aircraft:reference_area",
             is_sizing=True,
@@ -161,18 +159,18 @@ def test_mission_component(cleanup, with_dummy_plugin_2):
 
 def test_mission_component_breguet(cleanup, with_dummy_plugin_2):
 
-    input_file_path = pth.join(DATA_FOLDER_PATH, "test_mission.xml")
-    vars = DataFile(input_file_path)
+    input_file_path = DATA_FOLDER_PATH / "test_mission.xml"
+    vars = DataFile(input_file_path.as_posix())
     ivc = vars.to_ivc()
     ivc.add_output("data:mission:operational:ramp_weight", 70100.0, units="kg")
 
     problem = run_system(
         AdvancedMissionComp(
             propulsion_id="test.wrapper.propulsion.dummy_engine",
-            out_file=pth.join(RESULTS_FOLDER_PATH, "breguet.csv"),
+            out_file=(RESULTS_FOLDER_PATH / "breguet.csv").as_posix(),
             use_initializer_iteration=False,
             mission_file_path=MissionWrapper(
-                pth.join(DATA_FOLDER_PATH, "test_breguet_from_block_fuel.yml"),
+                (DATA_FOLDER_PATH / "test_breguet_from_block_fuel.yml").as_posix(),
                 mission_name="operational",
             ),
             reference_area_variable="data:geometry:aircraft:reference_area",
@@ -206,16 +204,16 @@ def test_mission_component_breguet(cleanup, with_dummy_plugin_2):
 
 
 def test_mission_group_without_fuel_adjustment(cleanup, with_dummy_plugin_2):
-    input_file_path = pth.join(DATA_FOLDER_PATH, "test_mission.xml")
-    ivc = DataFile(input_file_path).to_ivc()
+    input_file_path = DATA_FOLDER_PATH / "test_mission.xml"
+    ivc = DataFile(input_file_path.as_posix()).to_ivc()
 
     with pytest.raises(FastMissionFileMissingMissionNameError):
         run_system(
             OMMission(
                 propulsion_id="test.wrapper.propulsion.dummy_engine",
-                out_file=pth.join(RESULTS_FOLDER_PATH, "unlooped_mission_group.csv"),
+                out_file=(RESULTS_FOLDER_PATH / "unlooped_mission_group.csv").as_posix(),
                 use_initializer_iteration=False,
-                mission_file_path=pth.join(DATA_FOLDER_PATH, "test_mission.yml"),
+                mission_file_path=(DATA_FOLDER_PATH / "test_mission.yml").as_posix(),
                 adjust_fuel=False,
                 reference_area_variable="data:geometry:aircraft:reference_area",
                 add_solver=True,
@@ -226,9 +224,9 @@ def test_mission_group_without_fuel_adjustment(cleanup, with_dummy_plugin_2):
     problem = run_system(
         OMMission(
             propulsion_id="test.wrapper.propulsion.dummy_engine",
-            out_file=pth.join(RESULTS_FOLDER_PATH, "unlooped_mission_group.csv"),
+            out_file=(RESULTS_FOLDER_PATH / "unlooped_mission_group.csv").as_posix(),
             use_initializer_iteration=False,
-            mission_file_path=pth.join(DATA_FOLDER_PATH, "test_mission.yml"),
+            mission_file_path=(DATA_FOLDER_PATH / "test_mission.yml").as_posix(),
             mission_name="operational",
             adjust_fuel=False,
             reference_area_variable="data:geometry:aircraft:reference_area",
@@ -245,15 +243,15 @@ def test_mission_group_without_fuel_adjustment(cleanup, with_dummy_plugin_2):
 
 
 def test_mission_group_breguet_without_fuel_adjustment(cleanup, with_dummy_plugin_2):
-    input_file_path = pth.join(DATA_FOLDER_PATH, "test_breguet.xml")
-    ivc = DataFile(input_file_path).to_ivc()
+    input_file_path = DATA_FOLDER_PATH / "test_breguet.xml"
+    ivc = DataFile(input_file_path.as_posix()).to_ivc()
 
     problem = run_system(
         OMMission(
             propulsion_id="test.wrapper.propulsion.dummy_engine",
-            out_file=pth.join(RESULTS_FOLDER_PATH, "unlooped_breguet_mission_group.csv"),
+            out_file=(RESULTS_FOLDER_PATH / "unlooped_breguet_mission_group.csv").as_posix(),
             use_initializer_iteration=False,
-            mission_file_path=pth.join(DATA_FOLDER_PATH, "test_breguet.yml"),
+            mission_file_path=(DATA_FOLDER_PATH / "test_breguet.yml").as_posix(),
             adjust_fuel=False,
             reference_area_variable="data:geometry:aircraft:reference_area",
         ),
@@ -267,17 +265,17 @@ def test_mission_group_breguet_without_fuel_adjustment(cleanup, with_dummy_plugi
 
 def test_mission_group_with_fuel_adjustment(cleanup, with_dummy_plugin_2):
 
-    input_file_path = pth.join(DATA_FOLDER_PATH, "test_mission.xml")
-    vars = DataFile(input_file_path)
+    input_file_path = DATA_FOLDER_PATH / "test_mission.xml"
+    vars = DataFile(input_file_path.as_posix())
     del vars["data:mission:operational:TOW"]
     ivc = vars.to_ivc()
 
     problem = run_system(
         OMMission(
             propulsion_id="test.wrapper.propulsion.dummy_engine",
-            out_file=pth.join(RESULTS_FOLDER_PATH, "looped_mission_group.csv"),
+            out_file=(RESULTS_FOLDER_PATH / "looped_mission_group.csv").as_posix(),
             use_initializer_iteration=True,
-            mission_file_path=pth.join(DATA_FOLDER_PATH, "test_mission.yml"),
+            mission_file_path=(DATA_FOLDER_PATH / "test_mission.yml").as_posix(),
             mission_name="operational",
             add_solver=True,
             reference_area_variable="data:geometry:aircraft:reference_area",
@@ -314,17 +312,17 @@ def test_mission_group_with_fuel_adjustment(cleanup, with_dummy_plugin_2):
 def test_mission_group_breguet_with_fuel_adjustment(cleanup, with_dummy_plugin_2):
     # Also checking behavior when is_sizing is True
 
-    input_file_path = pth.join(DATA_FOLDER_PATH, "test_breguet.xml")
-    vars = DataFile(input_file_path)
+    input_file_path = DATA_FOLDER_PATH / "test_breguet.xml"
+    vars = DataFile(input_file_path.as_posix())
     del vars["data:mission:operational:ramp_weight"]
     ivc = vars.to_ivc()
 
     problem = run_system(
         OMMission(
             propulsion_id="test.wrapper.propulsion.dummy_engine",
-            out_file=pth.join(RESULTS_FOLDER_PATH, "looped_breguet_mission_group.csv"),
+            out_file=(RESULTS_FOLDER_PATH / "looped_breguet_mission_group.csv").as_posix(),
             use_initializer_iteration=True,
-            mission_file_path=pth.join(DATA_FOLDER_PATH, "test_breguet.yml"),
+            mission_file_path=(DATA_FOLDER_PATH / "test_breguet.yml").as_posix(),
             add_solver=True,
             reference_area_variable="data:geometry:aircraft:reference_area",
             is_sizing=True,
@@ -360,16 +358,16 @@ def test_mission_group_breguet_with_fuel_adjustment(cleanup, with_dummy_plugin_2
 
 def test_mission_group_with_fuel_objective(cleanup, with_dummy_plugin_2):
 
-    input_file_path = pth.join(DATA_FOLDER_PATH, "test_mission.xml")
-    vars = DataFile(input_file_path)
+    input_file_path = DATA_FOLDER_PATH / "test_mission.xml"
+    vars = DataFile(input_file_path.as_posix())
     ivc = vars.to_ivc()
 
     problem = run_system(
         OMMission(
             propulsion_id="test.wrapper.propulsion.dummy_engine",
-            out_file=pth.join(RESULTS_FOLDER_PATH, "fuel_as_objective.csv"),
+            out_file=(RESULTS_FOLDER_PATH / "fuel_as_objective.csv").as_posix(),
             use_initializer_iteration=False,
-            mission_file_path=pth.join(DATA_FOLDER_PATH, "test_mission.yml"),
+            mission_file_path=(DATA_FOLDER_PATH / "test_mission.yml").as_posix(),
             mission_name="fuel_as_objective",
             add_solver=True,
             adjust_fuel=False,
@@ -399,8 +397,8 @@ def test_mission_group_with_fuel_objective(cleanup, with_dummy_plugin_2):
 
 def test_mission_group_with_CL_limitation(cleanup, with_dummy_plugin_2):
 
-    input_file_path = pth.join(DATA_FOLDER_PATH, "test_mission.xml")
-    vars = VariableIO(input_file_path).read(ignore=["data:mission:operational:max_CL"])
+    input_file_path = DATA_FOLDER_PATH / "test_mission.xml"
+    vars = VariableIO(input_file_path.as_posix()).read(ignore=["data:mission:operational:max_CL"])
     ivc = vars.to_ivc()
 
     # Activate CL limitation during cruise and climb
@@ -409,10 +407,11 @@ def test_mission_group_with_CL_limitation(cleanup, with_dummy_plugin_2):
     problem = run_system(
         AdvancedMissionComp(
             propulsion_id="test.wrapper.propulsion.dummy_engine",
-            out_file=pth.join(RESULTS_FOLDER_PATH, "CL_limitation_1.csv"),
+            out_file=(RESULTS_FOLDER_PATH / "CL_limitation_1.csv").as_posix(),
             use_initializer_iteration=False,
             mission_file_path=MissionWrapper(
-                pth.join(DATA_FOLDER_PATH, "test_mission.yml"), mission_name="operational"
+                (DATA_FOLDER_PATH / "test_mission.yml").as_posix(),
+                mission_name="operational",
             ),
             reference_area_variable="data:geometry:aircraft:reference_area",
         ),
@@ -439,10 +438,11 @@ def test_mission_group_with_CL_limitation(cleanup, with_dummy_plugin_2):
     problem = run_system(
         AdvancedMissionComp(
             propulsion_id="test.wrapper.propulsion.dummy_engine",
-            out_file=pth.join(RESULTS_FOLDER_PATH, "CL_limitation_2.csv"),
+            out_file=(RESULTS_FOLDER_PATH / "CL_limitation_2.csv").as_posix(),
             use_initializer_iteration=False,
             mission_file_path=MissionWrapper(
-                pth.join(DATA_FOLDER_PATH, "test_mission.yml"), mission_name="operational_optimal"
+                (DATA_FOLDER_PATH / "test_mission.yml").as_posix(),
+                mission_name="operational_optimal",
             ),
             reference_area_variable="data:geometry:aircraft:reference_area",
         ),
@@ -469,15 +469,15 @@ def test_mission_group_with_CL_limitation(cleanup, with_dummy_plugin_2):
 
 
 def test_mission_group_without_route(cleanup, with_dummy_plugin_2):
-    input_file_path = pth.join(DATA_FOLDER_PATH, "test_mission.xml")
-    ivc = DataFile(input_file_path).to_ivc()
+    input_file_path = DATA_FOLDER_PATH / "test_mission.xml"
+    ivc = DataFile(input_file_path.as_posix()).to_ivc()
 
     problem = run_system(
         OMMission(
             propulsion_id="test.wrapper.propulsion.dummy_engine",
-            out_file=pth.join(RESULTS_FOLDER_PATH, "without_route_mission_group.csv"),
+            out_file=(RESULTS_FOLDER_PATH / "without_route_mission_group.csv").as_posix(),
             use_initializer_iteration=False,
-            mission_file_path=pth.join(DATA_FOLDER_PATH, "test_mission.yml"),
+            mission_file_path=(DATA_FOLDER_PATH / "test_mission.yml").as_posix(),
             mission_name="without_route",
             adjust_fuel=True,
             reference_area_variable="data:geometry:aircraft:reference_area",

--- a/src/fastoad/models/performances/mission/openmdao/tests/test_mission_run.py
+++ b/src/fastoad/models/performances/mission/openmdao/tests/test_mission_run.py
@@ -1,5 +1,5 @@
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2023 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -11,9 +11,8 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import os.path as pth
-from os import makedirs
-from shutil import rmtree
+import shutil
+from pathlib import Path
 
 import pytest
 from numpy.testing import assert_allclose
@@ -23,28 +22,25 @@ from fastoad._utils.testing import run_system
 from fastoad.io import DataFile
 from ..mission_run import MissionComp
 
-DATA_FOLDER_PATH = pth.join(pth.dirname(__file__), "data")
-RESULTS_FOLDER_PATH = pth.join(
-    pth.dirname(__file__), "results", pth.splitext(pth.basename(__file__))[0]
-)
+DATA_FOLDER_PATH = Path(__file__).parent / "data"
+RESULTS_FOLDER_PATH = Path(__file__).parent / "results" / Path(__file__).stem
 
 
 @pytest.fixture(scope="module")
 def cleanup():
-    rmtree(RESULTS_FOLDER_PATH, ignore_errors=True)
-    makedirs(RESULTS_FOLDER_PATH)
+    shutil.rmtree(RESULTS_FOLDER_PATH, ignore_errors=True)
 
 
 def test_mission_run(cleanup, with_dummy_plugin_2):
 
-    input_file_path = pth.join(DATA_FOLDER_PATH, "test_mission_run.xml")
-    ivc = DataFile(input_file_path).to_ivc()
+    input_file_path = DATA_FOLDER_PATH / "test_mission_run.xml"
+    ivc = DataFile(input_file_path.as_posix()).to_ivc()
 
     problem = run_system(
         MissionComp(
             propulsion_id="test.wrapper.propulsion.dummy_engine",
-            out_file=pth.join(RESULTS_FOLDER_PATH, "mission.csv"),
-            mission_file_path=pth.join(DATA_FOLDER_PATH, "test_mission.yml"),
+            out_file=(RESULTS_FOLDER_PATH / "mission.csv").as_posix(),
+            mission_file_path=(DATA_FOLDER_PATH / "test_mission.yml").as_posix(),
             mission_name="operational",
             reference_area_variable="data:geometry:aircraft:reference_area",
             variable_prefix="data:payload_range",

--- a/src/fastoad/models/performances/mission/openmdao/tests/test_payload_range.py
+++ b/src/fastoad/models/performances/mission/openmdao/tests/test_payload_range.py
@@ -1,5 +1,5 @@
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2023 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -10,10 +10,8 @@
 #  GNU General Public License for more details.
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
-import os.path as pth
-from os import makedirs
-from shutil import rmtree
+import shutil
+from pathlib import Path
 
 import numpy as np
 import pytest
@@ -23,27 +21,24 @@ from fastoad._utils.testing import run_system
 from fastoad.io import DataFile
 from ..payload_range import PayloadRange
 
-DATA_FOLDER_PATH = pth.join(pth.dirname(__file__), "data")
-RESULTS_FOLDER_PATH = pth.join(
-    pth.dirname(__file__), "results", pth.splitext(pth.basename(__file__))[0]
-)
+DATA_FOLDER_PATH = Path(__file__).parent / "data"
+RESULTS_FOLDER_PATH = Path(__file__).parent / "results" / Path(__file__).stem
 
 
 @pytest.fixture(scope="module")
 def cleanup():
-    rmtree(RESULTS_FOLDER_PATH, ignore_errors=True)
-    makedirs(RESULTS_FOLDER_PATH)
+    shutil.rmtree(RESULTS_FOLDER_PATH, ignore_errors=True)
 
 
 def test_payload_range_custom_breguet_mission(cleanup, with_dummy_plugin_2):
 
-    input_file_path = pth.join(DATA_FOLDER_PATH, "test_payload_range.xml")
-    ivc = DataFile(input_file_path).to_ivc()
+    input_file_path = DATA_FOLDER_PATH / "test_payload_range.xml"
+    ivc = DataFile(input_file_path.as_posix()).to_ivc()
 
     problem = run_system(
         PayloadRange(
             propulsion_id="test.wrapper.propulsion.dummy_engine",
-            mission_file_path=pth.join(DATA_FOLDER_PATH, "test_payload_range.yml"),
+            mission_file_path=(DATA_FOLDER_PATH / "test_payload_range.yml").as_posix(),
             mission_name="operational",
             reference_area_variable="data:geometry:aircraft:reference_area",
             nb_contour_points=6,
@@ -108,8 +103,8 @@ def test_payload_range_custom_breguet_mission(cleanup, with_dummy_plugin_2):
 
 def test_payload_range_sizing_breguet(cleanup, with_dummy_plugin_2):
 
-    input_file_path = pth.join(DATA_FOLDER_PATH, "test_payload_range.xml")
-    ivc = DataFile(input_file_path).to_ivc()
+    input_file_path = DATA_FOLDER_PATH / "test_payload_range.xml"
+    ivc = DataFile(input_file_path.as_posix()).to_ivc()
 
     problem = run_system(
         PayloadRange(
@@ -143,8 +138,8 @@ def test_payload_range_sizing_breguet(cleanup, with_dummy_plugin_2):
 
 def test_payload_range_sizing_mission(cleanup, with_dummy_plugin_2):
 
-    input_file_path = pth.join(DATA_FOLDER_PATH, "test_payload_range.xml")
-    ivc = DataFile(input_file_path).to_ivc()
+    input_file_path = DATA_FOLDER_PATH / "test_payload_range.xml"
+    ivc = DataFile(input_file_path.as_posix()).to_ivc()
 
     problem = run_system(
         PayloadRange(

--- a/src/fastoad/models/performances/mission/openmdao/tests/test_sizing_breguet.py
+++ b/src/fastoad/models/performances/mission/openmdao/tests/test_sizing_breguet.py
@@ -1,5 +1,5 @@
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2022 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -10,9 +10,8 @@
 #  GNU General Public License for more details.
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
-import os.path as pth
-from shutil import rmtree
+import shutil
+from pathlib import Path
 
 import numpy as np
 import openmdao.api as om
@@ -22,14 +21,12 @@ from numpy.testing import assert_allclose
 from fastoad._utils.testing import run_system
 from ..mission import OMMission
 
-RESULTS_FOLDER_PATH = pth.join(
-    pth.dirname(__file__), "results", pth.splitext(pth.basename(__file__))[0]
-)
+RESULTS_FOLDER_PATH = Path(__file__).parent / "results" / Path(__file__).stem
 
 
 @pytest.fixture(scope="module")
 def cleanup():
-    rmtree(RESULTS_FOLDER_PATH, ignore_errors=True)
+    shutil.rmtree(RESULTS_FOLDER_PATH, ignore_errors=True)
 
 
 def test_sizing_breguet(cleanup, with_dummy_plugin_2):
@@ -58,7 +55,7 @@ def test_sizing_breguet(cleanup, with_dummy_plugin_2):
     problem = run_system(
         OMMission(
             propulsion_id="test.wrapper.propulsion.dummy_engine",
-            out_file=pth.join(RESULTS_FOLDER_PATH, "sizing_breguet.csv"),
+            out_file=(RESULTS_FOLDER_PATH / "sizing_breguet.csv").as_posix(),
             use_initializer_iteration=False,
             mission_file_path="::sizing_breguet",
             adjust_fuel=False,

--- a/src/fastoad/models/performances/mission/openmdao/tests/test_sizing_mission.py
+++ b/src/fastoad/models/performances/mission/openmdao/tests/test_sizing_mission.py
@@ -1,5 +1,5 @@
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2022 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -10,9 +10,8 @@
 #  GNU General Public License for more details.
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
-import os.path as pth
-from shutil import rmtree
+import shutil
+from pathlib import Path
 
 import numpy as np
 import openmdao.api as om
@@ -22,14 +21,12 @@ from numpy.testing import assert_allclose
 from fastoad._utils.testing import run_system
 from ..mission import OMMission
 
-RESULTS_FOLDER_PATH = pth.join(
-    pth.dirname(__file__), "results", pth.splitext(pth.basename(__file__))[0]
-)
+RESULTS_FOLDER_PATH = Path(__file__).parent / "results" / Path(__file__).stem
 
 
 @pytest.fixture(scope="module")
 def cleanup():
-    rmtree(RESULTS_FOLDER_PATH, ignore_errors=True)
+    shutil.rmtree(RESULTS_FOLDER_PATH, ignore_errors=True)
 
 
 def test_sizing_mission(cleanup, with_dummy_plugin_2):
@@ -66,7 +63,7 @@ def test_sizing_mission(cleanup, with_dummy_plugin_2):
     problem = run_system(
         OMMission(
             propulsion_id="test.wrapper.propulsion.dummy_engine",
-            out_file=pth.join(RESULTS_FOLDER_PATH, "sizing_mission.csv"),
+            out_file=(RESULTS_FOLDER_PATH / "sizing_mission.csv").as_posix(),
             use_initializer_iteration=False,
             mission_file_path="::sizing_mission",
             adjust_fuel=False,
@@ -76,8 +73,8 @@ def test_sizing_mission(cleanup, with_dummy_plugin_2):
     # import pandas as pd
     #
     # plot_flight(
-    #     pd.read_csv(pth.join(RESULTS_FOLDER_PATH, "sizing_mission.csv")),
-    #     pth.join(RESULTS_FOLDER_PATH, "sizing_mission.png"),
+    #     pd.read_csv(RESULTS_FOLDER_PATH / "sizing_mission.csv"),
+    #     RESULTS_FOLDER_PATH / "sizing_mission.png",
     # )
 
     assert_allclose(problem["data:mission:sizing:taxi_out:fuel"], 351.0, atol=1)

--- a/src/fastoad/models/performances/mission/openmdao/tests/test_with_custom_segment.py
+++ b/src/fastoad/models/performances/mission/openmdao/tests/test_with_custom_segment.py
@@ -1,5 +1,5 @@
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2023 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -10,10 +10,9 @@
 #  GNU General Public License for more details.
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
-import os.path as pth
+import shutil
 from dataclasses import dataclass
-from shutil import rmtree
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
@@ -26,15 +25,13 @@ from ..mission_run import AdvancedMissionComp
 from ..mission_wrapper import MissionWrapper
 from ...segments.base import AbstractFlightSegment, RegisterSegment
 
-DATA_FOLDER_PATH = pth.join(pth.dirname(__file__), "data")
-RESULTS_FOLDER_PATH = pth.join(
-    pth.dirname(__file__), "results", pth.splitext(pth.basename(__file__))[0]
-)
+DATA_FOLDER_PATH = Path(__file__).parent / "data"
+RESULTS_FOLDER_PATH = Path(__file__).parent / "results" / Path(__file__).stem
 
 
 @pytest.fixture(scope="module")
 def cleanup():
-    rmtree(RESULTS_FOLDER_PATH, ignore_errors=True)
+    shutil.rmtree(RESULTS_FOLDER_PATH, ignore_errors=True)
 
 
 @RegisterSegment("test_segment_A")
@@ -53,15 +50,15 @@ class TestSegment(AbstractFlightSegment):
 
 
 def test_with_custom_segment(cleanup, with_dummy_plugin_2):
-    input_file_path = pth.join(DATA_FOLDER_PATH, "test_with_custom_segment.xml")
-    ivc = DataFile(input_file_path).to_ivc()
+    input_file_path = DATA_FOLDER_PATH / "test_with_custom_segment.xml"
+    ivc = DataFile(input_file_path.as_posix()).to_ivc()
 
     problem = run_system(
         AdvancedMissionComp(
             propulsion_id="test.wrapper.propulsion.dummy_engine",
             use_initializer_iteration=False,
             mission_file_path=MissionWrapper(
-                pth.join(DATA_FOLDER_PATH, "test_with_custom_segment.yml")
+                (DATA_FOLDER_PATH / "test_with_custom_segment.yml").as_posix()
             ),
             mission_name="test",
         ),

--- a/src/fastoad/models/performances/mission/tests/test_routes.py
+++ b/src/fastoad/models/performances/mission/tests/test_routes.py
@@ -1,6 +1,6 @@
 """Tests module for routes.py"""
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2023 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -12,9 +12,8 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import os.path as pth
-from os import mkdir
-from shutil import rmtree
+import shutil
+from pathlib import Path
 
 import pytest
 from numpy.testing import assert_allclose
@@ -26,18 +25,28 @@ from .conftest import ClimbPhase, DescentPhase, InitialClimbPhase
 from ..routes import RangedRoute
 from ..segments.registered.cruise import CruiseSegment
 
-DATA_FOLDER_PATH = pth.join(pth.dirname(__file__), "data")
-RESULTS_FOLDER_PATH = pth.join(pth.dirname(__file__), "results")
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
+#  FAST is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+RESULTS_FOLDER_PATH = Path(__file__).parent / "results" / Path(__file__).stem
 
 
 @pytest.fixture(scope="module")
 def cleanup():
-    rmtree(RESULTS_FOLDER_PATH, ignore_errors=True)
-    mkdir(RESULTS_FOLDER_PATH)
+    shutil.rmtree(RESULTS_FOLDER_PATH, ignore_errors=True)
 
 
 def test_ranged_route(low_speed_polar, high_speed_polar, propulsion, cleanup):
-
     total_distance = 2.0e6
 
     kwargs = dict(propulsion=propulsion, reference_area=120.0)

--- a/src/fastoad/module_management/tests/test_bundle_loader.py
+++ b/src/fastoad/module_management/tests/test_bundle_loader.py
@@ -2,7 +2,7 @@
 Test module for bundle_loader.py
 """
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -15,7 +15,7 @@ Test module for bundle_loader.py
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import logging
-import os.path as pth
+from pathlib import Path
 
 import pelix
 import pytest
@@ -27,12 +27,12 @@ from ..exceptions import (
     FastBundleLoaderUnknownFactoryNameError,
 )
 
-_LOGGER = logging.getLogger(__name__)
-"""Logger for this module"""
+_LOGGER = logging.getLogger(__name__)  # Logger for this module
 
 logging.basicConfig(level=logging.DEBUG)
 
-DATA_FOLDER_PATH = pth.join(pth.dirname(__file__), "data")
+
+DATA_FOLDER_PATH = Path(__file__).parent / "data"
 
 
 @pytest.fixture()
@@ -105,7 +105,7 @@ def test_install_packages(delete_framework):
     """
     loader = BundleLoader()
 
-    loader.explore_folder(pth.join(DATA_FOLDER_PATH, "dummy_pelix_bundles"))
+    loader.explore_folder((DATA_FOLDER_PATH / "dummy_pelix_bundles").as_posix())
     assert (
         loader.framework.get_bundle_by_name("dummy_pelix_bundles.hello_world_with_decorators")
         is not None
@@ -128,7 +128,7 @@ def test_install_packages_on_faulty_install(delete_framework):
     sys.modules["numpy.random.mtrand"].__path__ = None
 
     # Install packages
-    loader.explore_folder(pth.join(DATA_FOLDER_PATH, "dummy_pelix_bundles"))
+    loader.explore_folder((DATA_FOLDER_PATH / "dummy_pelix_bundles").as_posix())
     assert (
         loader.framework.get_bundle_by_name("dummy_pelix_bundles.hello_world_with_decorators")
         is not None
@@ -144,7 +144,7 @@ def test_register_factory(delete_framework):
     """
 
     loader = BundleLoader()
-    loader.explore_folder(pth.join(DATA_FOLDER_PATH, "dummy_pelix_bundles"))
+    loader.explore_folder((DATA_FOLDER_PATH / "dummy_pelix_bundles").as_posix())
 
     class Greetings1:
         def hello(self, name="World"):
@@ -160,7 +160,7 @@ def test_get_services(delete_framework):
     Tests the method for retrieving services according to properties
     """
     loader = BundleLoader()
-    loader.explore_folder(pth.join(DATA_FOLDER_PATH, "dummy_pelix_bundles"))
+    loader.explore_folder((DATA_FOLDER_PATH / "dummy_pelix_bundles").as_posix())
 
     # Missing service
     services = loader.get_services("does.not.exists")
@@ -206,7 +206,7 @@ def test_instantiate_component(delete_framework):
     Tests the method for instantiating a component from factory name
     """
     loader = BundleLoader()
-    loader.explore_folder(pth.join(DATA_FOLDER_PATH, "dummy_pelix_bundles"))
+    loader.explore_folder((DATA_FOLDER_PATH / "dummy_pelix_bundles").as_posix())
 
     with pytest.raises(FastBundleLoaderUnknownFactoryNameError):
         unknown = loader.instantiate_component("the-unknown-hello-world-factory")
@@ -230,7 +230,7 @@ def test_get_factory_names(delete_framework):
     Tests the method for retrieving factories according to properties
     """
     loader = BundleLoader()
-    loader.explore_folder(pth.join(DATA_FOLDER_PATH, "dummy_pelix_bundles"))
+    loader.explore_folder((DATA_FOLDER_PATH / "dummy_pelix_bundles").as_posix())
 
     # Missing service
     factory_names = loader.get_factory_names("does.not.exists")

--- a/src/fastoad/module_management/tests/test_plugins.py
+++ b/src/fastoad/module_management/tests/test_plugins.py
@@ -1,5 +1,5 @@
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2023 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -10,8 +10,6 @@
 #  GNU General Public License for more details.
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
-import os.path as pth
 
 import pytest
 
@@ -30,8 +28,6 @@ from ..exceptions import (
     FastUnknownSourceDataFileError,
 )
 from ..service_registry import RegisterService
-
-DATA_FOLDER_PATH = pth.join(pth.dirname(__file__), "data")
 
 
 # Tests ####################################

--- a/src/fastoad/module_management/tests/test_register_openmdao_system.py
+++ b/src/fastoad/module_management/tests/test_register_openmdao_system.py
@@ -15,7 +15,7 @@ Test module for openmdao_system_registry.py
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import logging
-import os.path as pth
+from pathlib import Path
 
 import openmdao.api as om
 import pytest
@@ -29,13 +29,15 @@ from ..._utils.sellar.sellar_base import BasicSellarModel, BasicSellarProblem, I
 from ...openmdao.variables import Variable
 
 _LOGGER = logging.getLogger(__name__)  # Logger for this module
-DATA_FOLDER_PATH = pth.join(pth.dirname(__file__), "data")
+
+
+DATA_FOLDER_PATH = Path(__file__).parent / "data"
 
 
 @pytest.fixture(scope="module")
 def load():
     """Loads components"""
-    RegisterOpenMDAOSystem.explore_folder(pth.join(DATA_FOLDER_PATH, "module_sellar_example"))
+    RegisterOpenMDAOSystem.explore_folder((DATA_FOLDER_PATH / "module_sellar_example").as_posix())
 
 
 def test_variable_description(load):

--- a/src/fastoad/module_management/tests/test_register_specialized_service.py
+++ b/src/fastoad/module_management/tests/test_register_specialized_service.py
@@ -1,5 +1,5 @@
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -11,15 +11,15 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import os.path as pth
+
+from pathlib import Path
 
 import pytest
 
 from ..exceptions import FastBundleLoaderUnknownFactoryNameError, FastIncompatibleServiceClassError
 from ..service_registry import RegisterSpecializedService
 
-DATA_FOLDER_PATH = pth.join(pth.dirname(__file__), "data")
-
+DATA_FOLDER_PATH = Path(__file__).parent / "data"
 
 # Initialization of services ###############
 class DummyBase:
@@ -41,7 +41,7 @@ class RegisterDummyServiceB(
 @pytest.fixture(scope="module")
 def load():
     """Loads components"""
-    RegisterSpecializedService.explore_folder(pth.join(DATA_FOLDER_PATH, "dummy_services"))
+    RegisterSpecializedService.explore_folder((DATA_FOLDER_PATH / "dummy_services").as_posix())
 
 
 def test_get_provider_ids_without_explore_folders():

--- a/src/fastoad/module_management/tests/test_register_submodel.py
+++ b/src/fastoad/module_management/tests/test_register_submodel.py
@@ -1,5 +1,5 @@
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2022 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -11,7 +11,8 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import os.path as pth
+
+from pathlib import Path
 
 import pytest
 
@@ -23,8 +24,7 @@ from ..exceptions import (
 )
 from ..service_registry import RegisterSubmodel
 
-DATA_FOLDER_PATH = pth.join(pth.dirname(__file__), "data")
-
+DATA_FOLDER_PATH = Path(__file__).parent / "data"
 
 # Tests ####################################
 @pytest.fixture(scope="module")
@@ -32,7 +32,7 @@ def load():
     """Loads components"""
     previous_active_submodels = RegisterSubmodel.active_models
     RegisterSubmodel.active_models = {}
-    BundleLoader().explore_folder(pth.join(DATA_FOLDER_PATH, "dummy_submodels"))
+    BundleLoader().explore_folder((DATA_FOLDER_PATH / "dummy_submodels").as_posix())
     yield
     RegisterSubmodel.active_models = previous_active_submodels
 

--- a/src/fastoad/openmdao/tests/test_validity_checker.py
+++ b/src/fastoad/openmdao/tests/test_validity_checker.py
@@ -12,10 +12,9 @@
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import logging
-import os.path as pth
+import shutil
 from logging import FileHandler
-from os import mkdir
-from shutil import rmtree
+from pathlib import Path
 
 import openmdao.api as om
 import pytest
@@ -24,17 +23,17 @@ from .openmdao_sellar_example.disc1 import Disc1Bis, Disc1Ter
 from .openmdao_sellar_example.disc2 import Disc2
 from ..problem import FASTOADProblem
 from ..validity_checker import ValidityDomainChecker, ValidityStatus
-from ..variables import VariableList, Variable
+from ..variables import Variable, VariableList
 
 _LOGGER = logging.getLogger(__name__)  # Logger for this module
 
-RESULTS_FOLDER_PATH = pth.join(pth.dirname(__file__), "results", "validity_checker")
+RESULTS_FOLDER_PATH = Path(__file__).parent / "results" / Path(__file__).stem
 
 
 @pytest.fixture(scope="module")
 def cleanup():
-    rmtree(RESULTS_FOLDER_PATH, ignore_errors=True)
-    mkdir(RESULTS_FOLDER_PATH)
+    shutil.rmtree(RESULTS_FOLDER_PATH, ignore_errors=True)
+    RESULTS_FOLDER_PATH.mkdir(parents=True)
 
 
 def set_logger_file(log_file_path):
@@ -67,7 +66,7 @@ def test_register_checks_instantiation(cleanup):
     ValidityDomainChecker({"other_var": (-10.0, 1.0)}, "main.logger1")
 
     # Check 1 --------------------------------------------------------------------------------------
-    log_file_path = pth.join(RESULTS_FOLDER_PATH, "log1.txt")
+    log_file_path = RESULTS_FOLDER_PATH / "log1.txt"
     set_logger_file(log_file_path)
     variables = VariableList(
         [
@@ -104,7 +103,7 @@ def test_register_checks_instantiation(cleanup):
         assert len(log_file.readlines()) == 4
 
     # Check 2 --------------------------------------------------------------------------------------
-    log_file_path = pth.join(RESULTS_FOLDER_PATH, "log2.txt")
+    log_file_path = RESULTS_FOLDER_PATH / "log2.txt"
     set_logger_file(log_file_path)
     variables = VariableList(
         [
@@ -141,7 +140,7 @@ def test_register_checks_instantiation(cleanup):
         assert len(log_file.readlines()) == 4
 
     # Check 3 --------------------------------------------------------------------------------------
-    log_file_path = pth.join(RESULTS_FOLDER_PATH, "log3.txt")
+    log_file_path = RESULTS_FOLDER_PATH / "log3.txt"
     set_logger_file(log_file_path)
     variables = VariableList(
         [
@@ -177,7 +176,7 @@ def test_register_checks_instantiation(cleanup):
 
 
 def test_register_checks_as_decorator(cleanup):
-    log_file_path = pth.join(RESULTS_FOLDER_PATH, "log4.txt")
+    log_file_path = RESULTS_FOLDER_PATH / "log4.txt"
     set_logger_file(log_file_path)
 
     @ValidityDomainChecker({"input1": (1.0, 5.0), "output2": (300.0, 500.0)}, "main.dec")

--- a/src/fastoad/openmdao/tests/test_variables.py
+++ b/src/fastoad/openmdao/tests/test_variables.py
@@ -14,7 +14,7 @@ Module for testing VariableList.py
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import os.path as pth
+from pathlib import Path
 from typing import List
 
 import numpy as np
@@ -30,10 +30,24 @@ from .openmdao_sellar_example.functions import FunctionF, FunctionG1, FunctionG2
 from ..variables import Variable, VariableList
 
 
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
+#  FAST is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+
 @pytest.fixture(scope="module")
 def cleanup():
     # Need to clean up variable descriptions because it is manipulated in other tests.
-    Variable.read_variable_descriptions(pth.dirname(fastoad.models.__file__), update_existing=False)
+    Variable.read_variable_descriptions(Path(fastoad.models.__file__).parent, update_existing=False)
 
 
 def test_variables(with_dummy_plugin_2):

--- a/src/fastoad/openmdao/tests/test_whatsopt.py
+++ b/src/fastoad/openmdao/tests/test_whatsopt.py
@@ -10,8 +10,8 @@
 #  GNU General Public License for more details.
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
-import os.path as pth
-from shutil import rmtree
+import shutil
+from pathlib import Path
 
 import pytest
 
@@ -19,13 +19,14 @@ from .openmdao_sellar_example.sellar import SellarModel
 from ..problem import FASTOADProblem
 from ..whatsopt import write_xdsm
 
-DATA_FOLDER_PATH = pth.join(pth.dirname(__file__), "data")
-RESULTS_FOLDER_PATH = pth.join(pth.dirname(__file__), "results")
+DATA_FOLDER_PATH = Path(__file__).parent / "data"
+RESULTS_FOLDER_PATH = Path(__file__).parent / "results", Path(__file__).stem
 
 
 @pytest.fixture(scope="module")
 def cleanup():
-    rmtree(RESULTS_FOLDER_PATH, ignore_errors=True)
+    shutil.rmtree(RESULTS_FOLDER_PATH, ignore_errors=True)
+    RESULTS_FOLDER_PATH.mkdir()
 
 
 @pytest.mark.skip(
@@ -36,10 +37,10 @@ def test_write_xdsm(cleanup):
 
     problem = FASTOADProblem()
     problem.model.add_subsystem("sellar", SellarModel(), promotes=["*"])
-    problem.output_file_path = pth.join(RESULTS_FOLDER_PATH, "output.xml")
+    problem.output_file_path = RESULTS_FOLDER_PATH / "output.xml"
     problem.setup()
     problem.final_setup()
 
-    xdsm_file_path = pth.join(RESULTS_FOLDER_PATH, "xdsm.html")
-    write_xdsm(problem, xdsm_file_path, dry_run=True)
-    assert pth.exists(xdsm_file_path)
+    xdsm_file_path = RESULTS_FOLDER_PATH / "xdsm.html"
+    write_xdsm(problem, xdsm_file_path.as_posix(), dry_run=True)
+    assert xdsm_file_path.joinpath()


### PR DESCRIPTION
This PR begins the suppression of `os.path` usage in favor of `pathlib`.

In this first step, `pathlib` is now used in unit tests. When Path objects are not accepted by tested code, the `as_posix()` method is used.

Looking for `as_posix()` in `test_*.py` files will allow to spot parts of API that are not pathlib-compliant.