### PR TITLE
Enabling pathlib.Path inputs for DataFile objects

### DIFF
--- a/src/fastoad/cmd/api.py
+++ b/src/fastoad/cmd/api.py
@@ -2,7 +2,7 @@
 API
 """
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2022 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -22,9 +22,10 @@ import sys
 import textwrap as tw
 from collections import defaultdict
 from collections.abc import Iterable
-from time import time
-from typing import Dict, IO, List, Union
 from enum import Enum
+from io import TextIOBase
+from time import time
+from typing import Dict, List, Union
 
 import openmdao.api as om
 import pandas as pd
@@ -328,7 +329,7 @@ def generate_inputs(
 
 def list_variables(
     configuration_file_path: str,
-    out: Union[IO, str] = None,
+    out: Union[TextIOBase, str] = None,
     overwrite: bool = False,
     force_text_output: bool = False,
     tablefmt: str = "grid",
@@ -436,7 +437,7 @@ def _generate_table_format(variables_df, tablefmt="grid"):
 
 def list_modules(
     source_path: Union[List[str], str] = None,
-    out: Union[IO, str] = None,
+    out: Union[TextIOBase, str] = None,
     overwrite: bool = False,
     verbose: bool = False,
     force_text_output: bool = False,

--- a/src/fastoad/cmd/api.py
+++ b/src/fastoad/cmd/api.py
@@ -23,9 +23,9 @@ import textwrap as tw
 from collections import defaultdict
 from collections.abc import Iterable
 from enum import Enum
-from io import TextIOBase
+from os import PathLike
 from time import time
-from typing import Dict, List, Union
+from typing import Dict, List, Union, TextIO
 
 import openmdao.api as om
 import pandas as pd
@@ -328,8 +328,8 @@ def generate_inputs(
 
 
 def list_variables(
-    configuration_file_path: str,
-    out: Union[TextIOBase, str] = None,
+    configuration_file_path: Union[str, PathLike],
+    out: Union[str, PathLike, TextIO] = None,
     overwrite: bool = False,
     force_text_output: bool = False,
     tablefmt: str = "grid",
@@ -436,8 +436,8 @@ def _generate_table_format(variables_df, tablefmt="grid"):
 
 
 def list_modules(
-    source_path: Union[List[str], str] = None,
-    out: Union[TextIOBase, str] = None,
+    source_path: Union[List[Union[str, PathLike]], str, PathLike] = None,
+    out: Union[str, PathLike, TextIO] = None,
     overwrite: bool = False,
     verbose: bool = False,
     force_text_output: bool = False,

--- a/src/fastoad/io/formatter.py
+++ b/src/fastoad/io/formatter.py
@@ -1,5 +1,8 @@
+"""
+Base class for VariableIOFormatter objects.
+"""
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -12,6 +15,7 @@
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 from abc import ABC, abstractmethod
+from io import IOBase
 from typing import Union, IO
 
 from fastoad.openmdao.variables import VariableList
@@ -25,7 +29,7 @@ class IVariableIOFormatter(ABC):
     """
 
     @abstractmethod
-    def read_variables(self, data_source: Union[str, IO]) -> VariableList:
+    def read_variables(self, data_source: Union[str, IO, IOBase]) -> VariableList:
         """
         Reads variables from provided data source file.
 
@@ -34,7 +38,7 @@ class IVariableIOFormatter(ABC):
         """
 
     @abstractmethod
-    def write_variables(self, data_source: Union[str, IO], variables: VariableList):
+    def write_variables(self, data_source: Union[str, IO, IOBase], variables: VariableList):
         """
         Writes variables to defined data source file.
 

--- a/src/fastoad/io/formatter.py
+++ b/src/fastoad/io/formatter.py
@@ -15,7 +15,6 @@ Base class for VariableIOFormatter objects.
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 from abc import ABC, abstractmethod
-from io import IOBase
 from os import PathLike
 from typing import Union, IO
 
@@ -30,7 +29,7 @@ class IVariableIOFormatter(ABC):
     """
 
     @abstractmethod
-    def read_variables(self, data_source: Union[str, PathLike, IO, IOBase]) -> VariableList:
+    def read_variables(self, data_source: Union[str, PathLike, IO]) -> VariableList:
         """
         Reads variables from provided data source file.
 
@@ -39,9 +38,7 @@ class IVariableIOFormatter(ABC):
         """
 
     @abstractmethod
-    def write_variables(
-        self, data_source: Union[str, PathLike, IO, IOBase], variables: VariableList
-    ):
+    def write_variables(self, data_source: Union[str, PathLike, IO], variables: VariableList):
         """
         Writes variables to defined data source file.
 

--- a/src/fastoad/io/formatter.py
+++ b/src/fastoad/io/formatter.py
@@ -16,6 +16,7 @@ Base class for VariableIOFormatter objects.
 
 from abc import ABC, abstractmethod
 from io import IOBase
+from os import PathLike
 from typing import Union, IO
 
 from fastoad.openmdao.variables import VariableList
@@ -29,7 +30,7 @@ class IVariableIOFormatter(ABC):
     """
 
     @abstractmethod
-    def read_variables(self, data_source: Union[str, IO, IOBase]) -> VariableList:
+    def read_variables(self, data_source: Union[str, PathLike, IO, IOBase]) -> VariableList:
         """
         Reads variables from provided data source file.
 
@@ -38,7 +39,9 @@ class IVariableIOFormatter(ABC):
         """
 
     @abstractmethod
-    def write_variables(self, data_source: Union[str, IO, IOBase], variables: VariableList):
+    def write_variables(
+        self, data_source: Union[str, PathLike, IO, IOBase], variables: VariableList
+    ):
         """
         Writes variables to defined data source file.
 

--- a/src/fastoad/io/tests/test_data_file.py
+++ b/src/fastoad/io/tests/test_data_file.py
@@ -13,8 +13,9 @@
 
 import shutil
 from io import IOBase
+from os import PathLike
 from pathlib import Path
-from typing import Union
+from typing import Union, IO
 
 import openmdao.api as om
 import pytest
@@ -44,12 +45,14 @@ class DummyFormatter(IVariableIOFormatter):
     def __init__(self, variables):
         self.variables = variables
 
-    def read_variables(self, data_source: Union[str, IOBase]) -> VariableList:
+    def read_variables(self, data_source: Union[str, PathLike, IO, IOBase]) -> VariableList:
         var_list = VariableList()
         var_list.update(self.variables, add_variables=True)
         return var_list
 
-    def write_variables(self, data_source: Union[str, IOBase], variables: VariableList):
+    def write_variables(
+        self, data_source: Union[str, PathLike, IO, IOBase], variables: VariableList
+    ):
         self.variables.update(variables, add_variables=True)
 
 

--- a/src/fastoad/io/tests/test_data_file.py
+++ b/src/fastoad/io/tests/test_data_file.py
@@ -12,8 +12,9 @@
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import shutil
+from io import IOBase
 from pathlib import Path
-from typing import IO, Union
+from typing import Union
 
 import openmdao.api as om
 import pytest
@@ -43,12 +44,12 @@ class DummyFormatter(IVariableIOFormatter):
     def __init__(self, variables):
         self.variables = variables
 
-    def read_variables(self, data_source: Union[str, IO]) -> VariableList:
+    def read_variables(self, data_source: Union[str, IOBase]) -> VariableList:
         var_list = VariableList()
         var_list.update(self.variables, add_variables=True)
         return var_list
 
-    def write_variables(self, data_source: Union[str, IO], variables: VariableList):
+    def write_variables(self, data_source: Union[str, IOBase], variables: VariableList):
         self.variables.update(variables, add_variables=True)
 
 
@@ -75,6 +76,16 @@ def test_datafile_save_read(cleanup, variables_ref):
     assert len(data_file_2) == 2
 
     assert set(data_file_2) == set(variables_ref)
+
+    # Check using text file object --------------------
+    with open(file_path) as text_file_io:
+        data_file_3 = DataFile(text_file_io)
+    assert data_file_3 == data_file_2
+
+    # Check using binary file object --------------------
+    with open(file_path, "rb") as binary_file_io:
+        data_file_4 = DataFile(binary_file_io)
+    assert data_file_4 == data_file_2
 
 
 def test_datafile_from_ivc(variables_ref):

--- a/src/fastoad/io/tests/test_data_file.py
+++ b/src/fastoad/io/tests/test_data_file.py
@@ -12,7 +12,6 @@
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import shutil
-from io import IOBase
 from os import PathLike
 from pathlib import Path
 from typing import Union, IO
@@ -45,14 +44,12 @@ class DummyFormatter(IVariableIOFormatter):
     def __init__(self, variables):
         self.variables = variables
 
-    def read_variables(self, data_source: Union[str, PathLike, IO, IOBase]) -> VariableList:
+    def read_variables(self, data_source: Union[str, PathLike, IO]) -> VariableList:
         var_list = VariableList()
         var_list.update(self.variables, add_variables=True)
         return var_list
 
-    def write_variables(
-        self, data_source: Union[str, PathLike, IO, IOBase], variables: VariableList
-    ):
+    def write_variables(self, data_source: Union[str, PathLike, IO], variables: VariableList):
         self.variables.update(variables, add_variables=True)
 
 

--- a/src/fastoad/io/tests/test_data_file.py
+++ b/src/fastoad/io/tests/test_data_file.py
@@ -54,7 +54,7 @@ class DummyFormatter(IVariableIOFormatter):
 
 
 def test_datafile_save_read(cleanup, variables_ref):
-    file_path = (RESULTS_FOLDER_PATH / "dummy_data_file.xml").as_posix()
+    file_path = RESULTS_FOLDER_PATH / "dummy_data_file.xml"
     with pytest.raises(FileNotFoundError) as exc_info:
         _ = DataFile(file_path)
     assert exc_info.value.args[0] == f'File "{file_path}" is unavailable for reading.'

--- a/src/fastoad/io/variable_io.py
+++ b/src/fastoad/io/variable_io.py
@@ -119,32 +119,26 @@ class VariableIO:
         :return: filtered variables
         """
 
-        # Dev note: We use sets, but sets of Variable instances do
-        # not work. Do we work with variable names instead.
-        # FIXME: Variable instances are now hashable, so set of Variable instances should now work
+        if only is None and ignore is None:
+            return variables
 
-        var_names = variables.names()
+        used_variables = VariableList(
+            [
+                variable
+                for variable in variables
+                if not ignore or not any(fnmatchcase(variable.name, pattern) for pattern in ignore)
+            ]
+        )
 
-        if only is None:
-            used_var_names = set(var_names)
-        else:
-            used_var_names = set()
-            for pattern in only:
-                used_var_names.update(
-                    [variable.name for variable in variables if fnmatchcase(variable.name, pattern)]
-                )
+        if only is not None:
+            used_variables = VariableList(
+                [
+                    variable
+                    for variable in used_variables
+                    if any(fnmatchcase(variable.name, pattern) for pattern in only)
+                ]
+            )
 
-        if ignore is not None:
-            for pattern in ignore:
-                used_var_names.difference_update(
-                    [variable.name for variable in variables if fnmatchcase(variable.name, pattern)]
-                )
-
-        # It could be simpler, but I want to keep the order
-        used_variables = VariableList()
-        for var in variables:
-            if var.name in used_var_names:
-                used_variables.append(var)
         return used_variables
 
 

--- a/src/fastoad/io/variable_io.py
+++ b/src/fastoad/io/variable_io.py
@@ -11,7 +11,6 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import logging
 from fnmatch import fnmatchcase
 from io import IOBase
 from os import PathLike
@@ -23,8 +22,6 @@ from . import IVariableIOFormatter
 from .xml import VariableXmlStandardFormatter
 from .._utils.files import as_path
 from ..exceptions import FastError
-
-_LOGGER = logging.getLogger(__name__)  # Logger for this module
 
 
 class VariableIO:

--- a/src/fastoad/io/variable_io.py
+++ b/src/fastoad/io/variable_io.py
@@ -1,5 +1,5 @@
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2022 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -12,8 +12,9 @@
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 from fnmatch import fnmatchcase
+from io import IOBase
 from os.path import exists, isfile
-from typing import IO, List, Sequence, Union
+from typing import List, Sequence, Union, IO, Optional
 
 from fastoad.openmdao.variables import VariableList
 from . import IVariableIOFormatter
@@ -32,7 +33,9 @@ class VariableIO:
                       VariableBasicXmlFormatter instance.
     """
 
-    def __init__(self, data_source: Union[str, IO], formatter: IVariableIOFormatter = None):
+    def __init__(
+        self, data_source: Optional[Union[str, IO, IOBase]], formatter: IVariableIOFormatter = None
+    ):
         self.data_source = data_source
         self.formatter: IVariableIOFormatter = (
             formatter if formatter else VariableXmlStandardFormatter()
@@ -135,7 +138,7 @@ class DataFile(VariableList):
 
     def __init__(
         self,
-        data_source: Union[str, IO, list] = None,
+        data_source: Union[str, IO, IOBase, list] = None,
         formatter: IVariableIOFormatter = None,
         load_data=True,
     ):
@@ -156,7 +159,7 @@ class DataFile(VariableList):
         """
         super().__init__()
         self._variable_io = VariableIO(None, formatter)
-        if isinstance(data_source, (str, IO)):
+        if isinstance(data_source, (str, IO, IOBase)):
             self.file_path = data_source
             if load_data:
                 self.load()

--- a/src/fastoad/io/variable_io.py
+++ b/src/fastoad/io/variable_io.py
@@ -12,7 +12,6 @@
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 from fnmatch import fnmatchcase
-from io import IOBase
 from os import PathLike
 from pathlib import Path
 from typing import List, Sequence, Union, IO, Optional
@@ -37,7 +36,7 @@ class VariableIO:
 
     def __init__(
         self,
-        data_source: Optional[Union[str, PathLike, IO, IOBase]],
+        data_source: Optional[Union[str, PathLike, IO]],
         formatter: IVariableIOFormatter = None,
     ):
         if isinstance(data_source, (str, PathLike)):
@@ -149,7 +148,7 @@ class DataFile(VariableList):
 
     def __init__(
         self,
-        data_source: Union[str, PathLike, IO, IOBase, list] = None,
+        data_source: Union[str, PathLike, IO, list] = None,
         formatter: IVariableIOFormatter = None,
         load_data=True,
     ):
@@ -173,12 +172,12 @@ class DataFile(VariableList):
         self._variable_io = None
         self.formatter = formatter
 
-        if isinstance(data_source, (str, PathLike, IO, IOBase)):
+        if isinstance(data_source, list):
+            self.update(data_source)
+        elif data_source is not None:
             self.file_path = data_source
             if load_data:
                 self.load()
-        if isinstance(data_source, list):
-            self.update(data_source)
 
     @property
     def file_path(self) -> str:

--- a/src/fastoad/io/xml/tests/test_variable_io_base.py
+++ b/src/fastoad/io/xml/tests/test_variable_io_base.py
@@ -89,7 +89,7 @@ def test_custom_xml_read_and_write_from_ivc(cleanup):
 
     # test read ---------------------------------------------------------------
 
-    file_path = (DATA_FOLDER_PATH / "custom.xml").as_posix()
+    file_path = DATA_FOLDER_PATH / "custom.xml"
 
     translator = VarXpathTranslator(variable_names=var_names, xpaths=xpaths)
     xml_read = VariableIO(file_path, formatter=VariableXmlBaseFormatter(translator))
@@ -98,13 +98,13 @@ def test_custom_xml_read_and_write_from_ivc(cleanup):
 
     # test with a non-exhaustive translation table (missing variable name in the translator)
     # we expect that the variable is not included in the ivc
-    file_path = (DATA_FOLDER_PATH / "custom_additional_var.xml").as_posix()
+    file_path = DATA_FOLDER_PATH / "custom_additional_var.xml"
     xml_read = VariableIO(file_path, formatter=VariableXmlBaseFormatter(translator))
     var_list = xml_read.read()
     _check_basic_vars(var_list)
 
     # test with setting a translation with an additional var not present in the xml
-    file_path = (DATA_FOLDER_PATH / "custom.xml").as_posix()
+    file_path = DATA_FOLDER_PATH / "custom.xml"
     xml_read = VariableIO(
         file_path,
         formatter=VariableXmlBaseFormatter(
@@ -131,13 +131,13 @@ def test_custom_xml_read_and_write_from_ivc(cleanup):
     # test write --------------------------------------------------------------
     new_filename = result_folder / "custom.xml"
     translator = VarXpathTranslator(variable_names=var_names, xpaths=xpaths)
-    xml_write = VariableIO(new_filename.as_posix(), formatter=VariableXmlBaseFormatter(translator))
+    xml_write = VariableIO(new_filename, formatter=VariableXmlBaseFormatter(translator))
     xml_write.write(var_list)
 
     # check written data
     assert new_filename.is_file()
     translator.set(var_names, xpaths)
-    xml_check = VariableIO(new_filename.as_posix(), formatter=VariableXmlBaseFormatter(translator))
+    xml_check = VariableIO(new_filename, formatter=VariableXmlBaseFormatter(translator))
     new_ivc = xml_check.read()
     _check_basic_vars(new_ivc)
 
@@ -153,12 +153,12 @@ def test_custom_xml_read_and_write_with_translation_table(cleanup):
     # test after setting translation table
     filename = DATA_FOLDER_PATH / "custom.xml"
     translator = VarXpathTranslator(source=DATA_FOLDER_PATH / "custom_translation.txt")
-    xml_read = VariableIO(filename.as_posix(), formatter=VariableXmlBaseFormatter(translator))
+    xml_read = VariableIO(filename, formatter=VariableXmlBaseFormatter(translator))
     vars = xml_read.read()
     _check_basic_vars(vars)
 
     new_filename = result_folder / "custom.xml"
-    xml_write = VariableIO(new_filename.as_posix(), formatter=VariableXmlBaseFormatter(translator))
+    xml_write = VariableIO(new_filename, formatter=VariableXmlBaseFormatter(translator))
     xml_write.write(vars)
 
 
@@ -180,7 +180,7 @@ def test_custom_xml_read_and_write_with_only_or_ignore(cleanup):
     filename = DATA_FOLDER_PATH / "custom.xml"
 
     translator = VarXpathTranslator(variable_names=var_names, xpaths=xpaths)
-    xml_read = VariableIO(filename.as_posix(), formatter=VariableXmlBaseFormatter(translator))
+    xml_read = VariableIO(filename, formatter=VariableXmlBaseFormatter(translator))
 
     # test with "only"
     outputs = xml_read.read(only=["geometry:wing:span"])

--- a/src/fastoad/io/xml/tests/test_variable_io_base.py
+++ b/src/fastoad/io/xml/tests/test_variable_io_base.py
@@ -25,19 +25,6 @@ from .. import VariableXmlBaseFormatter
 from ..translator import VarXpathTranslator
 from ...variable_io import VariableIO
 
-#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
-#  FAST is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#  You should have received a copy of the GNU General Public License
-#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
 DATA_FOLDER_PATH = Path(__file__).parent / "data"
 RESULTS_FOLDER_PATH = Path(__file__).parent / "results" / Path(__file__).stem
 

--- a/src/fastoad/io/xml/tests/test_variable_io_legacy.py
+++ b/src/fastoad/io/xml/tests/test_variable_io_legacy.py
@@ -52,7 +52,7 @@ def test_legacy1(cleanup):
     # test read ---------------------------------------------------------------
     file_path = DATA_FOLDER_PATH / "CeRAS01_baseline.xml"
 
-    xml_read = VariableIO(file_path.as_posix(), formatter=VariableLegacy1XmlFormatter())
+    xml_read = VariableIO(file_path, formatter=VariableLegacy1XmlFormatter())
     var_list = xml_read.read()
 
     entry_count = len(var_list)
@@ -80,7 +80,7 @@ def test_legacy1(cleanup):
 
     # test write ---------------------------------------------------------------
     new_filename = result_folder / "CeRAS01_baseline.xml"
-    xml_write = VariableIO(new_filename.as_posix(), formatter=VariableLegacy1XmlFormatter())
+    xml_write = VariableIO(new_filename, formatter=VariableLegacy1XmlFormatter())
     xml_write.write(var_list)
 
     # check by reading without conversion table

--- a/src/fastoad/io/xml/tests/test_variable_io_legacy.py
+++ b/src/fastoad/io/xml/tests/test_variable_io_legacy.py
@@ -23,19 +23,6 @@ from numpy.testing import assert_allclose
 from .. import VariableLegacy1XmlFormatter
 from ... import VariableIO
 
-#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
-#  FAST is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#  You should have received a copy of the GNU General Public License
-#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
 DATA_FOLDER_PATH = Path(__file__).parent / "data"
 RESULTS_FOLDER_PATH = Path(__file__).parent / "results" / Path(__file__).stem
 

--- a/src/fastoad/io/xml/tests/test_variable_io_legacy.py
+++ b/src/fastoad/io/xml/tests/test_variable_io_legacy.py
@@ -50,9 +50,9 @@ def test_legacy1(cleanup):
     result_folder = RESULTS_FOLDER_PATH / "legacy1_xml"
 
     # test read ---------------------------------------------------------------
-    filename = DATA_FOLDER_PATH / "CeRAS01_baseline.xml"
+    file_path = DATA_FOLDER_PATH / "CeRAS01_baseline.xml"
 
-    xml_read = VariableIO(filename.as_posix(), formatter=VariableLegacy1XmlFormatter())
+    xml_read = VariableIO(file_path.as_posix(), formatter=VariableLegacy1XmlFormatter())
     var_list = xml_read.read()
 
     entry_count = len(var_list)
@@ -67,6 +67,16 @@ def test_legacy1(cleanup):
     assert var_list["data:TLAR:NPAX"].units is None
     assert_allclose(var_list["data:geometry:wing:wetted_area"].value, 200.607)
     assert var_list["data:geometry:wing:wetted_area"].units == "m**2"
+
+    # Check using text file object --------------------
+    with open(file_path, encoding="utf-8") as text_file_io:
+        var_list_2 = VariableIO(text_file_io, formatter=VariableLegacy1XmlFormatter()).read()
+    assert var_list_2 == var_list
+
+    # Check using binary file object --------------------
+    with open(file_path, "rb") as binary_file_io:
+        var_list_3 = VariableIO(binary_file_io, formatter=VariableLegacy1XmlFormatter()).read()
+    assert var_list_3 == var_list
 
     # test write ---------------------------------------------------------------
     new_filename = result_folder / "CeRAS01_baseline.xml"

--- a/src/fastoad/io/xml/tests/test_variable_io_standard.py
+++ b/src/fastoad/io/xml/tests/test_variable_io_standard.py
@@ -95,65 +95,75 @@ def test_basic_xml_read_and_write_from_vars(cleanup):
     result_folder = RESULTS_FOLDER_PATH / "basic_xml"
 
     # Check write hand-made component
-    vars = VariableList()
-    vars["geometry/total_surface"] = {"value": [780.3], "units": "m**2", "desc": "scalar 1"}
-    vars["geometry/wing/span"] = {"value": 42.0, "units": "m", "desc": "scalar 2"}
-    vars["geometry/wing/aspect_ratio"] = {"value": [9.8]}
-    vars["geometry/fuselage/length"] = {"value": 40.0, "units": "m"}
-    vars["constants"] = {"value": [-42.0], "desc": "value with children tags"}
-    vars["constants/k1"] = {"value": [1.0, 2.0, 3.0], "units": "kg"}
-    vars["constants/k2"] = {"value": [10.0, 20.0]}
-    vars["constants/k3"] = {
+    var_list = VariableList()
+    var_list["geometry/total_surface"] = {"value": [780.3], "units": "m**2", "desc": "scalar 1"}
+    var_list["geometry/wing/span"] = {"value": 42.0, "units": "m", "desc": "scalar 2"}
+    var_list["geometry/wing/aspect_ratio"] = {"value": [9.8]}
+    var_list["geometry/fuselage/length"] = {"value": 40.0, "units": "m"}
+    var_list["constants"] = {"value": [-42.0], "desc": "value with children tags"}
+    var_list["constants/k1"] = {"value": [1.0, 2.0, 3.0], "units": "kg"}
+    var_list["constants/k2"] = {"value": [10.0, 20.0]}
+    var_list["constants/k3"] = {
         "value": np.array([100.0, 200.0, 300.0, 400.0]),
         "units": "m/s",
         "desc": "value list, space-separated",
     }
-    vars["constants/k4"] = {
+    var_list["constants/k4"] = {
         "value": [-1.0, -2.0, -3.0],
         "desc": "value list, brackets + comma-separated",
     }
-    vars["constants/k5"] = {
+    var_list["constants/k5"] = {
         "value": [100.0, 200.0, 400.0, 500.0, 600.0],
         "desc": "value list, comma-separated",
     }
-    vars["constants/k8"] = {"value": [[1e2, 3.4e5], [5.4e3, 2.1]], "desc": "2D list"}
+    var_list["constants/k8"] = {"value": [[1e2, 3.4e5], [5.4e3, 2.1]], "desc": "2D list"}
 
     # Try writing with non-existing folder
     assert not result_folder.exists()
-    filename = result_folder / "handmade.xml"
-    xml_write = VariableIO(filename.as_posix(), formatter=VariableXmlStandardFormatter())
+    file_path = result_folder / "handmade.xml"
+    xml_write = VariableIO(file_path.as_posix(), formatter=VariableXmlStandardFormatter())
     xml_write.path_separator = "/"
-    xml_write.write(vars)
+    xml_write.write(var_list)
 
     # check (read another IndepVarComp instance from xml)
-    xml_check = VariableIO(filename.as_posix(), formatter=VariableXmlStandardFormatter())
+    xml_check = VariableIO(file_path.as_posix(), formatter=VariableXmlStandardFormatter())
     xml_check.path_separator = ":"
-    new_vars = xml_check.read()
-    _check_basic_vars(new_vars)
+    new_var_list = xml_check.read()
+    _check_basic_vars(new_var_list)
 
     # Check reading hand-made XML (with some format twists)
-    filename = DATA_FOLDER_PATH / "basic.xml"
-    xml_read = VariableIO(filename.as_posix(), formatter=VariableXmlStandardFormatter())
+    file_path = DATA_FOLDER_PATH / "basic.xml"
+    xml_read = VariableIO(file_path.as_posix(), formatter=VariableXmlStandardFormatter())
     xml_read.path_separator = ":"
-    vars = xml_read.read()
-    _check_basic_vars(vars)
+    var_list = xml_read.read()
+    _check_basic_vars(var_list)
 
     # write it (with existing destination folder)
-    new_filename = result_folder / "basic.xml"
-    xml_write = VariableIO(new_filename.as_posix(), formatter=VariableXmlStandardFormatter())
+    new_file_path = result_folder / "basic.xml"
+    xml_write = VariableIO(new_file_path.as_posix(), formatter=VariableXmlStandardFormatter())
     xml_write.path_separator = ":"
-    xml_write.write(vars)
+    xml_write.write(var_list)
 
     # check (read another IndepVarComp instance from new xml)
-    xml_check = VariableIO(new_filename.as_posix(), formatter=VariableXmlStandardFormatter())
+    xml_check = VariableIO(new_file_path.as_posix(), formatter=VariableXmlStandardFormatter())
     xml_check.path_separator = ":"
-    new_vars = xml_check.read()
-    _check_basic_vars(new_vars)
+    new_var_list = xml_check.read()
+    _check_basic_vars(new_var_list)
 
     # try to write with bad separator
     xml_write.formatter.path_separator = "/"
     with pytest.raises(FastXPathEvalError):
-        xml_write.write(vars)
+        xml_write.write(var_list)
+
+    # Check using text file object --------------------
+    with open(file_path) as text_file_io:
+        var_list_2 = VariableIO(text_file_io, formatter=VariableXmlStandardFormatter()).read()
+    assert var_list_2 == var_list
+
+    # Check using binary file object --------------------
+    with open(file_path, "rb") as binary_file_io:
+        var_list_3 = VariableIO(binary_file_io, formatter=VariableXmlStandardFormatter()).read()
+    assert var_list_3 == var_list
 
 
 def test_basic_xml_partial_read_and_write_from_vars(cleanup):

--- a/src/fastoad/io/xml/tests/test_variable_io_standard.py
+++ b/src/fastoad/io/xml/tests/test_variable_io_standard.py
@@ -121,31 +121,31 @@ def test_basic_xml_read_and_write_from_vars(cleanup):
     # Try writing with non-existing folder
     assert not result_folder.exists()
     file_path = result_folder / "handmade.xml"
-    xml_write = VariableIO(file_path.as_posix(), formatter=VariableXmlStandardFormatter())
+    xml_write = VariableIO(file_path, formatter=VariableXmlStandardFormatter())
     xml_write.path_separator = "/"
     xml_write.write(var_list)
 
     # check (read another IndepVarComp instance from xml)
-    xml_check = VariableIO(file_path.as_posix(), formatter=VariableXmlStandardFormatter())
+    xml_check = VariableIO(file_path, formatter=VariableXmlStandardFormatter())
     xml_check.path_separator = ":"
     new_var_list = xml_check.read()
     _check_basic_vars(new_var_list)
 
     # Check reading hand-made XML (with some format twists)
     file_path = DATA_FOLDER_PATH / "basic.xml"
-    xml_read = VariableIO(file_path.as_posix(), formatter=VariableXmlStandardFormatter())
+    xml_read = VariableIO(file_path, formatter=VariableXmlStandardFormatter())
     xml_read.path_separator = ":"
     var_list = xml_read.read()
     _check_basic_vars(var_list)
 
     # write it (with existing destination folder)
     new_file_path = result_folder / "basic.xml"
-    xml_write = VariableIO(new_file_path.as_posix(), formatter=VariableXmlStandardFormatter())
+    xml_write = VariableIO(new_file_path, formatter=VariableXmlStandardFormatter())
     xml_write.path_separator = ":"
     xml_write.write(var_list)
 
     # check (read another IndepVarComp instance from new xml)
-    xml_check = VariableIO(new_file_path.as_posix(), formatter=VariableXmlStandardFormatter())
+    xml_check = VariableIO(new_file_path, formatter=VariableXmlStandardFormatter())
     xml_check.path_separator = ":"
     new_var_list = xml_check.read()
     _check_basic_vars(new_var_list)
@@ -174,7 +174,7 @@ def test_basic_xml_partial_read_and_write_from_vars(cleanup):
 
     # Read full IndepVarComp
     filename = DATA_FOLDER_PATH / "basic.xml"
-    xml_read = VariableIO(filename.as_posix(), formatter=VariableXmlStandardFormatter())
+    xml_read = VariableIO(filename, formatter=VariableXmlStandardFormatter())
     vars = xml_read.read(ignore=["does_not_exist"])
     _check_basic_vars(vars)
 
@@ -183,7 +183,7 @@ def test_basic_xml_partial_read_and_write_from_vars(cleanup):
     vars["should_also_be_ignored"] = {"value": -10.0}
 
     badvar_filename = result_folder / "with_bad_var.xml"
-    xml_write = VariableIO(badvar_filename.as_posix(), formatter=VariableXmlStandardFormatter())
+    xml_write = VariableIO(badvar_filename, formatter=VariableXmlStandardFormatter())
     xml_write.write(vars, ignore=["does_not_exist"])  # Check with non-existent var in ignore list
 
     tree = etree.parse(badvar_filename.as_posix())
@@ -191,7 +191,7 @@ def test_basic_xml_partial_read_and_write_from_vars(cleanup):
     assert float(tree.xpath("should_also_be_ignored")[0].text.strip()) == -10.0
 
     # Check partial reading with 'ignore'
-    xml_read = VariableIO(badvar_filename.as_posix(), formatter=VariableXmlStandardFormatter())
+    xml_read = VariableIO(badvar_filename, formatter=VariableXmlStandardFormatter())
     new_vars = xml_read.read(ignore=["should_be_ignored:pointless", "should_also_be_ignored"])
     _check_basic_vars(new_vars)
 
@@ -214,18 +214,18 @@ def test_basic_xml_partial_read_and_write_from_vars(cleanup):
 
     # Check partial writing with 'ignore'
     varok_filename = result_folder / "with_bad_var.xml"
-    xml_write = VariableIO(varok_filename.as_posix(), formatter=VariableXmlStandardFormatter())
+    xml_write = VariableIO(varok_filename, formatter=VariableXmlStandardFormatter())
     xml_write.write(vars, ignore=["should_be_ignored:pointless", "should_also_be_ignored"])
 
-    xml_read = VariableIO(varok_filename.as_posix(), formatter=VariableXmlStandardFormatter())
+    xml_read = VariableIO(varok_filename, formatter=VariableXmlStandardFormatter())
     new_vars = xml_read.read()
     _check_basic_vars(new_vars)
 
     # Check partial writing with 'only'
     varok2_filename = result_folder / "with_bad_var.xml"
-    xml_write = VariableIO(varok2_filename.as_posix(), formatter=VariableXmlStandardFormatter())
+    xml_write = VariableIO(varok2_filename, formatter=VariableXmlStandardFormatter())
     xml_write.write(vars, only=ok_vars)
 
-    xml_read = VariableIO(varok2_filename.as_posix(), formatter=VariableXmlStandardFormatter())
+    xml_read = VariableIO(varok2_filename, formatter=VariableXmlStandardFormatter())
     new_vars = xml_read.read()
     _check_basic_vars(new_vars)

--- a/src/fastoad/io/xml/translator.py
+++ b/src/fastoad/io/xml/translator.py
@@ -1,9 +1,8 @@
 """
 Conversion from OpenMDAO variables to XPath
 """
-
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -14,6 +13,8 @@ Conversion from OpenMDAO variables to XPath
 #  GNU General Public License for more details.
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from io import IOBase
 from typing import IO, Sequence, Set, Union
 
 import numpy as np
@@ -40,7 +41,7 @@ class VarXpathTranslator:
         *,
         variable_names: Sequence[str] = None,
         xpaths: Sequence[str] = None,
-        source: Union[str, IO] = None
+        source: Union[str, IOBase] = None
     ):
         if variable_names is not None and xpaths is not None:
             self.set(variable_names, xpaths)
@@ -80,7 +81,7 @@ class VarXpathTranslator:
         self._variable_names = list(variable_names)
         self._xpaths = list(xpaths)
 
-    def read_translation_table(self, source: Union[str, IO]):
+    def read_translation_table(self, source: Union[str, IO, IOBase]):
         """
         Reads a file that sets how OpenMDAO variable are matched to XML Path.
         Provided file should have 2 comma-separated columns:

--- a/src/fastoad/io/xml/translator.py
+++ b/src/fastoad/io/xml/translator.py
@@ -14,7 +14,6 @@ Conversion from OpenMDAO variables to XPath
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from io import IOBase
 from typing import IO, Sequence, Set, Union
 
 import numpy as np
@@ -41,7 +40,7 @@ class VarXpathTranslator:
         *,
         variable_names: Sequence[str] = None,
         xpaths: Sequence[str] = None,
-        source: Union[str, IOBase] = None
+        source: Union[str, IO] = None
     ):
         if variable_names is not None and xpaths is not None:
             self.set(variable_names, xpaths)
@@ -81,7 +80,7 @@ class VarXpathTranslator:
         self._variable_names = list(variable_names)
         self._xpaths = list(xpaths)
 
-    def read_translation_table(self, source: Union[str, IO, IOBase]):
+    def read_translation_table(self, source: Union[str, IO]):
         """
         Reads a file that sets how OpenMDAO variable are matched to XML Path.
         Provided file should have 2 comma-separated columns:

--- a/src/fastoad/io/xml/variable_io_base.py
+++ b/src/fastoad/io/xml/variable_io_base.py
@@ -2,7 +2,7 @@
 Defines how OpenMDAO variables are serialized to XML using a conversion table
 """
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2023 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -17,6 +17,7 @@ Defines how OpenMDAO variables are serialized to XML using a conversion table
 import json
 import logging
 import re
+from io import IOBase
 from typing import IO, Union
 
 import numpy as np
@@ -84,10 +85,10 @@ class VariableXmlBaseFormatter(IVariableIOFormatter):
             "°": "deg",
             "°C": "degC",
             "kt": "kn",
-            "\bin\b": "inch",
+            r"\bin\b": "inch",
         }
 
-    def read_variables(self, data_source: Union[str, IO]) -> VariableList:
+    def read_variables(self, data_source: Union[str, IO, IOBase]) -> VariableList:
         variables = VariableList()
 
         # If there is a comment, it will be used as description if the previous
@@ -145,7 +146,7 @@ class VariableXmlBaseFormatter(IVariableIOFormatter):
 
         return variables
 
-    def write_variables(self, data_source: Union[str, IO], variables: VariableList):
+    def write_variables(self, data_source: Union[str, IO, IOBase], variables: VariableList):
 
         root = etree.Element(ROOT_TAG)
 

--- a/src/fastoad/io/xml/variable_io_base.py
+++ b/src/fastoad/io/xml/variable_io_base.py
@@ -17,7 +17,6 @@ Defines how OpenMDAO variables are serialized to XML using a conversion table
 import json
 import logging
 import re
-from io import IOBase
 from os import PathLike
 from pathlib import Path
 from typing import IO, Union, Optional
@@ -90,7 +89,7 @@ class VariableXmlBaseFormatter(IVariableIOFormatter):
             r"\bin\b": "inch",
         }
 
-    def read_variables(self, data_source: Union[str, PathLike, IO, IOBase]) -> VariableList:
+    def read_variables(self, data_source: Union[str, PathLike, IO]) -> VariableList:
         variables = VariableList()
 
         # If there is a comment, it will be used as description if the previous
@@ -141,9 +140,7 @@ class VariableXmlBaseFormatter(IVariableIOFormatter):
 
         return variables
 
-    def write_variables(
-        self, data_source: Union[str, PathLike, IO, IOBase], variables: VariableList
-    ):
+    def write_variables(self, data_source: Union[str, PathLike, IO], variables: VariableList):
 
         root = etree.Element(ROOT_TAG)
 
@@ -175,7 +172,7 @@ class VariableXmlBaseFormatter(IVariableIOFormatter):
                 element.append(etree.Comment(variable.description))
         # Write
         tree = etree.ElementTree(root)
-        if not isinstance(data_source, (IO, IOBase)):
+        if isinstance(data_source, (str, PathLike)):
             make_parent_dir(data_source)
         if isinstance(data_source, Path):
             data_source = data_source.as_posix()

--- a/src/fastoad/io/xml/variable_io_standard.py
+++ b/src/fastoad/io/xml/variable_io_standard.py
@@ -16,6 +16,7 @@ Defines how OpenMDAO variables are serialized to XML
 
 import logging
 from io import IOBase
+from os import PathLike
 from typing import Union, IO
 
 from fastoad.openmdao.variables import VariableList
@@ -76,7 +77,7 @@ class VariableXmlStandardFormatter(VariableXmlBaseFormatter):
     def path_separator(self, separator):
         self._translator.path_separator = separator
 
-    def read_variables(self, data_source: Union[str, IO, IOBase]) -> VariableList:
+    def read_variables(self, data_source: Union[str, PathLike, IO, IOBase]) -> VariableList:
         # Check separator, as OpenMDAO won't accept the dot.
         if self.path_separator == ".":
             _LOGGER.warning(
@@ -84,7 +85,9 @@ class VariableXmlStandardFormatter(VariableXmlBaseFormatter):
             )
         return super().read_variables(data_source)
 
-    def write_variables(self, data_source: Union[str, IO, IOBase], variables: VariableList):
+    def write_variables(
+        self, data_source: Union[str, PathLike, IO, IOBase], variables: VariableList
+    ):
         try:
             super().write_variables(data_source, variables)
         except FastXPathEvalError as err:

--- a/src/fastoad/io/xml/variable_io_standard.py
+++ b/src/fastoad/io/xml/variable_io_standard.py
@@ -15,7 +15,6 @@ Defines how OpenMDAO variables are serialized to XML
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 import logging
-from io import IOBase
 from os import PathLike
 from typing import Union, IO
 
@@ -77,7 +76,7 @@ class VariableXmlStandardFormatter(VariableXmlBaseFormatter):
     def path_separator(self, separator):
         self._translator.path_separator = separator
 
-    def read_variables(self, data_source: Union[str, PathLike, IO, IOBase]) -> VariableList:
+    def read_variables(self, data_source: Union[str, PathLike, IO]) -> VariableList:
         # Check separator, as OpenMDAO won't accept the dot.
         if self.path_separator == ".":
             _LOGGER.warning(
@@ -85,9 +84,7 @@ class VariableXmlStandardFormatter(VariableXmlBaseFormatter):
             )
         return super().read_variables(data_source)
 
-    def write_variables(
-        self, data_source: Union[str, PathLike, IO, IOBase], variables: VariableList
-    ):
+    def write_variables(self, data_source: Union[str, PathLike, IO], variables: VariableList):
         try:
             super().write_variables(data_source, variables)
         except FastXPathEvalError as err:

--- a/src/fastoad/io/xml/variable_io_standard.py
+++ b/src/fastoad/io/xml/variable_io_standard.py
@@ -2,7 +2,7 @@
 Defines how OpenMDAO variables are serialized to XML
 """
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2020  ONERA & ISAE-SUPAERO
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -13,7 +13,9 @@ Defines how OpenMDAO variables are serialized to XML
 #  GNU General Public License for more details.
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 import logging
+from io import IOBase
 from typing import Union, IO
 
 from fastoad.openmdao.variables import VariableList
@@ -74,7 +76,7 @@ class VariableXmlStandardFormatter(VariableXmlBaseFormatter):
     def path_separator(self, separator):
         self._translator.path_separator = separator
 
-    def read_variables(self, data_source: Union[str, IO]) -> VariableList:
+    def read_variables(self, data_source: Union[str, IO, IOBase]) -> VariableList:
         # Check separator, as OpenMDAO won't accept the dot.
         if self.path_separator == ".":
             _LOGGER.warning(
@@ -82,7 +84,7 @@ class VariableXmlStandardFormatter(VariableXmlBaseFormatter):
             )
         return super().read_variables(data_source)
 
-    def write_variables(self, data_source: Union[str, IO], variables: VariableList):
+    def write_variables(self, data_source: Union[str, IO, IOBase], variables: VariableList):
         try:
             super().write_variables(data_source, variables)
         except FastXPathEvalError as err:

--- a/src/fastoad/openmdao/variables/variable_list.py
+++ b/src/fastoad/openmdao/variables/variable_list.py
@@ -2,7 +2,7 @@
 Class for managing a list of OpenMDAO variables.
 """
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2023 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -411,3 +411,6 @@ class VariableList(list):
             return type(self)(super().__add__(other))
         else:
             return super().__add__(other)
+
+    def __eq__(self, other) -> bool:
+        return set(self) == set(other)


### PR DESCRIPTION
Fixes #520 by making the DataFile class able to use `pathlib.Path` instances as input.

Also added some refactoring that CodeClimate was demanding.
