### PR TITLE
Release v1.7.3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,16 @@
 Changelog
 =========
 
+Version 1.7.3
+=============
+- Added:
+    - Compatibility with Python 3.11. (#538)
+    - Aircraft plot: minor change in naming of geometry variable for horizontal tail (old name still accepted). (#546)
+
+- Fixed:
+    - Fixed validity checker for array variables. (#537)
+    - In mass breakdown bar plot, legend was controlling visibility only for the right-handed plot. (#545 by @aeomath)
+
 Version 1.7.2
 =============
 - Added:
@@ -17,7 +27,6 @@ Version 1.7.2
     - Fixed behavior when input variables could be added using `model_options`. (#530)
     - Fixed the variables displayed by default in MissionViewer. (#535)
 
-
 Version 1.7.1
 =============
 - Added:
@@ -25,7 +34,6 @@ Version 1.7.1
 
 - Fixed:
     - Missions can now be defined without route. (#515)
-
 
 Version 1.7.0
 =============


### PR DESCRIPTION
Draft release : https://github.com/fast-aircraft-design/FAST-OAD/releases/tag/untagged-c4b7b5567d9c0e16b414

Brings compatibility with Python 3.11 and some fixes.