### PR TITLE
Adding grouped legend for each aircraft configuration (fix issue #544)

### DIFF
--- a/src/fastoad/gui/analysis_and_plots.py
+++ b/src/fastoad/gui/analysis_and_plots.py
@@ -316,11 +316,11 @@ def mass_breakdown_bar_plot(
     # Same legend for each aircraft configuration
     l = int(len(fig.data)/2)
     aircraft_config = f"aircraft{l}"
-    
+
     weight_labels = ["MTOW", "OWE", "Fuel - Mission", "Payload"]
     weight_values = [mtow, owe, fuel_mission, payload]
     fig.add_trace(
-        go.Bar(name="", x=weight_labels, y=weight_values, marker_color=COLS[i], showlegend=False, 
+        go.Bar(name="", x=weight_labels, y=weight_values, marker_color=COLS[i], showlegend=False,
                legendgroup=aircraft_config),
         row=1,
         col=1,

--- a/src/fastoad/gui/analysis_and_plots.py
+++ b/src/fastoad/gui/analysis_and_plots.py
@@ -329,7 +329,8 @@ def mass_breakdown_bar_plot(
     # Get data:weight decomposition
     main_weight_values, main_weight_names, _ = _data_weight_decomposition(variables, owe=None)
     fig.add_trace(
-        go.Bar(name=name, x=main_weight_names, y=main_weight_values, marker_color=COLS[i]),
+        go.Bar(name=name, x=main_weight_names, y=main_weight_values, marker_color=COLS[i],
+               legendgroup=aircraft_config),
         row=1,
         col=2,
     )

--- a/src/fastoad/gui/analysis_and_plots.py
+++ b/src/fastoad/gui/analysis_and_plots.py
@@ -313,10 +313,14 @@ def mass_breakdown_bar_plot(
     # Same color for each aircraft configuration
     i = int(len(fig.data) / 2) % 10
 
+    # Same legend for each aircraft configuration
+    l = int(len(fig.data)/2)
+    aircraft_config = f"aircraft{l}"
+    
     weight_labels = ["MTOW", "OWE", "Fuel - Mission", "Payload"]
     weight_values = [mtow, owe, fuel_mission, payload]
     fig.add_trace(
-        go.Bar(name="", x=weight_labels, y=weight_values, marker_color=COLS[i], showlegend=False),
+        go.Bar(name="", x=weight_labels, y=weight_values, marker_color=COLS[i], showlegend=False, legendgroup=aircraft_config),
         row=1,
         col=1,
     )

--- a/src/fastoad/gui/analysis_and_plots.py
+++ b/src/fastoad/gui/analysis_and_plots.py
@@ -320,7 +320,8 @@ def mass_breakdown_bar_plot(
     weight_labels = ["MTOW", "OWE", "Fuel - Mission", "Payload"]
     weight_values = [mtow, owe, fuel_mission, payload]
     fig.add_trace(
-        go.Bar(name="", x=weight_labels, y=weight_values, marker_color=COLS[i], showlegend=False, legendgroup=aircraft_config),
+        go.Bar(name="", x=weight_labels, y=weight_values, marker_color=COLS[i], showlegend=False, 
+               legendgroup=aircraft_config),
         row=1,
         col=1,
     )


### PR DESCRIPTION
This PR should close issue #544 

When using subplots in the mass_breakdown_bar_plot , it was impossible to isolate one aircraft from another and only one plot was masked.

To resolve this ,  we create a grouped legend for each aircraft configuration ( same methods as the one to have the same color for each aircraft) 