### PR TITLE
Fix validity checker for array variables

### DIFF
--- a/src/fastoad/openmdao/tests/openmdao_sellar_example/disc1.py
+++ b/src/fastoad/openmdao/tests/openmdao_sellar_example/disc1.py
@@ -18,7 +18,7 @@ from fastoad._utils.sellar.disc1 import BasicDisc1
 from ...validity_checker import ValidityDomainChecker
 
 
-@ValidityDomainChecker({"x": (-1, 1)})  # This validity domain should not apply
+@ValidityDomainChecker({"x": (-1, 1), "z": (0, 10)})  # This validity domain should not apply
 class Disc1(BasicDisc1):
     """An OpenMDAO component to encapsulate Disc1 discipline"""
 
@@ -44,6 +44,6 @@ class Disc1Bis(BasicDisc1):
         self.add_output("y1", val=1.0, desc="variable y1")  # for testing output description capture
 
 
-@ValidityDomainChecker({"x": (0, 1)})  # This validity domain should apply in case 2
+@ValidityDomainChecker({"x": (0, 1), "z": (0, 1)})  # This validity domain should apply in case 2
 class Disc1Ter(Disc1Bis):
     """Same component with different validity domain."""

--- a/src/fastoad/openmdao/tests/test_validity_checker.py
+++ b/src/fastoad/openmdao/tests/test_validity_checker.py
@@ -254,3 +254,7 @@ def test_sellar(caplog):
     problem.setup()
     problem.run_model()
     assert 'Variable "x" out of bound: value [2.] is over upper limit ( 1 )' in caplog.text
+    assert (
+        'Variable "z" out of bound: value [5. 2.] m**2 is over upper limit ( 1 m**2 )'
+        in caplog.text
+    )

--- a/src/fastoad/openmdao/validity_checker.py
+++ b/src/fastoad/openmdao/validity_checker.py
@@ -190,10 +190,10 @@ class ValidityDomainChecker:
                 ) and var.name in limit_definitions:
                     limit_def = limit_definitions[var.name]
                     value = convert_units(var.value, var.units, limit_def.units)
-                    if value < limit_def.lower:
+                    if np.any(value < limit_def.lower):
                         status = ValidityStatus.TOO_LOW
                         limit = limit_def.lower
-                    elif value > limit_def.upper:
+                    elif np.any(value > limit_def.upper):
                         status = ValidityStatus.TOO_HIGH
                         limit = limit_def.upper
                     else:
@@ -226,7 +226,9 @@ class ValidityDomainChecker:
         for record in records:
             if record.status != ValidityStatus.OK:
                 logger = logging.getLogger(record.logger_name)
-                limit_text = "under lower" if record.value < record.limit_value else "over upper"
+                limit_text = (
+                    "under lower" if np.any(record.value < record.limit_value) else "over upper"
+                )
                 logger.warning(
                     'Variable "%s" out of bound: value %s%s is %s limit ( %s%s ) in file %s',
                     record.variable_name,


### PR DESCRIPTION
This PR fixes a crash that could occur if `Variable.DomainChecker` was used on a non scalar variable.