### PR TITLE
Update of Flightpoint class

### DIFF
--- a/docs/documentation/mission_module/extensibility/flight_point.rst
+++ b/docs/documentation/mission_module/extensibility/flight_point.rst
@@ -23,12 +23,11 @@ Available flight parameters
 ***************************
 The documentation of :class:`~fastoad.model_base.flight_point.FlightPoint` provides
 the list of available flight parameters, available as attributes.
-As FlightPoint is a dataclass, this list is available through Python using::
+This list is available through Python using::
 
     >>> import fastoad.api as oad
-    >>> from dataclasses import fields
 
-    >>> [f.name for f in fields(oad.FlightPoint)]
+    >>> oad.FlightPoint.get_field_names()
 
 *******************************
 Exchanges with pandas DataFrame
@@ -64,15 +63,20 @@ smoothly, especially when exchanging data with pandas, you have to work at class
 This can be done using :meth:`~fastoad.model_base.flight_point.FlightPoint.add_field`, preferably
 outside of any class or function::
 
-    # Adds a float field with None as default value
-    >>> FlightPoint.add_field("ion_drive_power")
+    # Adding a float field with None as default value
+    >>> FlightPoint.add_field(
+    ...    "ion_drive_power",
+    ...    unit="YW",
+    ...    is_cumulative=False, # Tells if quantity sums up during mission
+    ...    is_output=True, # Tells if quantity is expected as mission output
+    ...    )
 
-    # Adds a field and define its type and default value
+    # Adding a field and defining its type and default value
     >>> FlightPoint.add_field("warp", annotation_type=int, default_value=9)
 
     # Now these fields can be used at instantiation
     >>> fp = FlightPoint(ion_drive_power=110.0, warp=12)
 
-    # Removes a field, even an original one (useful only to avoid having it in outputs)
+    # Removing a field, even an original one
     >>> FlightPoint.remove_field("sfc")
 

--- a/src/fastoad/gui/mission_viewer.py
+++ b/src/fastoad/gui/mission_viewer.py
@@ -134,8 +134,7 @@ class MissionViewer:
         Otherwise return the column corresponding to the default index.
         """
 
-        flight_point_units = FlightPoint.get_units()
-        unit_quantity = flight_point_units[quantity_name]
+        unit_quantity = FlightPoint.get_unit(quantity_name)
         column_quantity = f"{quantity_name} [{unit_quantity}]"
         label_quantity = column_quantity if column_quantity in keys else keys[default_idx]
 

--- a/src/fastoad/model_base/flight_point.py
+++ b/src/fastoad/model_base/flight_point.py
@@ -225,6 +225,16 @@ class FlightPoint:
         new_point.scalarize()
         return new_point
 
+    def scalarize(self):
+        """
+        Convenience method for converting to scalars all fields that have a
+        one-item array-like value.
+        """
+        self_as_dict = asdict(self)
+        for field_name, value in self_as_dict.items():
+            if np.size(value) == 1:
+                setattr(self, field_name, np.asarray(value).item())
+
     @classmethod
     def get_field_names(cls):
         """
@@ -319,16 +329,6 @@ class FlightPoint:
             delattr(cls, name)
             del cls.__annotations__[name]
             dataclass(cls)
-
-    def scalarize(self):
-        """
-        Convenience method for converting to scalars all fields that have a
-        one-item array-like value.
-        """
-        self_as_dict = asdict(self)
-        for field_name, value in self_as_dict.items():
-            if np.size(value) == 1:
-                setattr(self, field_name, np.asarray(value).item())
 
     @classmethod
     def _redeclare_fields(cls):

--- a/src/fastoad/model_base/flight_point.py
+++ b/src/fastoad/model_base/flight_point.py
@@ -16,18 +16,18 @@
 from copy import deepcopy
 from dataclasses import asdict, dataclass, field, fields
 from numbers import Number
-from typing import Any, List, Mapping, Optional, Sequence, Union
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Union
 
 import numpy as np
 import pandas as pd
 
 from fastoad.constants import EngineSetting
 
-FIELD_STATUS = "field_status"
+FIELD_DESCRIPTOR = "field_descriptor"
 
 
 @dataclass
-class _FieldStatus:
+class _FieldDescriptor:
     """
     Class to be used as dataclass field metadata.
     """
@@ -94,83 +94,99 @@ class FlightPoint:
     """
 
     time: float = field(
-        default=0.0, metadata={FIELD_STATUS: _FieldStatus(cumulative=True, unit="s")}
+        default=0.0, metadata={FIELD_DESCRIPTOR: _FieldDescriptor(cumulative=True, unit="s")}
     )  #: Time in seconds.
 
     #: Altitude in meters.
-    altitude: float = field(default=None, metadata={FIELD_STATUS: _FieldStatus(unit="m")})
+    altitude: float = field(default=None, metadata={FIELD_DESCRIPTOR: _FieldDescriptor(unit="m")})
 
     #: temperature deviation from Standard Atmosphere
-    isa_offset: float = field(default=0.0, metadata={FIELD_STATUS: _FieldStatus(unit="K")})
+    isa_offset: float = field(default=0.0, metadata={FIELD_DESCRIPTOR: _FieldDescriptor(unit="K")})
 
     #: Covered ground distance in meters.
-    ground_distance: float = field(default=0.0, metadata={FIELD_STATUS: _FieldStatus(unit="m")})
+    ground_distance: float = field(
+        default=0.0, metadata={FIELD_DESCRIPTOR: _FieldDescriptor(unit="m")}
+    )
 
     #: Mass in kg.
-    mass: float = field(default=None, metadata={FIELD_STATUS: _FieldStatus(unit="kg")})
+    mass: float = field(default=None, metadata={FIELD_DESCRIPTOR: _FieldDescriptor(unit="kg")})
 
     #: Consumed fuel since mission start, in kg.
     consumed_fuel: float = field(
-        default=0.0, metadata={FIELD_STATUS: _FieldStatus(cumulative=True, unit="kg")}
+        default=0.0, metadata={FIELD_DESCRIPTOR: _FieldDescriptor(cumulative=True, unit="kg")}
     )
 
     #: True airspeed (TAS) in m/s.
-    true_airspeed: float = field(default=None, metadata={FIELD_STATUS: _FieldStatus(unit="m/s")})
+    true_airspeed: float = field(
+        default=None, metadata={FIELD_DESCRIPTOR: _FieldDescriptor(unit="m/s")}
+    )
 
     #: Equivalent airspeed (EAS) in m/s.
     equivalent_airspeed: float = field(
-        default=None, metadata={FIELD_STATUS: _FieldStatus(unit="m/s")}
+        default=None, metadata={FIELD_DESCRIPTOR: _FieldDescriptor(unit="m/s")}
     )
 
     #: Mach number.
-    mach: float = field(default=None, metadata={FIELD_STATUS: _FieldStatus(unit="-")})
+    mach: float = field(default=None, metadata={FIELD_DESCRIPTOR: _FieldDescriptor(unit="-")})
 
     #: Engine setting.
-    engine_setting: EngineSetting = field(default=None, metadata={FIELD_STATUS: _FieldStatus()})
+    engine_setting: EngineSetting = field(
+        default=None, metadata={FIELD_DESCRIPTOR: _FieldDescriptor()}
+    )
 
     # pylint: disable=invalid-name
     #: Lift coefficient.
-    CL: float = field(default=None, metadata={FIELD_STATUS: _FieldStatus(unit="-")})
+    CL: float = field(default=None, metadata={FIELD_DESCRIPTOR: _FieldDescriptor(unit="-")})
 
     # pylint: disable=invalid-name
     #: Drag coefficient.
-    CD: float = field(default=None, metadata={FIELD_STATUS: _FieldStatus(unit="-")})
+    CD: float = field(default=None, metadata={FIELD_DESCRIPTOR: _FieldDescriptor(unit="-")})
 
     #: Aircraft lift in Newtons
-    lift: float = field(default=None, metadata={FIELD_STATUS: _FieldStatus(unit="N")})
+    lift: float = field(default=None, metadata={FIELD_DESCRIPTOR: _FieldDescriptor(unit="N")})
 
     #: Aircraft drag in Newtons.
-    drag: float = field(default=None, metadata={FIELD_STATUS: _FieldStatus(unit="N")})
+    drag: float = field(default=None, metadata={FIELD_DESCRIPTOR: _FieldDescriptor(unit="N")})
 
     #: Thrust in Newtons.
-    thrust: float = field(default=None, metadata={FIELD_STATUS: _FieldStatus(unit="N")})
+    thrust: float = field(default=None, metadata={FIELD_DESCRIPTOR: _FieldDescriptor(unit="N")})
 
     #: Thrust rate (between 0. and 1.)
-    thrust_rate: float = field(default=None, metadata={FIELD_STATUS: _FieldStatus(unit="-")})
+    thrust_rate: float = field(
+        default=None, metadata={FIELD_DESCRIPTOR: _FieldDescriptor(unit="-")}
+    )
 
     #: If True, propulsion should match the thrust value.
     #: If False, propulsion should match thrust rate.
-    thrust_is_regulated: bool = field(default=None, metadata={FIELD_STATUS: _FieldStatus(unit="-")})
+    thrust_is_regulated: bool = field(
+        default=None, metadata={FIELD_DESCRIPTOR: _FieldDescriptor(unit="-")}
+    )
 
     #: Specific Fuel Consumption in kg/N/s.
-    sfc: float = field(default=None, metadata={FIELD_STATUS: _FieldStatus(unit="kg/N/s")})
+    sfc: float = field(default=None, metadata={FIELD_DESCRIPTOR: _FieldDescriptor(unit="kg/N/s")})
 
     #: Slope angle in radians.
-    slope_angle: float = field(default=None, metadata={FIELD_STATUS: _FieldStatus(unit="rad")})
+    slope_angle: float = field(
+        default=None, metadata={FIELD_DESCRIPTOR: _FieldDescriptor(unit="rad")}
+    )
 
     #: Acceleration value in m/s**2.
-    acceleration: float = field(default=None, metadata={FIELD_STATUS: _FieldStatus(unit="m/s**2")})
+    acceleration: float = field(
+        default=None, metadata={FIELD_DESCRIPTOR: _FieldDescriptor(unit="m/s**2")}
+    )
 
     #: angle of attack in radians
-    alpha: float = field(default=0.0, metadata={FIELD_STATUS: _FieldStatus(unit="rad")})
+    alpha: float = field(default=0.0, metadata={FIELD_DESCRIPTOR: _FieldDescriptor(unit="rad")})
 
     #: slope angle derivative in rad/s
     slope_angle_derivative: float = field(
-        default=None, metadata={FIELD_STATUS: _FieldStatus(unit="rad/s")}
+        default=None, metadata={FIELD_DESCRIPTOR: _FieldDescriptor(unit="rad/s")}
     )
 
     #: Name of current phase.
-    name: str = field(default=None, metadata={FIELD_STATUS: _FieldStatus()})
+    name: str = field(default=None, metadata={FIELD_DESCRIPTOR: _FieldDescriptor()})
+
+    __field_descriptors = {}  # Will store field metadata when needed
 
     def __post_init__(self):
         self._relative_parameters = {"ground_distance", "time"}
@@ -250,9 +266,8 @@ class FlightPoint:
         A dimensionless physical quantity will have "-" as unit.
         """
         return {
-            cls_field.name: cls_field.metadata[FIELD_STATUS].unit
-            for cls_field in fields(cls)
-            if not cls_field.name.startswith("_")
+            name: field_descriptor.unit
+            for name, field_descriptor in cls._get_field_descriptors().items()
         }
 
     @classmethod
@@ -309,7 +324,9 @@ class FlightPoint:
             field(
                 default=default_value,
                 metadata={
-                    FIELD_STATUS: _FieldStatus(unit=unit, cumulative=cumulative, output=output)
+                    FIELD_DESCRIPTOR: _FieldDescriptor(
+                        unit=unit, cumulative=cumulative, output=output
+                    )
                 },
             ),
         )
@@ -331,6 +348,21 @@ class FlightPoint:
             dataclass(cls)
 
     @classmethod
+    def _get_field_descriptors(cls) -> Dict[str, _FieldDescriptor]:
+        """
+        Uses this method instead of accessing cls.__field_descriptors to ensure it
+        will always be correctly populated.
+        """
+        if not cls.__field_descriptors:
+            cls.__field_descriptors = {
+                cls_field.name: cls_field.metadata[FIELD_DESCRIPTOR]
+                for cls_field in fields(cls)
+                if not cls_field.name.startswith("_")
+            }
+
+        return cls.__field_descriptors
+
+    @classmethod
     def _redeclare_fields(cls):
         """
         To be done before "re-dataclassing" cls.
@@ -342,3 +374,5 @@ class FlightPoint:
             setattr(
                 cls, cls_field.name, field(default=cls_field.default, metadata=cls_field.metadata)
             )
+
+        cls.__field_descriptors = {}  # Will need to rebuild this dict on next usage.

--- a/src/fastoad/model_base/flight_point.py
+++ b/src/fastoad/model_base/flight_point.py
@@ -75,27 +75,33 @@ class FlightPoint:
         smoothly, especially when exchanging data with pandas, you have to work at class level.
         This can be done using :meth:`add_field`, preferably outside any class or function::
 
-            # Adds a float field with None as default value
-            >>> FlightPoint.add_field("ion_drive_power")
+            # Adding a float field with None as default value
+            >>> FlightPoint.add_field(
+            ...    "ion_drive_power",
+            ...    unit="W",
+            ...    is_cumulative=False, # Tells if quantity sums up during mission
+            ...    is_output=True, # Tells if quantity is expected as mission output
+            ...    )
 
-            # Adds a field and define its type and default value
+            # Adding a field and defining its type and default value
             >>> FlightPoint.add_field("warp", annotation_type=int, default_value=9)
 
             # Now these fields can be used at instantiation
             >>> fp = FlightPoint(ion_drive_power=110.0, warp=12)
 
-            # Removes a field, even an original one (useful only to avoid having it in outputs)
+            # Removing a field, even an original one
             >>> FlightPoint.remove_field("sfc")
 
     .. note::
 
-        All parameters in FlightPoint instances are expected to be in SI units.
+        All original parameters in FlightPoint instances are expected to be in SI units.
 
     """
 
+    #: Time in seconds.
     time: float = field(
         default=0.0, metadata={FIELD_DESCRIPTOR: _FieldDescriptor(is_cumulative=True, unit="s")}
-    )  #: Time in seconds.
+    )
 
     #: Altitude in meters.
     altitude: float = field(default=None, metadata={FIELD_DESCRIPTOR: _FieldDescriptor(unit="m")})

--- a/src/fastoad/model_base/flight_point.py
+++ b/src/fastoad/model_base/flight_point.py
@@ -290,8 +290,6 @@ class FlightPoint:
         :param cumulative: True if field value is sums up during mission
         :param output: True if field should be written in mission outputs
         """
-        cls.remove_field(name)
-
         cls._redeclare_fields()
 
         del cls.__init__  # Delete constructor to allow it being rebuilt with dataclass() call

--- a/src/fastoad/model_base/flight_point.py
+++ b/src/fastoad/model_base/flight_point.py
@@ -230,7 +230,7 @@ class FlightPoint:
         """
         :return: names of all fields of the flight point.
         """
-        return [field.name for field in fields(cls) if not field.name.startswith("_")]
+        return [cls_field.name for cls_field in fields(cls) if not cls_field.name.startswith("_")]
 
     @classmethod
     def get_units(cls) -> dict:
@@ -240,9 +240,9 @@ class FlightPoint:
         A dimensionless physical quantity will have "-" as unit.
         """
         return {
-            field.name: field.metadata[FIELD_STATUS].unit
-            for field in fields(cls)
-            if not field.name.startswith("_")
+            cls_field.name: cls_field.metadata[FIELD_STATUS].unit
+            for cls_field in fields(cls)
+            if not cls_field.name.startswith("_")
         }
 
     @classmethod

--- a/src/fastoad/model_base/flight_point.py
+++ b/src/fastoad/model_base/flight_point.py
@@ -292,6 +292,8 @@ class FlightPoint:
         """
         cls.remove_field(name)
 
+        cls._redeclare_fields()
+
         del cls.__init__  # Delete constructor to allow it being rebuilt with dataclass() call
         setattr(
             cls,
@@ -314,6 +316,7 @@ class FlightPoint:
         :param name: field name
         """
         if name in cls.__annotations__:
+            cls._redeclare_fields()
             del cls.__init__  # Delete constructor to allow it being rebuilt with dataclass() call
             delattr(cls, name)
             del cls.__annotations__[name]
@@ -328,3 +331,16 @@ class FlightPoint:
         for field_name, value in self_as_dict.items():
             if np.size(value) == 1:
                 setattr(self, field_name, np.asarray(value).item())
+
+    @classmethod
+    def _redeclare_fields(cls):
+        """
+        To be done before "re-dataclassing" cls.
+
+        In current state, fields are now declared using only default value (no metadata). We have
+        to redo the field declaration properly.
+        """
+        for cls_field in fields(cls):
+            setattr(
+                cls, cls_field.name, field(default=cls_field.default, metadata=cls_field.metadata)
+            )

--- a/src/fastoad/model_base/tests/test_flight_point.py
+++ b/src/fastoad/model_base/tests/test_flight_point.py
@@ -83,6 +83,7 @@ def test_scalarize():
 
 
 def test_get_units():
+    FlightPoint.add_field("foo", annotation_type=float, default_value=42.0, unit="m")
     FlightPoint.add_field("foo", annotation_type=float, default_value=42.0, unit="slug/ft")
 
     assert FlightPoint.get_units()["time"] == "s"

--- a/src/fastoad/model_base/tests/test_flight_point.py
+++ b/src/fastoad/model_base/tests/test_flight_point.py
@@ -1,5 +1,5 @@
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -80,3 +80,15 @@ def test_scalarize():
     assert fp.mass == 70000.0
     assert fp.altitude == 1000.0
     assert_allclose(fp.mach, [0.7, 0.8])
+
+
+def test_get_units():
+    FlightPoint.add_field("foo", annotation_type=float, default_value=42.0, unit="slug/ft")
+
+    assert FlightPoint.get_units()["time"] == "s"
+    assert FlightPoint.get_units()["foo"] == "slug/ft"
+
+    FlightPoint.remove_field("foo")
+
+    assert FlightPoint.get_units().get("altitude") == "m"
+    assert FlightPoint.get_units().get("engine_setting") is None

--- a/src/fastoad/model_base/tests/test_flight_point.py
+++ b/src/fastoad/model_base/tests/test_flight_point.py
@@ -82,14 +82,35 @@ def test_scalarize():
     assert_allclose(fp.mach, [0.7, 0.8])
 
 
-def test_get_units():
-    FlightPoint.add_field("foo", annotation_type=float, default_value=42.0, unit="m")
-    FlightPoint.add_field("foo", annotation_type=float, default_value=42.0, unit="slug/ft")
+def test_descriptors():
+    FlightPoint.add_field(
+        "foo", annotation_type=float, default_value=42.0, unit="m", cumulative=False, output=True
+    )
+    # Testing redeclaration
+    FlightPoint.add_field(
+        "foo",
+        annotation_type=float,
+        default_value=42.0,
+        unit="slug/ft",
+        cumulative=True,
+        output=False,
+    )
 
     assert FlightPoint.get_units()["time"] == "s"
     assert FlightPoint.get_units()["foo"] == "slug/ft"
 
+    assert FlightPoint.get_unit("time") == "s"
+    assert FlightPoint.get_unit("foo") == "slug/ft"
+
+    assert FlightPoint.is_cumulative("time")
+    assert not FlightPoint.is_cumulative("altitude")
+    assert FlightPoint.is_cumulative("foo")
+
+    assert FlightPoint.is_output("time")
+    assert FlightPoint.is_output("altitude")
+    assert not FlightPoint.is_output("foo")
+
     FlightPoint.remove_field("foo")
 
-    assert FlightPoint.get_units().get("altitude") == "m"
-    assert FlightPoint.get_units().get("engine_setting") is None
+    assert FlightPoint.get_unit("altitude") == "m"
+    assert FlightPoint.get_unit("engine_setting") is None

--- a/src/fastoad/models/performances/mission/mission_definition/mission_builder/input_definition.py
+++ b/src/fastoad/models/performances/mission/mission_definition/mission_builder/input_definition.py
@@ -1,6 +1,6 @@
 """Management of mission input definitions."""
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2022 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -81,7 +81,7 @@ class InputDefinition:
             self.is_relative = True
             self.parameter_name = self.parameter_name[6:]
 
-        self.output_unit = FlightPoint.get_units().get(self.parameter_name)
+        self.output_unit = FlightPoint.get_unit(self.parameter_name)
         if self.output_unit is None:
             self.output_unit = BASE_UNITS.get(self.parameter_name)
         if self.output_unit == "-":

--- a/src/fastoad/models/performances/mission/openmdao/mission_run.py
+++ b/src/fastoad/models/performances/mission/openmdao/mission_run.py
@@ -110,7 +110,7 @@ class MissionComp(om.ExplicitComponent, BaseMissionComp):
 
         flight_points = flight_points.applymap(as_scalar)
         rename_dict = {
-            field_name: f"{field_name} [{unit}]"
+            field_name: f"{field_name}{' ['+unit+']' if unit else ''}"
             for field_name, unit in FlightPoint.get_units().items()
         }
         flight_points.rename(columns=rename_dict, inplace=True)


### PR DESCRIPTION
This PR adds new features to the FlightPoint class.

Each field of the FlightPoint class is now described as cumulative or not, and present in output or not. The "field descriptor" mechanism is also used to store unit information.

Added fields behave the same.

FlightPoint documentation has been slightly modified, and can be previewed [here](https://fast-oad.readthedocs.io/en/flightpoint-update/documentation/mission_module/extensibility/flight_point.html).