### PR TITLE
Fix behavior when model_options could add input variables

### DIFF
--- a/src/fastoad/io/configuration/configuration.py
+++ b/src/fastoad/io/configuration/configuration.py
@@ -119,17 +119,17 @@ class FASTOADProblemConfigurator:
         problem.input_file_path = self.input_file_path
         problem.output_file_path = self.output_file_path
 
+        model_options = self._data.get(KEY_MODEL_OPTIONS, {})
+        for options in model_options.values():
+            self._make_option_path_values_absolute(options)
+        problem.model_options = model_options
+
         if read_inputs:
             problem.read_inputs()
 
         driver = self._data.get(KEY_DRIVER, "")
         if driver:
             problem.driver = _om_eval(driver)
-
-        model_options = self._data.get(KEY_MODEL_OPTIONS, {})
-        for options in model_options.values():
-            self._make_option_path_values_absolute(options)
-        problem.model_options = model_options
 
         if self.get_optimization_definition():
             self._add_constraints(problem.model, auto_scaling)

--- a/src/fastoad/io/configuration/tests/data/conf_sellar_example/functions.py
+++ b/src/fastoad/io/configuration/tests/data/conf_sellar_example/functions.py
@@ -78,6 +78,16 @@ class FunctionFAlt(FunctionF):
         # This option has no effect and is used for checks
         self.options.declare("dummy_generic_option", types=str, default="")
 
+        # This one adds a variable to check if it affects correctly input variables
+        self.options.declare("add_input_var", types=bool, default=False)
+
+    def setup(self):
+        super().setup()
+        if self.options["add_input_var"]:
+            self.add_input("bar", val=1.0, desc="")
+
+        self.add_output("baz", val=1.0)
+
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
         """Functions computation"""
 
@@ -87,6 +97,9 @@ class FunctionFAlt(FunctionF):
         y2 = inputs["yy2"]
 
         outputs["f"] = x1 ** 2 + z2 + y1 + exp(-y2) - 28.0
+
+        if "bar" in inputs:
+            outputs["baz"] = inputs["bar"]
 
 
 @RegisterSubmodel(SERVICE_FUNCTION_G1, "function.g1.default")

--- a/src/fastoad/io/configuration/tests/data/ref_inputs.xml
+++ b/src/fastoad/io/configuration/tests/data/ref_inputs.xml
@@ -1,6 +1,6 @@
 <!--
   ~ This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-  ~ Copyright (C) 2021 ONERA & ISAE-SUPAERO
+  ~ Copyright (C) 2024 ONERA & ISAE-SUPAERO
   ~ FAST is free software: you can redistribute it and/or modify
   ~ it under the terms of the GNU General Public License as published by
   ~ the Free Software Foundation, either version 3 of the License, or
@@ -19,5 +19,5 @@
     <y1>nan</y1><!-- If this variable is kept in the input IVC, OpenMDAO will raise an exception because it is an output of a component
                      As it should be ignored, its NaN value should bring no harm.-->
     <foo>nan</foo><!-- This totally unused variable is expected to be transferred in output file -->
-    <bar>42</bar><!-- This totally unused variable is expected to be transferred in output file -->
+    <bar>42</bar><!-- This variable is optionally used, and expected to be in output file in any case -->
 </aircraft>

--- a/src/fastoad/io/configuration/tests/data/valid_sellar_alternate.toml
+++ b/src/fastoad/io/configuration/tests/data/valid_sellar_alternate.toml
@@ -32,6 +32,7 @@ driver = "om.ScipyOptimizeDriver(optimizer='SLSQP')"
 [model_options."*"]
   dummy_f_option = 10  # has no effect in this alternate version
   dummy_generic_option = "it works"
+  add_input_var = true
 [model_options."*".dummy_disc1_option]
     a = 10
     b = 20

--- a/src/fastoad/io/configuration/tests/data/valid_sellar_alternate.yml
+++ b/src/fastoad/io/configuration/tests/data/valid_sellar_alternate.yml
@@ -32,6 +32,7 @@ model_options:
       a: 10
       b: 20
     dummy_generic_option: "it works"
+    add_input_var: true
   "cycle.*":
     dummy_generic_option: "it works here also"
 


### PR DESCRIPTION
This PR fixes a bug that was occurring when an option in model_options could add input variables to some component : the generation of the input file was Ok, but the added input variables were not read for problem evaluation.
