### PR TITLE
Climb was not stopping when start was already over the asked optimal altitude/flight level

### DIFF
--- a/src/fastoad/models/performances/mission/segments/registered/altitude_change.py
+++ b/src/fastoad/models/performances/mission/segments/registered/altitude_change.py
@@ -92,7 +92,12 @@ class AltitudeChangeSegment(AbstractManualThrustSegment):
                 # let's put a numerical, negative value in target.altitude to
                 # ensure there will be no problem in self.get_distance_to_target()
                 target.altitude = -1000.0
-                self.interrupt_if_getting_further_from_target = False
+                if self.get_distance_to_target([start], target) > 0:
+                    # If target is a CL and distance to target is positive, then
+                    # the target CL might be achieved even if it gets further
+                    # at some time, because of the mass loss.
+                    # Then it is better to deactivate this safeguard.
+                    self.interrupt_if_getting_further_from_target = False
             else:
                 # Target altitude is fixed, back to original settings (in case
                 # this instance is used more than once)


### PR DESCRIPTION
In mission, when asking a climb up to an optimal altitude/flight level (i.e. where the maximum CL is achieved), if the maximum CL was achieved for a lower altitude than the starting one, the climb was not stopped until hard limits were attained (the 40000m hard-coded limit, or possibly a crash of the propulsion model).

This PR fixes this problem.