### PR TITLE
Added a feature for concurrently running several computations

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,17 +48,22 @@ jobs:
           poetry run ruff format --check .  # Check format
         shell: bash
 
-      - name: Unit tests without coverage
         # Runners that won't send coverage report are run without coverage overhead
-        if: ${{ (runner.os != 'Linux' ) || matrix.python-version != '3.10' }}
+      - name: Unit tests without coverage
+        if: ${{ (runner.os != 'macOS') && ( runner.os != 'Linux' || matrix.python-version != '3.10' )}}
+        run: poetry run mpiexec -n 1 pytest src
+        shell: bash
+      - name: Unit tests without coverage
+        # MPI tests stall on macOS if launched with mpiexec
+        if: ${{ runner.os == 'macOS' }}
         run: poetry run pytest src
         shell: bash
 
       - name: Unit tests with coverage
         # Only for runner that will send coverage reports (see below)
-        if: ${{ (runner.os == 'Linux' ) && matrix.python-version == '3.10' }}
+        if: ${{ runner.os == 'Linux' && matrix.python-version == '3.10' }}
         run: |
-          poetry run pytest src --cov
+          poetry run mpiexec -n 1 pytest src --cov
           poetry run coverage xml  # for sending coverage report
         shell: bash
 

--- a/src/fastoad/__init__.py
+++ b/src/fastoad/__init__.py
@@ -1,5 +1,5 @@
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2022 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or

--- a/src/fastoad/api.py
+++ b/src/fastoad/api.py
@@ -34,6 +34,9 @@ from fastoad.cmd.api import (
 )
 
 # noinspection PyUnresolvedReferences
+from fastoad.cmd.calc_runner import RunCase
+
+# noinspection PyUnresolvedReferences
 from fastoad.gui.analysis_and_plots import (
     aircraft_geometry_plot,
     drag_polar_plot,

--- a/src/fastoad/api.py
+++ b/src/fastoad/api.py
@@ -34,7 +34,7 @@ from fastoad.cmd.api import (
 )
 
 # noinspection PyUnresolvedReferences
-from fastoad.cmd.calc_runner import RunCase
+from fastoad.cmd.calc_runner import CalcRunner
 
 # noinspection PyUnresolvedReferences
 from fastoad.gui.analysis_and_plots import (

--- a/src/fastoad/cmd/calc_runner.py
+++ b/src/fastoad/cmd/calc_runner.py
@@ -31,7 +31,8 @@ _LOGGER = logging.getLogger(__name__)  # Logger for this module
 
 @dataclass
 class RunCase:
-    configuration_file_path: Optional[Union[str, PathLike]]
+    configuration_file_path: Union[str, PathLike]
+    input_file_path: Optional[Union[str, PathLike]] = None
     optimize: bool = False
 
     def run(
@@ -47,6 +48,8 @@ class RunCase:
         :return:
         """
         configuration = FASTOADProblemConfigurator(self.configuration_file_path)
+        if self.input_file_path:
+            configuration.input_file_path = self.input_file_path
         if calculation_folder:
             make_parent_dir(calculation_folder)
             configuration.make_local(calculation_folder)

--- a/src/fastoad/cmd/calc_runner.py
+++ b/src/fastoad/cmd/calc_runner.py
@@ -1,0 +1,135 @@
+"""Tools for running multiple computations"""
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
+#  FAST is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import logging
+import multiprocessing as mp
+from contextlib import contextmanager
+from dataclasses import dataclass
+from math import ceil, log10
+from os import PathLike
+from typing import List, Optional, Union
+
+from openmdao.utils.mpi import FakeComm
+
+from fastoad._utils.files import as_path, make_parent_dir
+from fastoad.io.configuration import FASTOADProblemConfigurator
+from fastoad.openmdao.variables import VariableList
+
+_LOGGER = logging.getLogger(__name__)  # Logger for this module
+
+
+@dataclass
+class RunCase:
+    configuration_file_path: Optional[Union[str, PathLike]]
+    optimize: bool = False
+
+    def run(
+        self,
+        input_values: Optional[VariableList] = None,
+        calculation_folder: Optional[Union[str, PathLike]] = None,
+    ):
+        """
+        Run the computation.
+
+        :param input_values:
+        :param calculation_folder:
+        :return:
+        """
+        configuration = FASTOADProblemConfigurator(self.configuration_file_path)
+        if calculation_folder:
+            make_parent_dir(calculation_folder)
+            configuration.make_local(calculation_folder)
+
+        problem = configuration.get_problem(read_inputs=True)
+        problem.comm = FakeComm()
+        problem.setup()
+
+        if input_values:
+            for input_variable in input_values:
+                problem.set_val(
+                    input_variable.name,
+                    val=input_variable.val,
+                    units=input_variable.units,
+                )
+
+        if self.optimize:
+            problem.run_driver()
+        else:
+            problem.run_model()
+
+        output_data = problem.write_outputs()
+
+        return output_data
+
+    def run_cases(
+        self,
+        input_list: List[VariableList],
+        destination_folder: Union[str, PathLike],
+        n_proc: Optional[int] = None,
+        use_MPI_if_available: bool = True,
+    ):
+        """
+
+        :param input_list:
+        :param destination_folder:
+        :param n_proc:
+        :param use_MPI_if_available:
+        :return:
+        """
+        destination_folder = as_path(destination_folder)
+        if n_proc == 0:
+            n_proc = mp.cpu_count() - 1
+
+        case_count = len(input_list)
+        n_digits = ceil(log10(case_count))
+
+        calculation_inputs = []
+        for i, input_vars in enumerate(input_list):
+            calculation_folder = destination_folder / f"calc_{i:0{n_digits}d}"
+            calculation_inputs.append((self, input_vars, calculation_folder))
+
+        use_MPI = False
+        max_proc = mp.cpu_count()
+        if use_MPI_if_available:
+            try:
+                from mpi4py import MPI  # noqa: F401
+
+                use_MPI = True
+                max_proc = MPI.COMM_WORLD.Get_size()
+            except ImportError:
+                _LOGGER.warning("No MPI environment found. Using multiprocessing instead.")
+                pass
+
+        if n_proc is not None:
+            n_proc = min(n_proc, max_proc)
+
+        if use_MPI:
+            pool = _MPIPool
+        else:
+            pool = mp.Pool
+
+        with pool(n_proc) as pool:
+            pool.starmap(RunCase.run, calculation_inputs)
+
+
+@contextmanager
+def _MPIPool(*args, **kwargs):
+    """Assumes availability of MPI environment."""
+    from mpi4py.futures import MPIPoolExecutor
+
+    pool = MPIPoolExecutor(*args, **kwargs)
+    try:
+        yield pool
+    finally:
+        pool.shutdown()

--- a/src/fastoad/cmd/calc_runner.py
+++ b/src/fastoad/cmd/calc_runner.py
@@ -18,6 +18,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from math import ceil, log10
 from os import PathLike
+from pathlib import Path
 from typing import List, Optional, Union
 
 from openmdao.utils.mpi import FakeComm
@@ -154,7 +155,12 @@ class CalcRunner:
                 self._calculation_inputs(input_list, destination_folder, overwrite_subfolders),
             )
 
-    def _calculation_inputs(self, input_list, destination_folder, overwrite_subfolders):
+    def _calculation_inputs(
+        self,
+        input_list: List[VariableList],
+        destination_folder: Path,
+        overwrite_subfolders: bool,
+    ):
         """Iterator for providing inputs of :meth:`run`."""
         case_count = len(input_list)
         n_digits = ceil(log10(case_count))

--- a/src/fastoad/cmd/tests/data/sellar2.yml
+++ b/src/fastoad/cmd/tests/data/sellar2.yml
@@ -1,0 +1,34 @@
+title: Sellar
+
+module_folders:
+  - ./cmd_sellar_example
+
+input_file: ./inputs.xml
+output_file: ./outputs.xml
+
+driver: om.ScipyOptimizeDriver(optimizer='SLSQP', tol=1e-8)
+model:
+  group:
+    nonlinear_solver: om.NonlinearBlockGS(maxiter=100)
+    disc1:
+      id: cmd_test.sellar.disc1
+    disc2:
+      id: cmd_test.sellar.disc2
+  functions:
+    id: cmd_test.sellar.functions
+
+optimization:
+  design_variables:
+    - name: x
+      lower: 0
+      upper: 10
+    - name: z
+      lower: 0
+      upper: 10
+  constraints:
+    - name: g1
+      upper: 0
+    - name: g2
+      upper: 0
+  objective:
+    - name: f

--- a/src/fastoad/cmd/tests/test_calc_runner.py
+++ b/src/fastoad/cmd/tests/test_calc_runner.py
@@ -1,0 +1,85 @@
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
+#  FAST is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from fastoad.openmdao.variables import Variable, VariableList
+from ..calc_runner import RunCase
+
+DATA_FOLDER_PATH = Path(__file__).parent / "data"
+RESULTS_FOLDER_PATH = Path(__file__).parent / "results" / Path(__file__).stem
+
+
+@pytest.fixture(scope="module")
+def cleanup():
+    shutil.rmtree(RESULTS_FOLDER_PATH, ignore_errors=True)
+
+
+def test_one_run(cleanup):
+    run_case = RunCase(configuration_file_path=DATA_FOLDER_PATH / "sellar2.yml")
+    run_case.run(calculation_folder=RESULTS_FOLDER_PATH)
+
+
+def test_MPI_run_max_cpu(cleanup):
+    run_case = RunCase(configuration_file_path=DATA_FOLDER_PATH / "sellar2.yml")
+
+    input_vars = [
+        VariableList([Variable("x", val=0.0), Variable("z", val=0.0)]),
+        VariableList([Variable("x", val=10.0), Variable("z", val=0.0)]),
+        VariableList([Variable("x", val=10.0), Variable("z", val=10.0)]),
+        VariableList([Variable("x", val=0.0), Variable("z", val=10.0)]),
+    ] * 3
+    run_case.run_cases(
+        input_vars,
+        RESULTS_FOLDER_PATH / "with_MPI",
+        use_MPI_if_available=True,
+    )
+
+
+def test_MPI_run_2cpu(cleanup):
+    run_case = RunCase(configuration_file_path=DATA_FOLDER_PATH / "sellar2.yml")
+
+    input_vars = [
+        VariableList([Variable("x", val=0.0), Variable("z", val=0.0)]),
+        VariableList([Variable("x", val=10.0), Variable("z", val=0.0)]),
+        VariableList([Variable("x", val=10.0), Variable("z", val=10.0)]),
+        VariableList([Variable("x", val=0.0), Variable("z", val=10.0)]),
+    ] * 3
+
+    run_case.run_cases(
+        input_vars,
+        RESULTS_FOLDER_PATH / "with_MPI_2",
+        n_proc=2,
+        use_MPI_if_available=True,
+    )
+
+
+def test_multiprocessing_run_2cpu(cleanup):
+    run_case = RunCase(configuration_file_path=DATA_FOLDER_PATH / "sellar2.yml")
+
+    input_vars = [
+        VariableList([Variable("x", val=0.0), Variable("z", val=0.0)]),
+        VariableList([Variable("x", val=10.0), Variable("z", val=0.0)]),
+        VariableList([Variable("x", val=10.0), Variable("z", val=10.0)]),
+        VariableList([Variable("x", val=0.0), Variable("z", val=10.0)]),
+    ] * 3
+
+    run_case.run_cases(
+        input_vars,
+        RESULTS_FOLDER_PATH / "without_MPI_2",
+        n_proc=2,
+        use_MPI_if_available=False,
+    )

--- a/src/fastoad/cmd/tests/test_calc_runner.py
+++ b/src/fastoad/cmd/tests/test_calc_runner.py
@@ -62,7 +62,7 @@ def test_MPI_run_2cpu(cleanup):
     run_case.run_cases(
         input_vars,
         RESULTS_FOLDER_PATH / "with_MPI_2",
-        n_proc=2,
+        max_workers=2,
         use_MPI_if_available=True,
     )
 
@@ -80,6 +80,6 @@ def test_multiprocessing_run_2cpu(cleanup):
     run_case.run_cases(
         input_vars,
         RESULTS_FOLDER_PATH / "without_MPI_2",
-        n_proc=2,
+        max_workers=2,
         use_MPI_if_available=False,
     )

--- a/src/fastoad/cmd/tests/test_calc_runner.py
+++ b/src/fastoad/cmd/tests/test_calc_runner.py
@@ -17,7 +17,7 @@ from pathlib import Path
 import pytest
 
 from fastoad.openmdao.variables import Variable, VariableList
-from ..calc_runner import RunCase
+from ..calc_runner import CalcRunner
 
 DATA_FOLDER_PATH = Path(__file__).parent / "data"
 RESULTS_FOLDER_PATH = Path(__file__).parent / "results" / Path(__file__).stem
@@ -29,12 +29,12 @@ def cleanup():
 
 
 def test_one_run(cleanup):
-    run_case = RunCase(configuration_file_path=DATA_FOLDER_PATH / "sellar2.yml")
+    run_case = CalcRunner(configuration_file_path=DATA_FOLDER_PATH / "sellar2.yml")
     run_case.run(calculation_folder=RESULTS_FOLDER_PATH)
 
 
 def test_MPI_run_max_cpu(cleanup):
-    run_case = RunCase(configuration_file_path=DATA_FOLDER_PATH / "sellar2.yml")
+    run_case = CalcRunner(configuration_file_path=DATA_FOLDER_PATH / "sellar2.yml")
 
     input_vars = [
         VariableList([Variable("x", val=0.0), Variable("z", val=0.0)]),
@@ -50,7 +50,7 @@ def test_MPI_run_max_cpu(cleanup):
 
 
 def test_MPI_run_2cpu(cleanup):
-    run_case = RunCase(configuration_file_path=DATA_FOLDER_PATH / "sellar2.yml")
+    run_case = CalcRunner(configuration_file_path=DATA_FOLDER_PATH / "sellar2.yml")
 
     input_vars = [
         VariableList([Variable("x", val=0.0), Variable("z", val=0.0)]),
@@ -68,7 +68,7 @@ def test_MPI_run_2cpu(cleanup):
 
 
 def test_multiprocessing_run_2cpu(cleanup):
-    run_case = RunCase(configuration_file_path=DATA_FOLDER_PATH / "sellar2.yml")
+    run_case = CalcRunner(configuration_file_path=DATA_FOLDER_PATH / "sellar2.yml")
 
     input_vars = [
         VariableList([Variable("x", val=0.0), Variable("z", val=0.0)]),

--- a/src/fastoad/io/configuration/configuration.py
+++ b/src/fastoad/io/configuration/configuration.py
@@ -281,10 +281,11 @@ class FASTOADProblemConfigurator:
         Modify the current configurator so that all input and output files will be in
         the indicated folder.
 
-        :param new_folder_path:
-        :return:
+        :param new_folder_path: the folder path that will contain in/out files
+        :param copy_models: True if local models (declared in `module_folders`) should
+                            be copied in `new_folder_path`
         """
-        new_folder_path = Path(new_folder_path)
+        new_folder_path = as_path(new_folder_path)
 
         self._data[KEY_INPUT_FILE] = self._make_path_local(self.input_file_path, new_folder_path)
         self._data[KEY_OUTPUT_FILE] = self._make_path_local(self.output_file_path, new_folder_path)

--- a/src/fastoad/io/configuration/configuration.py
+++ b/src/fastoad/io/configuration/configuration.py
@@ -359,7 +359,7 @@ class FASTOADProblemConfigurator:
                     or key.endswith(("file", "path", "dir", "directory", "folder"))
                 ):
                     structure[key] = self._make_path_local(
-                        original_file_path, new_root_path, local_path
+                        original_file_path, new_root_path, local_path / key
                     )
 
     def _configure_driver(self, prob):

--- a/src/fastoad/io/configuration/tests/data/valid_sellar.toml
+++ b/src/fastoad/io/configuration/tests/data/valid_sellar.toml
@@ -26,7 +26,7 @@ driver = "om.ScipyOptimizeDriver(optimizer='SLSQP')"
             id = "configuration_test.sellar.disc1"
         [model.cycle.disc2]
             id = "configuration_test.sellar.disc2"
-    [model.functions]
+    [model.group.functions]
         id = "configuration_test.sellar.functions"
         input_path = "translator.txt"
 

--- a/src/fastoad/io/configuration/tests/data/valid_sellar.toml
+++ b/src/fastoad/io/configuration/tests/data/valid_sellar.toml
@@ -33,6 +33,8 @@ driver = "om.ScipyOptimizeDriver(optimizer='SLSQP')"
 [model_options."*"]
   dummy_f_option = 10
   dummy_generic_option = "it works"
+  unused_file = "conf_sellar_example/functions.py"
+
 [model_options."*".dummy_disc1_option]
     a = 1
     b = 2

--- a/src/fastoad/io/configuration/tests/data/valid_sellar.yml
+++ b/src/fastoad/io/configuration/tests/data/valid_sellar.yml
@@ -23,9 +23,10 @@ model:
       id: configuration_test.sellar.disc1
     disc2:
       id: configuration_test.sellar.disc2
-  functions:
-    id: configuration_test.sellar.functions
-    input_path: "translator.txt"
+  group:
+    functions:
+      id: configuration_test.sellar.functions
+      input_path: "translator.txt"
 
 model_options:
   "*":

--- a/src/fastoad/io/configuration/tests/data/valid_sellar.yml
+++ b/src/fastoad/io/configuration/tests/data/valid_sellar.yml
@@ -35,6 +35,7 @@ model_options:
       a: 1
       b: 2
     dummy_generic_option: "it works"
+    unused_file: "conf_sellar_example/functions.py"
   "cycle.*":
     dummy_generic_option: "it works here also"
     input_file: "__init__.py"

--- a/src/fastoad/io/configuration/tests/test_configuration.py
+++ b/src/fastoad/io/configuration/tests/test_configuration.py
@@ -387,15 +387,15 @@ def test_make_local(cleanup):
                 target_folder / "ref_inputs.xml", DATA_FOLDER_PATH / "ref_inputs.xml"
             )
             assert filecmp.cmp(
-                target_folder / "group" / "functions" / "translator.txt",
+                target_folder / "group" / "functions" / "input_path" / "translator.txt",
                 DATA_FOLDER_PATH / "translator.txt",
             )
             assert filecmp.cmp(
-                target_folder / "model_options" / "functions.py",
+                target_folder / "model_options" / "unused_file" / "functions.py",
                 DATA_FOLDER_PATH / "conf_sellar_example" / "functions.py",
             )
             assert filecmp.cmp(
-                target_folder / "model_options" / "cycle." / "__init__.py",
+                target_folder / "model_options" / "cycle." / "input_file" / "__init__.py",
                 DATA_FOLDER_PATH / "__init__.py",
             )
             # Run -----------------------------------------------------

--- a/src/fastoad/io/configuration/tests/test_configuration.py
+++ b/src/fastoad/io/configuration/tests/test_configuration.py
@@ -14,6 +14,7 @@ Test module for configuration.py
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import filecmp
 import os
 import shutil
 import sys
@@ -35,6 +36,19 @@ from fastoad.module_management.exceptions import FastBundleLoaderUnknownFactoryN
 from ..exceptions import (
     FASTConfigurationBadOpenMDAOInstructionError,
 )
+
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
+#  FAST is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 DATA_FOLDER_PATH = Path(__file__).parent / "data"
 RESULTS_FOLDER_PATH = Path(__file__).parent / "results"
@@ -147,14 +161,14 @@ def test_problem_definition_with_xml_ref(cleanup, caplog):
         problem.setup()
 
         # check the global way to set options
-        assert problem.model.functions.f.options["dummy_f_option"] == 10
-        assert problem.model.functions.f.options["dummy_generic_option"] == "it works"
+        assert problem.model.group.functions.f.options["dummy_f_option"] == 10
+        assert problem.model.group.functions.f.options["dummy_generic_option"] == "it works"
         assert problem.model.cycle.disc1.options["dummy_disc1_option"] == {"a": 1, "b": 2}
         assert problem.model.cycle.disc1.options["dummy_generic_option"] == "it works here also"
 
         # check that path options are made absolute
         assert (
-            Path(problem.model.functions.options["input_path"])
+            Path(problem.model.group.functions.options["input_path"])
             == DATA_FOLDER_PATH / "translator.txt"
         )
 
@@ -340,6 +354,71 @@ def test_set_optimization_definition(cleanup):
         conf_dict_opt = conf_dict["optimization"]
         # Should be equal
         assert optimization_conf == conf_dict_opt
+
+
+def test_make_local(cleanup):
+    for extension in ["toml", "yml"]:
+        reference_file = DATA_FOLDER_PATH / f"valid_sellar.{extension}"
+        for copy_models in [True, False]:
+            clear_openmdao_registry()
+            conf = FASTOADProblemConfigurator(reference_file)
+            conf.input_file_path = DATA_FOLDER_PATH / "ref_inputs.xml"
+            target_folder = (
+                RESULTS_FOLDER_PATH / f"local_{extension}{'_with_models' if copy_models else ''}"
+            )
+
+            conf.make_local(target_folder, copy_models=copy_models)
+
+            # Check files -----------------------------------------------------
+            if copy_models:
+                original_model_folder_path = DATA_FOLDER_PATH / "conf_sellar_example"
+                for file_path in original_model_folder_path.rglob("*.py"):
+                    copied_file_path = (
+                        target_folder
+                        / "models_0"
+                        / "conf_sellar_example"
+                        / file_path.relative_to(original_model_folder_path)
+                    )
+                    assert filecmp.cmp(copied_file_path, file_path)
+            else:
+                assert next(target_folder.glob("models_*"), None) is None
+
+            assert filecmp.cmp(
+                target_folder / "ref_inputs.xml", DATA_FOLDER_PATH / "ref_inputs.xml"
+            )
+            assert filecmp.cmp(
+                target_folder / "group" / "functions" / "translator.txt",
+                DATA_FOLDER_PATH / "translator.txt",
+            )
+
+            # Run -----------------------------------------------------
+            clear_openmdao_registry()
+            local_conf_1 = FASTOADProblemConfigurator(target_folder / f"valid_sellar.{extension}")
+            problem = local_conf_1.get_problem(read_inputs=True)
+            problem.setup()
+            problem.run_model()
+            problem.write_outputs()
+
+            assert (target_folder / "outputs.xml").is_file()
+
+            # Check that local input file is used --------------
+            (target_folder / "ref_inputs.xml").unlink()
+
+            clear_openmdao_registry()
+            local_conf_2 = FASTOADProblemConfigurator(target_folder / f"valid_sellar.{extension}")
+            with pytest.raises(FileNotFoundError):
+                _ = local_conf_2.get_problem(read_inputs=True)
+
+            # Check that local models are used --------------
+            if copy_models:
+                shutil.rmtree(target_folder / "models_0" / "conf_sellar_example")
+
+                clear_openmdao_registry()
+                local_conf_3 = FASTOADProblemConfigurator(
+                    target_folder / f"valid_sellar.{extension}"
+                )
+                with pytest.raises(FastBundleLoaderUnknownFactoryNameError):
+                    _ = local_conf_3.get_problem(read_inputs=True)
 
 
 @pytest.fixture()

--- a/src/fastoad/io/configuration/tests/test_configuration.py
+++ b/src/fastoad/io/configuration/tests/test_configuration.py
@@ -390,7 +390,14 @@ def test_make_local(cleanup):
                 target_folder / "group" / "functions" / "translator.txt",
                 DATA_FOLDER_PATH / "translator.txt",
             )
-
+            assert filecmp.cmp(
+                target_folder / "model_options" / "functions.py",
+                DATA_FOLDER_PATH / "conf_sellar_example" / "functions.py",
+            )
+            assert filecmp.cmp(
+                target_folder / "model_options" / "cycle." / "__init__.py",
+                DATA_FOLDER_PATH / "__init__.py",
+            )
             # Run -----------------------------------------------------
             clear_openmdao_registry()
             local_conf_1 = FASTOADProblemConfigurator(target_folder / f"valid_sellar.{extension}")

--- a/src/fastoad/openmdao/problem.py
+++ b/src/fastoad/openmdao/problem.py
@@ -136,7 +136,7 @@ class FASTOADProblem(om.Problem):
                 _LOGGER.warning("The following variables have NaN values: %s", nan_variable_names)
         variables.save()
 
-    def write_outputs(self):
+    def write_outputs(self) -> VariableList:
         """
         Writes all outputs in the configured output file.
         """
@@ -152,6 +152,8 @@ class FASTOADProblem(om.Problem):
                 VariableList.from_problem(self, promoted_only=True), add_variables=True
             )
             writer.write(variables)
+
+            return variables
 
     def read_inputs(self):
         """

--- a/tests/integration_tests/oad_process/data/mission_definition/sizing_breguet.yml
+++ b/tests/integration_tests/oad_process/data/mission_definition/sizing_breguet.yml
@@ -1,0 +1,98 @@
+phases:
+  start:
+    parts:
+      - segment: start
+        target:
+          altitude:
+            value: ~
+            unit: ft
+            default: 0.0
+          true_airspeed:
+            value: ~
+            unit: m/s
+            default: 0.0
+  taxi_out:
+    parts:
+      - segment: taxi
+        thrust_rate: ~
+        true_airspeed:
+          value: ~
+          default: 0.
+        target:
+          time: ~duration
+  takeoff:
+    parts:
+      - segment: transition
+        target:
+          delta_altitude:
+            value: ~safety_altitude
+            unit: ft
+            default: 35
+          delta_mass: -~fuel
+          time:
+            value: ~duration
+            unit: s
+            default: 0.0
+          true_airspeed: ~V2
+      - segment: mass_input
+        target:
+          mass: data:mission:sizing:TOW
+  climb:
+    parts:
+      - segment: transition
+        target:
+          altitude: data:mission:sizing:main_route:cruise:altitude
+          mach: data:TLAR:cruise_mach
+          delta_ground_distance:
+            value: 250
+            unit: km
+        mass_ratio:
+          value: settings:mission:sizing:breguet:climb:mass_ratio
+          default: 0.97
+  descent:
+    parts:
+      - segment: transition
+        target:
+          altitude: 0.
+          mach: 0.
+          delta_ground_distance:
+            value: 250
+            unit: km
+        mass_ratio:
+          value: settings:mission:sizing:breguet:descent:mass_ratio
+          default: 0.98
+  global_reserve:
+    parts:
+      - segment: transition
+        target:
+          altitude: 0.
+          mach: 0.
+        reserve_mass_ratio:
+          value: settings:mission:sizing:breguet:reserve:mass_ratio
+          default: 0.06
+
+routes:
+  main_route:
+    range: data:TLAR:range
+    climb_parts:
+      - phase: climb
+    cruise_part:
+      segment: breguet
+      engine_setting: cruise
+      polar: data:aerodynamics:aircraft:cruise
+      use_max_lift_drag_ratio: true
+    descent_parts:
+      - phase: descent
+
+missions:
+  sizing:
+    isa_offset:
+      value: ~ISA_offset
+      unit: degK
+      default: 0.0
+    parts:
+      - phase: start
+      - phase: taxi_out
+      - phase: takeoff
+      - route: main_route
+      - phase: global_reserve

--- a/tests/integration_tests/oad_process/data/oad_process.yml
+++ b/tests/integration_tests/oad_process/data/oad_process.yml
@@ -31,7 +31,7 @@ model:
         id: fastoad.performances.mission
         propulsion_id: fastoad.wrapper.propulsion.rubber_engine
         out_file: ../results/flight_points.csv
-        mission_file_path: ::sizing_breguet
+        mission_file_path: ./mission_definition/sizing_breguet.yml
         adjust_fuel: true
         use_inner_solvers: false
         is_sizing: true

--- a/tests/integration_tests/oad_process/test_oad_process.py
+++ b/tests/integration_tests/oad_process/test_oad_process.py
@@ -48,6 +48,7 @@ def test_oad_process(cleanup):
     """
 
     configurator = FASTOADProblemConfigurator(pth.join(DATA_FOLDER_PATH, "oad_process.yml"))
+    configurator.make_local(pth.join(RESULTS_FOLDER_PATH, "test_oad_process"))
 
     ref_inputs = pth.join(DATA_FOLDER_PATH, "CeRAS01_legacy.xml")
     problem = configurator.get_problem()


### PR DESCRIPTION
This PR adds the CalcRunner class:
- it allows to "make local" FAST-OAD computations, i.e. put in one folder all input and output files, making it possible to run again the computation with only this folder (configuration file is modified accordingly)
- it allows to run a batch of these "localized" computations concurrently, using either `multiprocessing` or `mpi4py`.

The follow-up of this PR will be:
- Making this feature available from CLI
- Refining the continuation of batch, based on calc results instead of simply the existence of the calc folder (based on calc number)

In a second time, adding a way of building the computation inputs (i.e a DoE) will be useful.