### PR TITLE
Better NaN detection in inputs

### DIFF
--- a/src/fastoad/openmdao/exceptions.py
+++ b/src/fastoad/openmdao/exceptions.py
@@ -21,20 +21,6 @@ from fastoad._utils.files import as_path
 from fastoad.exceptions import FastError
 
 
-#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
-#  FAST is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#  You should have received a copy of the GNU General Public License
-#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
-
 class FASTOpenMDAONanInInputsError(FastError):
     """Raised if NaN values are read in input data file."""
 

--- a/src/fastoad/openmdao/exceptions.py
+++ b/src/fastoad/openmdao/exceptions.py
@@ -1,10 +1,28 @@
 """
 Module for custom Exception classes linked to OpenMDAO
 """
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
+#  FAST is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from os import PathLike
+from typing import Iterable
+
+from fastoad._utils.files import as_path
+from fastoad.exceptions import FastError
 
 
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2022 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -17,21 +35,16 @@ Module for custom Exception classes linked to OpenMDAO
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 
-from typing import List
-
-from fastoad.exceptions import FastError
-
-
-class FASTOpenMDAONanInInputFile(FastError):
+class FASTOpenMDAONanInInputsError(FastError):
     """Raised if NaN values are read in input data file."""
 
-    def __init__(self, input_file_path: str, nan_variable_names: List[str]):
-        self.input_file_path = input_file_path
-        self.nan_variable_names = nan_variable_names
+    def __init__(self, input_file_path: [str, PathLike], nan_variable_names: Iterable[str]):
+        self.input_file_path = as_path(input_file_path)
+        self.nan_variable_names = sorted(list(nan_variable_names))
 
-        msg = "NaN values found in input file (%s). Please check following variables: %s" % (
-            input_file_path,
-            nan_variable_names,
+        msg = (
+            f"NaN values found in inputs. Please check that {input_file_path} contains "
+            f"following variables and that they are not NaN: {self.nan_variable_names}"
         )
 
         super().__init__(self, msg)

--- a/src/fastoad/openmdao/exceptions.py
+++ b/src/fastoad/openmdao/exceptions.py
@@ -21,7 +21,7 @@ from fastoad._utils.files import as_path
 from fastoad.exceptions import FastError
 
 
-class FASTOpenMDAONanInInputsError(FastError):
+class FASTNanInInputsError(FastError):
     """Raised if NaN values are read in input data file."""
 
     def __init__(self, input_file_path: [str, PathLike], nan_variable_names: Iterable[str]):

--- a/src/fastoad/openmdao/problem.py
+++ b/src/fastoad/openmdao/problem.py
@@ -26,7 +26,7 @@ from fastoad.module_management.service_registry import RegisterSubmodel
 from fastoad.openmdao.validity_checker import ValidityDomainChecker
 from fastoad.openmdao.variables import Variable, VariableList
 from ._utils import get_mpi_safe_problem_copy
-from .exceptions import FASTOpenMDAONanInInputFile
+from .exceptions import FASTOpenMDAONanInInputsError
 from ..module_management._bundle_loader import BundleLoader
 
 _LOGGER = logging.getLogger(__name__)  # Logger for this module
@@ -198,21 +198,44 @@ class FASTOADProblem(om.Problem):
 
         :return: VariableList of needed input variables, VariableList with unused variables.
         """
+
         problem_inputs_names = [var.name for var in self.analysis.problem_variables if var.is_input]
 
-        input_variables = DataFile(self.input_file_path)
+        input_file_variables = DataFile(self.input_file_path)
 
         unused_variables = VariableList(
-            [var for var in input_variables if var.name not in problem_inputs_names]
+            [var for var in input_file_variables if var.name not in problem_inputs_names]
         )
         for name in unused_variables.names():
-            del input_variables[name]
+            del input_file_variables[name]
 
-        nan_variable_names = [var.name for var in input_variables if np.any(np.isnan(var.value))]
-        if nan_variable_names:
-            raise FASTOpenMDAONanInInputFile(self.input_file_path, nan_variable_names)
+        non_filled_variable_names = self._get_remaining_nan_variable_names(input_file_variables)
 
-        return input_variables, unused_variables
+        if non_filled_variable_names:
+            raise FASTOpenMDAONanInInputsError(self.input_file_path, non_filled_variable_names)
+
+        return input_file_variables, unused_variables
+
+    def _get_remaining_nan_variable_names(self, input_file_variables):
+        """
+        Returns names of variables that will still be NaN after reading input_file_variables
+        """
+        problem_input_variables = VariableList(
+            [var for var in self.analysis.problem_variables if var.is_input]
+        )
+        default_nan_problem_variable_names = {
+            var.name for var in problem_input_variables if np.any(np.isnan(var.value))
+        }
+        non_nan_input_file_variable_names = {
+            var.name for var in input_file_variables if not np.any(np.isnan(var.value))
+        }
+        nan_input_file_variable_names = {
+            var.name for var in input_file_variables if np.any(np.isnan(var.value))
+        }
+        non_filled_variable_names = (
+            default_nan_problem_variable_names - non_nan_input_file_variable_names
+        ) | nan_input_file_variable_names
+        return non_filled_variable_names
 
     def _set_input_values_post_setup(self):
         """

--- a/src/fastoad/openmdao/problem.py
+++ b/src/fastoad/openmdao/problem.py
@@ -26,7 +26,7 @@ from fastoad.module_management.service_registry import RegisterSubmodel
 from fastoad.openmdao.validity_checker import ValidityDomainChecker
 from fastoad.openmdao.variables import Variable, VariableList
 from ._utils import get_mpi_safe_problem_copy
-from .exceptions import FASTOpenMDAONanInInputsError
+from .exceptions import FASTNanInInputsError
 from ..module_management._bundle_loader import BundleLoader
 
 _LOGGER = logging.getLogger(__name__)  # Logger for this module
@@ -212,7 +212,7 @@ class FASTOADProblem(om.Problem):
         non_filled_variable_names = self._get_remaining_nan_variable_names(input_file_variables)
 
         if non_filled_variable_names:
-            raise FASTOpenMDAONanInInputsError(self.input_file_path, non_filled_variable_names)
+            raise FASTNanInInputsError(self.input_file_path, non_filled_variable_names)
 
         return input_file_variables, unused_variables
 

--- a/src/fastoad/openmdao/tests/data/missing_inputs.xml
+++ b/src/fastoad/openmdao/tests/data/missing_inputs.xml
@@ -1,0 +1,18 @@
+<!--
+  ~ This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
+  ~ Copyright (C) 2021 ONERA & ISAE-SUPAERO
+  ~ FAST is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program.  If not, see <https://www.gnu.org/licenses/>.
+  -->
+
+<aircraft>
+  <useless>1.0</useless>
+</aircraft>

--- a/src/fastoad/openmdao/tests/data/missing_inputs.xml
+++ b/src/fastoad/openmdao/tests/data/missing_inputs.xml
@@ -1,6 +1,6 @@
 <!--
   ~ This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-  ~ Copyright (C) 2021 ONERA & ISAE-SUPAERO
+  ~ Copyright (C) 2024 ONERA & ISAE-SUPAERO
   ~ FAST is free software: you can redistribute it and/or modify
   ~ it under the terms of the GNU General Public License as published by
   ~ the Free Software Foundation, either version 3 of the License, or
@@ -14,5 +14,5 @@
   -->
 
 <aircraft>
-  <useless>1.0</useless>
+  <unused>1.0</unused>
 </aircraft>

--- a/src/fastoad/openmdao/tests/openmdao_sellar_example/disc1.py
+++ b/src/fastoad/openmdao/tests/openmdao_sellar_example/disc1.py
@@ -47,3 +47,18 @@ class Disc1Bis(BasicDisc1):
 @ValidityDomainChecker({"x": (0, 1), "z": (0, 1)})  # This validity domain should apply in case 2
 class Disc1Ter(Disc1Bis):
     """Same component with different validity domain."""
+
+
+class Disc1Quater(BasicDisc1):
+    """An OpenMDAO component to encapsulate Disc1 discipline"""
+
+    def setup(self):
+        self.add_input(
+            "x", val=np.nan, desc="input x"
+        )  # NaN as default for testing connexion check
+        self.add_input(
+            "z", val=[np.nan, np.nan], desc="", units="m**2"
+        )  # for testing non-None units
+        self.add_input("y2", val=1.0, desc="variable y2")  # for testing input description capture
+
+        self.add_output("y1", val=1.0, desc="variable y1")  # for testing output description capture

--- a/src/fastoad/openmdao/tests/openmdao_sellar_example/disc2.py
+++ b/src/fastoad/openmdao/tests/openmdao_sellar_example/disc2.py
@@ -12,6 +12,8 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import numpy as np
+
 from fastoad._utils.sellar.disc2 import BasicDisc2
 
 
@@ -21,6 +23,18 @@ class Disc2(BasicDisc2):
     def setup(self):
         self.add_input(
             "z", val=[5, 2], desc="variable z", units="m**2"
+        )  # for testing non-None units
+        self.add_input("y1", val=1.0, desc="")
+
+        self.add_output("y2", val=1.0, desc="")
+
+
+class Disc2Bis(BasicDisc2):
+    """An OpenMDAO component to encapsulate Disc2 discipline"""
+
+    def setup(self):
+        self.add_input(
+            "z", val=[np.nan, np.nan], desc="variable z", units="m**2"
         )  # for testing non-None units
         self.add_input("y1", val=1.0, desc="")
 

--- a/src/fastoad/openmdao/tests/test_problem.py
+++ b/src/fastoad/openmdao/tests/test_problem.py
@@ -19,12 +19,14 @@ import openmdao.api as om
 import pytest
 from numpy.testing import assert_allclose
 
-from fastoad.openmdao.exceptions import (
-    FASTOpenMDAONanInInputFile,
-)
 from fastoad.openmdao.problem import FASTOADProblem
 from fastoad.openmdao.variables import Variable, VariableList
+from .openmdao_sellar_example.disc1 import Disc1Quater
+from .openmdao_sellar_example.disc2 import Disc2Bis
+from .openmdao_sellar_example.functions import FunctionF
 from .openmdao_sellar_example.sellar import SellarModel
+from ..exceptions import FASTOpenMDAONanInInputFile
+from ..._utils.sellar.sellar_base import GenericSellarFactory
 from ...io import VariableIO
 
 DATA_FOLDER_PATH = Path(__file__).parent / "data"
@@ -159,6 +161,40 @@ def test_problem_read_inputs_with_nan_inputs(cleanup):
         problem.read_inputs()
     assert exc_info_2.value.input_file_path == input_data_path
     assert exc_info_2.value.nan_variable_names == ["x", "z"]
+
+
+def test_problem_read_inputs_with_missing_inputs(cleanup):
+    """
+    Tests that, when reading inputs using existing XML with missing value (for a
+    variable with default nan), an exception is raised.
+    """
+
+    problem = FASTOADProblem()
+    problem.model.add_subsystem(
+        "sellar",
+        SellarModel(
+            sellar_factory=GenericSellarFactory(
+                disc1_class=Disc1Quater, disc2_class=Disc2Bis, f_class=FunctionF
+            )
+        ),
+        promotes=["*"],
+    )
+
+    input_data_path = DATA_FOLDER_PATH / "missing_inputs.xml"
+
+    problem.input_file_path = input_data_path
+
+    with pytest.raises(FASTOpenMDAONanInInputFile) as exc_info_1:
+        problem.read_inputs()
+    assert exc_info_1.value.input_file_path == input_data_path
+    assert exc_info_1.value.nan_variable_names == ["z"]
+
+    problem.setup()
+
+    with pytest.raises(FASTOpenMDAONanInInputFile) as exc_info_2:
+        problem.read_inputs()
+    assert exc_info_2.value.input_file_path == input_data_path
+    assert exc_info_2.value.nan_variable_names == ["z"]
 
 
 def test_problem_with_dynamically_shaped_inputs(cleanup):

--- a/src/fastoad/openmdao/tests/test_problem.py
+++ b/src/fastoad/openmdao/tests/test_problem.py
@@ -25,7 +25,7 @@ from .openmdao_sellar_example.disc1 import Disc1Quater
 from .openmdao_sellar_example.disc2 import Disc2Bis
 from .openmdao_sellar_example.functions import FunctionF
 from .openmdao_sellar_example.sellar import SellarModel
-from ..exceptions import FASTOpenMDAONanInInputsError
+from ..exceptions import FASTNanInInputsError
 from ..._utils.sellar.sellar_base import GenericSellarFactory
 from ...io import VariableIO
 
@@ -150,14 +150,14 @@ def test_problem_read_inputs_with_nan_inputs(cleanup):
 
     problem.input_file_path = input_data_path
 
-    with pytest.raises(FASTOpenMDAONanInInputsError) as exc_info_1:
+    with pytest.raises(FASTNanInInputsError) as exc_info_1:
         problem.read_inputs()
     assert exc_info_1.value.input_file_path == input_data_path
     assert exc_info_1.value.nan_variable_names == ["x", "z"]
 
     problem.setup()
 
-    with pytest.raises(FASTOpenMDAONanInInputsError) as exc_info_2:
+    with pytest.raises(FASTNanInInputsError) as exc_info_2:
         problem.read_inputs()
     assert exc_info_2.value.input_file_path == input_data_path
     assert exc_info_2.value.nan_variable_names == ["x", "z"]
@@ -184,14 +184,14 @@ def test_problem_read_inputs_with_missing_inputs(cleanup):
 
     problem.input_file_path = input_data_path
 
-    with pytest.raises(FASTOpenMDAONanInInputsError) as exc_info_1:
+    with pytest.raises(FASTNanInInputsError) as exc_info_1:
         problem.read_inputs()
     assert exc_info_1.value.input_file_path == input_data_path
     assert exc_info_1.value.nan_variable_names == ["z"]
 
     problem.setup()
 
-    with pytest.raises(FASTOpenMDAONanInInputsError) as exc_info_2:
+    with pytest.raises(FASTNanInInputsError) as exc_info_2:
         problem.read_inputs()
     assert exc_info_2.value.input_file_path == input_data_path
     assert exc_info_2.value.nan_variable_names == ["z"]

--- a/src/fastoad/openmdao/tests/test_problem.py
+++ b/src/fastoad/openmdao/tests/test_problem.py
@@ -25,7 +25,7 @@ from .openmdao_sellar_example.disc1 import Disc1Quater
 from .openmdao_sellar_example.disc2 import Disc2Bis
 from .openmdao_sellar_example.functions import FunctionF
 from .openmdao_sellar_example.sellar import SellarModel
-from ..exceptions import FASTOpenMDAONanInInputFile
+from ..exceptions import FASTOpenMDAONanInInputsError
 from ..._utils.sellar.sellar_base import GenericSellarFactory
 from ...io import VariableIO
 
@@ -150,14 +150,14 @@ def test_problem_read_inputs_with_nan_inputs(cleanup):
 
     problem.input_file_path = input_data_path
 
-    with pytest.raises(FASTOpenMDAONanInInputFile) as exc_info_1:
+    with pytest.raises(FASTOpenMDAONanInInputsError) as exc_info_1:
         problem.read_inputs()
     assert exc_info_1.value.input_file_path == input_data_path
     assert exc_info_1.value.nan_variable_names == ["x", "z"]
 
     problem.setup()
 
-    with pytest.raises(FASTOpenMDAONanInInputFile) as exc_info_2:
+    with pytest.raises(FASTOpenMDAONanInInputsError) as exc_info_2:
         problem.read_inputs()
     assert exc_info_2.value.input_file_path == input_data_path
     assert exc_info_2.value.nan_variable_names == ["x", "z"]
@@ -184,14 +184,14 @@ def test_problem_read_inputs_with_missing_inputs(cleanup):
 
     problem.input_file_path = input_data_path
 
-    with pytest.raises(FASTOpenMDAONanInInputFile) as exc_info_1:
+    with pytest.raises(FASTOpenMDAONanInInputsError) as exc_info_1:
         problem.read_inputs()
     assert exc_info_1.value.input_file_path == input_data_path
     assert exc_info_1.value.nan_variable_names == ["z"]
 
     problem.setup()
 
-    with pytest.raises(FASTOpenMDAONanInInputFile) as exc_info_2:
+    with pytest.raises(FASTOpenMDAONanInInputsError) as exc_info_2:
         problem.read_inputs()
     assert exc_info_2.value.input_file_path == input_data_path
     assert exc_info_2.value.nan_variable_names == ["z"]


### PR DESCRIPTION
FAST-OAD behavior was to raise immediately an error if the input file contains a Nan value (for an actually used input variable).

This PR modifies the behavior so an error is raised also when an input variable with a NaN default value is not present in input file.