### PR TITLE
Fix CLI

### DIFF
--- a/src/fastoad/cmd/cli_utils.py
+++ b/src/fastoad/cmd/cli_utils.py
@@ -47,7 +47,7 @@ def out_file_option(func):
     )(overwrite_option(func))
 
 
-def manage_overwrite(func: Callable, **kwargs):
+def manage_overwrite(func: Callable, filename_func: Callable = None, **kwargs):
     """
     Runs `func`, that is expected to write a file, with provided keyword arguments `args`.
 
@@ -57,12 +57,14 @@ def manage_overwrite(func: Callable, **kwargs):
 
     :param func: callable that will do the operation and is expected to return
                  the path of written element.
+    :param filename_func: a function that provides the name of written file, given the
+                          value returned by func
     :param kwargs: keyword arguments for func
     :return: True if the file has been written,
     """
     written = False
     try:
-        written = _run_write_func(func, **kwargs)
+        written = _run_write_func(func, filename_func, **kwargs)
 
     except FastPathExistsError as exc:
         if click.confirm(f'"{exc.args[1]}" already exists. Do you want to overwrite it?'):
@@ -74,9 +76,11 @@ def manage_overwrite(func: Callable, **kwargs):
     return written
 
 
-def _run_write_func(func: Callable, **kwargs):
+def _run_write_func(func: Callable, filename_func: Callable = None, **kwargs):
     result = func(**kwargs)
     if result:
+        if filename_func:
+            result = filename_func(result)
         click.echo(f'"{result}" has been written.')
         return True
 

--- a/src/fastoad/cmd/tests/test_cli.py
+++ b/src/fastoad/cmd/tests/test_cli.py
@@ -444,6 +444,46 @@ def test_gen_source_data_several_plugin(cleanup, with_dummy_plugins, plugin_root
         assert cmp(Path(temp_dir, "my_source.xml"), original_file)
 
 
+def test_eval(cleanup):
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=RESULTS_FOLDER_PATH) as temp_dir:
+        result_1 = runner.invoke(
+            fast_oad,
+            [
+                "gen_inputs",
+                (DATA_FOLDER_PATH / "sellar.yml").as_posix(),
+                (DATA_FOLDER_PATH / "inputs.xml").as_posix(),
+            ],
+        )
+        assert not result_1.exception
+
+        result_2 = runner.invoke(
+            fast_oad,
+            ["eval", (DATA_FOLDER_PATH / "sellar.yml").as_posix(), "-f"],
+        )
+        assert not result_2.exception
+
+
+def test_optim(cleanup):
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=RESULTS_FOLDER_PATH) as temp_dir:
+        result_1 = runner.invoke(
+            fast_oad,
+            [
+                "gen_inputs",
+                (DATA_FOLDER_PATH / "sellar.yml").as_posix(),
+                (DATA_FOLDER_PATH / "inputs.xml").as_posix(),
+            ],
+        )
+        assert not result_1.exception
+
+        result_2 = runner.invoke(
+            fast_oad,
+            ["optim", (DATA_FOLDER_PATH / "sellar.yml").as_posix(), "-f"],
+        )
+        assert not result_2.exception
+
+
 def test_create_notebooks_with_no_notebook(cleanup, with_dummy_plugin_2, plugin_root_path):
     runner = CliRunner()
     with runner.isolated_filesystem(temp_dir=RESULTS_FOLDER_PATH):


### PR DESCRIPTION
A bad change has been done in PR #521, that was breaking `fastoad eval` and `fastoad optim` command lines.

A proper unit test has been added, and the change has been reverted.