### PR TITLE
Fixed links to OpenMDAO doc.

### DIFF
--- a/docs/documentation/custom_modules/add_modules.rst
+++ b/docs/documentation/custom_modules/add_modules.rst
@@ -8,7 +8,7 @@ With FAST-OAD, you can register any OpenMDAO system of your own so it can be
 used through the configuration file.
 
 It is therefore strongly advised to have at least a basic knowledge of
-`OpenMDAO <http://openmdao.org/twodocs/versions/latest>`_ to develop a module for FAST-OAD.
+:doc:`OpenMDAO <openmdao:main>` to develop a module for FAST-OAD.
 
 To have your OpenMDAO system available as a FAST-OAD module, you should follow these steps:
 
@@ -20,9 +20,9 @@ To have your OpenMDAO system available as a FAST-OAD module, you should follow t
 Create your OpenMDAO system
 ***************************
 
-It can be a `Group <http://openmdao.org/twodocs/versions/latest/features/core_features/grouping_components/index.html>`_
-or a `Component <http://openmdao.org/twodocs/versions/latest/features/core_features/defining_components/index.html>`_-like class
-(generally an `ExplicitComponent <http://openmdao.org/twodocs/versions/latest/features/core_features/defining_components/explicitcomp.html>`_).
+It can be a :doc:`Group  <openmdao:features/core_features/working_with_groups/main>`
+or a :doc:`Component  <openmdao:features/building_blocks/components/components>`-like class
+(generally an :doc:`ExplicitComponent <openmdao:features/core_features/working_with_components/explicit_component>`).
 
 You can create the Python file at the location of your choice. You will just have to provide later the folder path in
 FAST-OAD configuration file (see :ref:`add-modules-set-configuration-files`).
@@ -30,7 +30,7 @@ FAST-OAD configuration file (see :ref:`add-modules-set-configuration-files`).
 Variable naming
 ===============
 You have to pay attention to the naming of your input and output variables.
-As FAST-OAD uses the `promotion system of OpenMDAO <http://openmdao.org/twodocs/versions/latest/basic_guide/promote_vs_connect.html>`_,
+As FAST-OAD uses the :doc:`promotion system of OpenMDAO <openmdao:basic_user_guide/multidisciplinary_optimization/linking_vars>`,
 which means that variables you want to link to the rest of the process must have
 the name that is given in the global process.
 
@@ -48,7 +48,7 @@ Therefore, the way you name your new variables should be consistent with FAST-OA
 
 Defining options
 ================
-You may use the OpenMDAO way for adding :ref:`options to your system<openmdao:component_options>`.
+You may use the OpenMDAO way for adding :doc:`options to your system <openmdao:features/core_features/options/options>`.
 The options you add will be accessible from the FAST-OAD configuration file (see
 :ref:`configuration-file-problem-definition`).
 
@@ -74,15 +74,15 @@ or for a Group class:
     self.approx_totals()
 
 The two lines above are the most generic and the least CPU-efficient ways of declaring partial derivatives. For better
-efficiency, see how to `work with derivatives in OpenMDAO <http://openmdao.org/twodocs/versions/latest/features/core_features/working_with_derivatives/index.html>`_.
+efficiency, see how to :doc:`work with derivatives in OpenMDAO  <openmdao:features/core_features/working_with_derivatives/main>`.
 
 About ImplicitComponent classes
 ===============================
-In some cases, you may have to use `ImplicitComponent <http://openmdao.org/twodocs/versions/latest/features/core_features/defining_components/implicitcomp.html>`_
+In some cases, you may have to use :doc:`ImplicitComponent  <openmdao:features/core_features/working_with_components/implicit_component>`
 classes.
 
-Just remember, as told in `this tutorial <http://openmdao.org/twodocs/versions/latest/advanced_guide/implicit_comps/defining_icomps.html>`_,
-that the loop that will allow to solve it needs usage of the `NewtonSolver <http://openmdao.org/twodocs/versions/latest/features/building_blocks/solvers/nonlinear/newton.html#nlnewton>`_.
+Just remember, as told in :doc:`this tutorial <openmdao:advanced_user_guide/models_implicit_components/models_with_solvers_implicit>`,
+that the loop that will allow to solve it needs usage of the :doc:`Newton solver <features/building_blocks/solvers/newton>`.
 
 A good way to ensure it is to build a Group class that will solve the ImplicitComponent with NewtonSolver. This Group
 should be the system you will register in FAST-OAD.
@@ -93,7 +93,7 @@ Checking validity domains
 Generally, models are valid only when variable values are in given ranges.
 
 OpenMDAO provides a way to specify lower and upper bounds of an output variable and to enforce them
-when using a Newton solver by using `backtracking line searches <http://openmdao.org/twodocs/versions/latest/features/building_blocks/solvers/backtracking/index.html>`_.
+when using a Newton solver by using :doc:`backtracking line searches <openmdao:features/building_blocks/solvers/bounds_enforce>`.
 
 FAST-OAD proposes a way to set lower and upper bounds for input and output variables, but only
 for checking and giving feedback of variables that would be out of bounds.

--- a/docs/documentation/custom_modules/add_variable_documentation.rst
+++ b/docs/documentation/custom_modules/add_variable_documentation.rst
@@ -18,7 +18,7 @@ The description of a variable can be defined in two ways:
 Defining variable description in your OpenMDAO component
 ********************************************************
 OpenMDAO natively allows to define the description of a variable
-`when declaring it <https://openmdao.org/twodocs/versions/latest/features/core_features/defining_components/declaring_variables.html?highlight=desc>`_.
+when :doc:`declaring it <openmdao:features/core_features/working_with_components/continuous_variables>`.
 
 FAST-OAD will retrieve this information (the description has to be defined once,
 even if the variable is declared at several locations).

--- a/docs/documentation/mission_module/mission_file/setting_values.rst
+++ b/docs/documentation/mission_module/mission_file/setting_values.rst
@@ -23,7 +23,7 @@ The standard way is to set the parameter as value, with or without unit.
 
     If no unit is provided while parameter needs one, SI units will be assumed.
 
-    Provided units have to match `OpenMDAO convention <https://openmdao.org/newdocs/versions/latest/features/units.html>`_.
+    Provided units have to match :doc:`OpenMDAO convention <openmdao:features/units>`.
 
 Examples:
 

--- a/docs/documentation/usage.rst
+++ b/docs/documentation/usage.rst
@@ -16,7 +16,7 @@ FAST-OAD configuration file
 ***************************
 FAST-OAD configuration files are in `YAML <https://yaml.org>`_  format.
 A quick tutorial for YAML (among many ones) is available
-`here <https://www.cloudbees.com/blog/yaml-tutorial-everything-you-need-get-started/>`_
+`here <https://www.cloudbees.com/blog/yaml-tutorial-everything-you-need-get-started/>`_.
 
 
 .. code:: yaml
@@ -131,7 +131,7 @@ This belongs the domain of the OpenMDAO framework and its utilization. This sett
 optimization problems. It is defined as in Python when assuming the OpenMDAO convention
 :code:`import openmdao.api as om`.
 
-For more details, please see the OpenMDAO documentation on `drivers <http://openmdao.org/twodocs/versions/latest/features/building_blocks/drivers/index.html>`_.
+For more details, please see the OpenMDAO documentation on :doc:`drivers <openmdao:features/building_blocks/drivers/index>`.
 
 Solvers
 =======
@@ -147,8 +147,7 @@ components. If the model involves cycles, which happens for instance when some o
 inputs of B, and vice-versa, it is necessary to specify solvers as done above.
 
 For more details, please see the OpenMDAO documentation on
-`nonlinear solvers <http://openmdao.org/twodocs/versions/latest/features/building_blocks/solvers/nonlinear/index.html>`_
-and `linear solvers <http://openmdao.org/twodocs/versions/latest/features/building_blocks/solvers/linear/index.html>`_.
+:doc:`linear and nonlinear solvers <openmdao:features/building_blocks/solvers/solvers>`.
 
 
 .. _configuration-file-problem-definition:
@@ -276,7 +275,7 @@ Design variables
 
 Here are defined design variables (relevant only for optimization).
 Keys of this section are named after parameters of the OpenMDAO
-`System.add_design_var() method <http://openmdao.org/twodocs/versions/latest/features/core_features/adding_desvars_objs_consts/adding_desvars.html?highlight=add_design_var>`_
+:doc:`System.add_design_var() method <openmdao:features/core_features/adding_desvars_cons_objs/adding_design_variables>`
 
 Several design variables can be defined.
 
@@ -292,7 +291,7 @@ Objective function
 
 Here is defined the objective function (relevant only for optimization).
 Keys of this section are named after parameters of the OpenMDAO
-`System.add_objective() method <http://openmdao.org/twodocs/versions/latest/features/core_features/adding_desvars_objs_consts/adding_objectives.html?highlight=add_objective>`_
+:doc:`System.add_objective() method <openmdao:features/core_features/adding_desvars_cons_objs/adding_objective>`
 
 Only one objective variable can be defined.
 
@@ -309,7 +308,7 @@ Constraints
           upper: 0.1
 
 Here are defined constraint variables (relevant only for optimization).
-Keys of this section are named after parameters of the OpenMDAO `System.add_constraint() method <http://openmdao.org/twodocs/versions/latest/features/core_features/adding_desvars_objs_consts/adding_constraints.html?highlight=add_constraint>`_
+Keys of this section are named after parameters of the OpenMDAO :doc:`System.add_constraint() method <openmdao:features/core_features/adding_desvars_cons_objs/adding_constraint>`
 
 Several constraint variables can be defined.
 
@@ -471,7 +470,7 @@ This is especially useful to see how models and variables are connected.
 N2 diagram
 ----------
 
-FAST-OAD can use OpenMDAO to create a `N2 diagram <http://openmdao.org/twodocs/versions/latest/features/model_visualization/n2_basics.html>`_.
+FAST-OAD can use OpenMDAO to create a :doc:`N2 diagram  <openmdao:features/model_visualization/n2_basics/n2_basics>`.
 It provides in-depth information about the whole process.
 
 You can create a :code:`n2.html` file with:

--- a/docs/documentation/variables.rst
+++ b/docs/documentation/variables.rst
@@ -7,10 +7,10 @@ Problem variables
 FAST-OAD process relies on `OpenMDAO <https://openmdao.org/>`_, and process variables are OpenMDAO variables.
 
 For any component, variables are declared as inputs or outputs as described
-`here <http://openmdao.org/twodocs/versions/latest/features/core_features/defining_components/declaring_variables.html>`_.
+:doc:`here <openmdao:features/core_features/working_with_components/continuous_variables>`.
 
 FAST-OAD uses the
-`promotion system of OpenMDAO <http://openmdao.org/twodocs/versions/latest/basic_guide/promote_vs_connect.html>`_,
+:doc:`promotion system of OpenMDAO <openmdao:basic_user_guide/multidisciplinary_optimization/linking_vars>`,
 which means that all variables that are exchanged between FAST-OAD registered systems [#]_ have a unique name and are
 available for the whole process.
 
@@ -92,7 +92,7 @@ A complete file that would contain the three above-mentioned variables will be a
 .. note::
 
     Units are given as a string according to
-    `OpenMDAO units definitions <http://openmdao.org/twodocs/versions/latest/features/units.html>`_
+    :doc:`OpenMDAO units definitions <openmdao:features/units>`.
 
 .. note::
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,9 @@
 #  GNU General Public License for more details.
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+from openmdao.solvers.nonlinear.newton import NewtonSolver
 
 # pylint: disable=unused-import
 from src.conftest import no_xfoil_skip, xfoil_path  # noqa: F401
+
+NewtonSolver


### PR DESCRIPTION
In FAST-OAD documentation, links to OpenMDAO doc were broken. They have been updated using intersphinx mapping.