### PR TITLE
Custom imports handling in configuration file

### DIFF
--- a/docs/documentation/usage.rst
+++ b/docs/documentation/usage.rst
@@ -295,6 +295,16 @@ Also, see :ref:`get-variable-list`.
 Advanced configuration file
 ***************************
 
+Sys path
+========
+.. code:: yaml
+
+    sys_path:
+      - /path/to/your/module
+
+This section is used to add a path to the Python sys.path.
+This is useful when you have a module that is not in the Python path.
+
 
 Imports
 =======

--- a/docs/documentation/usage.rst
+++ b/docs/documentation/usage.rst
@@ -319,6 +319,43 @@ The YAML code lines above will do the equivalent in Python of:
     from utils.my_drivers.my_driver_2 import MyDriver2
     from utils.my_solvers.my_favourite_solver import MyFavouriteSolver
 
+
+Driver settings
+===============
+
+The `driver` configuration can be specified in two ways: using the old syntax (a string) or the new syntax (an object).
+
+### Old Syntax
+
+In the old syntax, the driver is specified as a string. This string should be a valid Python expression that creates an instance of an OpenMDAO driver.
+
+```yaml
+driver: om.ScipyOptimizeDriver(tol=1e-2, optimizer='COBYLA')
+```
+
+### New Syntax
+In the new syntax, the driver is specified with an least an instance and more fields such as `options`.
+
+```yaml
+driver:
+  instance: om.ScipyOptimizeDriver(optimizer='COBYLA')
+  options:
+    maxiter: 100
+    tol: 1e-2
+  advanced_options:
+    print_live_convergence: true
+```
+
+The code above is the equivalent in Python of:
+
+```python
+driver = om.ScipyOptimizeDriver(optimizer='COBYLA')
+driver.options['maxiter'] = 100
+driver.options['tol'] = 1e-2
+driver.advanced_options['print_live_convergence'] = True
+```
+
+
 .. _configuration-model-options:
 
 Model options

--- a/docs/documentation/usage.rst
+++ b/docs/documentation/usage.rst
@@ -30,12 +30,6 @@ A quick tutorial for YAML (among many ones) is available
     input_file: ./problem_inputs.xml
     output_file: ./problem_outputs.xml
 
-    # List of registered modules
-    imports:
-        my_driver_1: MyDriver1
-        utils.my_drivers.my_driver_2: MyDriver2
-        utils.my_solvers.my_favourite_solver: MyFavouriteSolver
-
     # Definition of problem driver assuming the OpenMDAO convention "import openmdao.api as om"
     driver: om.ScipyOptimizeDriver(tol=1e-2, optimizer='COBYLA')
 

--- a/docs/documentation/usage.rst
+++ b/docs/documentation/usage.rst
@@ -332,6 +332,7 @@ Standard Syntax
 In the standard syntax, the driver is specified as a string. This string should be a valid Python expression that creates an instance of an OpenMDAO driver.
 
 .. code:: yaml
+
     driver: om.ScipyOptimizeDriver(tol=1e-2, optimizer='COBYLA')
 
 

--- a/docs/documentation/usage.rst
+++ b/docs/documentation/usage.rst
@@ -286,7 +286,7 @@ Several constraint variables can be defined.
 Also, see :ref:`get-variable-list`.
 
 ***************************
-Advanced configuration file
+Advanced configuration
 ***************************
 
 Sys path

--- a/docs/documentation/usage.rst
+++ b/docs/documentation/usage.rst
@@ -324,37 +324,37 @@ The YAML code lines above will do the equivalent in Python of:
 Driver settings
 ===============
 
-The `driver` configuration can be specified in two ways: using the old syntax (a string) or the new syntax (an object).
+The `driver` configuration can be specified in two ways: using the standard syntax (a string) or the advanced syntax (an object).
 
-### Old Syntax
+### Standard Syntax
 
-In the old syntax, the driver is specified as a string. This string should be a valid Python expression that creates an instance of an OpenMDAO driver.
+In the standard syntax, the driver is specified as a string. This string should be a valid Python expression that creates an instance of an OpenMDAO driver.
 
-```yaml
-driver: om.ScipyOptimizeDriver(tol=1e-2, optimizer='COBYLA')
-```
+.. code:: yaml
+    driver: om.ScipyOptimizeDriver(tol=1e-2, optimizer='COBYLA')
 
-### New Syntax
-In the new syntax, the driver is specified with at least an instance and one or more dict fields such as `options`.
 
-```yaml
-driver:
-  instance: om.ScipyOptimizeDriver(optimizer='COBYLA')
-  options:
-    maxiter: 100
-    tol: 1e-2
-  advanced_options:
-    print_live_convergence: true
-```
+### Advanced Syntax
+In the advanced syntax, the driver is specified with at least an instance and one or more dict fields such as `options`.
+
+.. code:: yaml
+
+    driver:
+      instance: om.ScipyOptimizeDriver(optimizer='COBYLA')
+      options:
+        maxiter: 100
+        tol: 1e-2
+      advanced_options:
+        print_live_convergence: true
 
 The code above is the equivalent in Python of:
 
-```python
-driver = om.ScipyOptimizeDriver(optimizer='COBYLA')
-driver.options['maxiter'] = 100
-driver.options['tol'] = 1e-2
-driver.advanced_options['print_live_convergence'] = True
-```
+.. code:: python
+
+    driver = om.ScipyOptimizeDriver(optimizer='COBYLA')
+    driver.options['maxiter'] = 100
+    driver.options['tol'] = 1e-2
+    driver.advanced_options['print_live_convergence'] = True
 
 
 .. _configuration-model-options:

--- a/docs/documentation/usage.rst
+++ b/docs/documentation/usage.rst
@@ -326,7 +326,8 @@ Driver settings
 
 The `driver` configuration can be specified in two ways: using the standard syntax (a string) or the advanced syntax (an object).
 
-### Standard Syntax
+Standard Syntax
+---------------
 
 In the standard syntax, the driver is specified as a string. This string should be a valid Python expression that creates an instance of an OpenMDAO driver.
 
@@ -334,7 +335,9 @@ In the standard syntax, the driver is specified as a string. This string should 
     driver: om.ScipyOptimizeDriver(tol=1e-2, optimizer='COBYLA')
 
 
-### Advanced Syntax
+Advanced Syntax
+---------------
+
 In the advanced syntax, the driver is specified with at least an instance and one or more dict fields such as `options`.
 
 .. code:: yaml

--- a/docs/documentation/usage.rst
+++ b/docs/documentation/usage.rst
@@ -296,8 +296,9 @@ Sys path
     sys_path:
       - /path/to/your/module
 
-This section is used to add a path to the Python sys.path.
+This section is used to add a path to the Python `sys.path`.
 This is useful when you have a module that is not in the Python path.
+Note that this setting affects only the `imports` section below, which is used for setting drivers and solvers.
 
 
 Imports

--- a/docs/documentation/usage.rst
+++ b/docs/documentation/usage.rst
@@ -335,7 +335,7 @@ driver: om.ScipyOptimizeDriver(tol=1e-2, optimizer='COBYLA')
 ```
 
 ### New Syntax
-In the new syntax, the driver is specified with an least an instance and more fields such as `options`.
+In the new syntax, the driver is specified with at least an instance and one or more dict fields such as `options`.
 
 ```yaml
 driver:

--- a/docs/documentation/usage.rst
+++ b/docs/documentation/usage.rst
@@ -30,6 +30,12 @@ A quick tutorial for YAML (among many ones) is available
     input_file: ./problem_inputs.xml
     output_file: ./problem_outputs.xml
 
+    # List of registered modules
+    imports:
+        my_driver_1: MyDriver1
+        utils.my_drivers.my_driver_2: MyDriver2
+        utils.my_solvers.my_favourite_solver: MyFavouriteSolver
+
     # Definition of problem driver assuming the OpenMDAO convention "import openmdao.api as om"
     driver: om.ScipyOptimizeDriver(tol=1e-2, optimizer='COBYLA')
 
@@ -119,6 +125,25 @@ Input and output files
 
 Specifies the input and output files of the problem. They are defined in the configuration file
 and DO NOT APPEAR in the command line interface.
+
+Imports
+=======
+.. code:: yaml
+
+    imports:
+        my_driver_1: MyDriver1
+        utils.my_drivers.my_driver_2: MyDriver2
+        utils.my_solvers.my_favourite_solver: MyFavouriteSolver
+
+This section is used to import modules such as solvers and drivers that are not available in OpenMDAO.
+The key is the path of the module or Python file, and the value is the name of the object to import.
+The YAML code lines above will do the equivalent in Python of:
+
+.. code:: python
+
+    from my_driver_1 import MyDriver1
+    from utils.my_drivers.my_driver_2 import MyDriver2
+    from utils.my_solvers.my_favourite_solver import MyFavouriteSolver
 
 Problem driver
 ==============

--- a/docs/documentation/usage.rst
+++ b/docs/documentation/usage.rst
@@ -348,8 +348,8 @@ In the advanced syntax, the driver is specified with at least an instance and on
       options:
         maxiter: 100
         tol: 1e-2
-      advanced_options:
-        print_live_convergence: true
+      opt_settings:
+        maxtime: 10
 
 The code above is the equivalent in Python of:
 
@@ -358,7 +358,7 @@ The code above is the equivalent in Python of:
     driver = om.ScipyOptimizeDriver(optimizer='COBYLA')
     driver.options['maxiter'] = 100
     driver.options['tol'] = 1e-2
-    driver.advanced_options['print_live_convergence'] = True
+    driver.opt_settings['maxtime'] = 10
 
 
 .. _configuration-model-options:

--- a/docs/documentation/usage.rst
+++ b/docs/documentation/usage.rst
@@ -285,21 +285,9 @@ Several constraint variables can be defined.
 
 Also, see :ref:`get-variable-list`.
 
-***************************
+**********************
 Advanced configuration
-***************************
-
-Sys path
-========
-.. code:: yaml
-
-    sys_path:
-      - /path/to/your/module
-
-This section is used to add a path to the Python `sys.path`.
-This is useful when you have a module that is not in the Python path.
-Note that this setting affects only the `imports` section below, which is used for setting drivers and solvers.
-
+**********************
 
 Imports
 =======
@@ -320,6 +308,24 @@ The YAML code lines above will do the equivalent in Python of:
     from utils.my_drivers.my_driver_2 import MyDriver2
     from utils.my_solvers.my_favourite_solver import MyFavouriteSolver
 
+Extending :code:`sys.path`
+------------------
+For using drivers/solvers that are available on the local computer, the imports section
+can be completed to extend the Python path (`sys.path <https://docs.python.org/3/library/sys.html#sys.path>`_):
+
+.. code:: yaml
+
+    imports:
+        sys.path:
+            - /path/to/local/code1
+            - /path/to/local/code2
+        my_driver_1: MyDriver1
+        utils.my_drivers.my_driver_2: MyDriver2
+        utils.my_solvers.my_favourite_solver: MyFavouriteSolver
+
+.. warning::
+
+    Using relative paths here is strongly discouraged.
 
 Driver settings
 ===============

--- a/docs/documentation/usage.rst
+++ b/docs/documentation/usage.rst
@@ -126,25 +126,6 @@ Input and output files
 Specifies the input and output files of the problem. They are defined in the configuration file
 and DO NOT APPEAR in the command line interface.
 
-Imports
-=======
-.. code:: yaml
-
-    imports:
-        my_driver_1: MyDriver1
-        utils.my_drivers.my_driver_2: MyDriver2
-        utils.my_solvers.my_favourite_solver: MyFavouriteSolver
-
-This section is used to import modules such as solvers and drivers that are not available in OpenMDAO.
-The key is the path of the module or Python file, and the value is the name of the object to import.
-The YAML code lines above will do the equivalent in Python of:
-
-.. code:: python
-
-    from my_driver_1 import MyDriver1
-    from utils.my_drivers.my_driver_2 import MyDriver2
-    from utils.my_solvers.my_favourite_solver import MyFavouriteSolver
-
 Problem driver
 ==============
 
@@ -246,37 +227,6 @@ as option settings:
 - For FAST-OAD modules, the list of available options is available through the :code:`list_modules`
   sub-command (see :ref:`get-module-list`).
 
-.. _configuration-model-options:
-
-Model options
-==============
-
-OpenMDAO 3.27 introduced a new way to set options for any component in the problem, using the
-:code:`model_options` attribute of the :code:`Problem` object (see OpenMDAO documentation
-`here <https://openmdao.org/newdocs/versions/latest/features/core_features/options/options.html#setting-options-throughout-a-problem-model-problem-model-options>`_).
-
-This can be controlled from the configuration file, using for instance:
-
-.. code:: yaml
-
-    model_options:
-      "*":
-        propulsion_id: fastoad.wrapper.propulsion.rubber_engine
-      "aerodynamics.*":
-        use_xfoil: true
-
-With above lines, we set the :code:`"propulsion_id"` option for all concerned components
-in the problem, and we set the :code:`"use_xfoil"` option for all components inside the
-:code:`aerodynamics` module (please see
-`OpenMDAO documentation <https://openmdao.org/newdocs/versions/latest/features/core_features/options/options.html#using-glob-patterns-to-set-different-option-values-in-different-systems>`_
-for more examples using wildcards).
-
-.. note::
-
-  - Please note that the wildcards have to be (double) quoted.
-  - This feature is especially convenient to set options for sub-components of the declared models,
-    since these options are not directly accessible from the configuration file.
-
 
 Optimization settings
 =====================
@@ -340,6 +290,61 @@ Keys of this section are named after parameters of the OpenMDAO :doc:`System.add
 Several constraint variables can be defined.
 
 Also, see :ref:`get-variable-list`.
+
+***************************
+Advanced configuration file
+***************************
+
+
+Imports
+=======
+.. code:: yaml
+
+    imports:
+        my_driver_1: MyDriver1
+        utils.my_drivers.my_driver_2: MyDriver2
+        utils.my_solvers.my_favourite_solver: MyFavouriteSolver
+
+This section is used to import modules such as solvers and drivers that are not available in OpenMDAO.
+The key is the path of the module or Python file, and the value is the name of the object to import.
+The YAML code lines above will do the equivalent in Python of:
+
+.. code:: python
+
+    from my_driver_1 import MyDriver1
+    from utils.my_drivers.my_driver_2 import MyDriver2
+    from utils.my_solvers.my_favourite_solver import MyFavouriteSolver
+
+.. _configuration-model-options:
+
+Model options
+==============
+
+OpenMDAO 3.27 introduced a new way to set options for any component in the problem, using the
+:code:`model_options` attribute of the :code:`Problem` object (see OpenMDAO documentation
+`here <https://openmdao.org/newdocs/versions/latest/features/core_features/options/options.html#setting-options-throughout-a-problem-model-problem-model-options>`_).
+
+This can be controlled from the configuration file, using for instance:
+
+.. code:: yaml
+
+    model_options:
+      "*":
+        propulsion_id: fastoad.wrapper.propulsion.rubber_engine
+      "aerodynamics.*":
+        use_xfoil: true
+
+With above lines, we set the :code:`"propulsion_id"` option for all concerned components
+in the problem, and we set the :code:`"use_xfoil"` option for all components inside the
+:code:`aerodynamics` module (please see
+`OpenMDAO documentation <https://openmdao.org/newdocs/versions/latest/features/core_features/options/options.html#using-glob-patterns-to-set-different-option-values-in-different-systems>`_
+for more examples using wildcards).
+
+.. note::
+
+  - Please note that the wildcards have to be (double) quoted.
+  - This feature is especially convenient to set options for sub-components of the declared models,
+    since these options are not directly accessible from the configuration file.
 
 
 .. _usage-cli:

--- a/src/fastoad/io/configuration/configuration.py
+++ b/src/fastoad/io/configuration/configuration.py
@@ -18,6 +18,7 @@ import json
 import logging
 from abc import ABC, abstractmethod
 from importlib.resources import open_text
+from importlib import import_module
 from os import PathLike
 from pathlib import Path
 from typing import Dict, List, Optional, Union
@@ -66,6 +67,8 @@ class FASTOADProblemConfigurator:
 
     def __init__(self, conf_file_path: Union[str, PathLike] = None):
         self._serializer: _IDictSerializer = _YAMLSerializer()
+        # Store imported classes
+        self._imported_classes = {}
 
         # self._configuration_modifier offers a way to modify problems after
         # they have been generated from configuration (private usage for now)
@@ -129,7 +132,7 @@ class FASTOADProblemConfigurator:
 
         driver = self._data.get(KEY_DRIVER, "")
         if driver:
-            problem.driver = _om_eval(driver)
+            problem.driver = self._om_eval(driver)
 
         if self.get_optimization_definition():
             self._add_constraints(problem.model, auto_scaling)
@@ -162,6 +165,11 @@ class FASTOADProblemConfigurator:
         with open_text(resources, JSON_SCHEMA_NAME) as json_file:
             json_schema = json.loads(json_file.read())
         validate(self._data, json_schema)
+
+        # Handle imports
+        imports = self._data.get("imports", {})
+        for module_name, class_name in imports.items():
+            self._imported_classes[class_name] = getattr(import_module(module_name), class_name)
 
         # Issue a simple warning for unknown keys at root level
         for key in self._data:
@@ -333,7 +341,7 @@ class FASTOADProblemConfigurator:
                 # value may have to be literally interpreted
                 if key.endswith(("solver", "driver")):
                     try:
-                        value = _om_eval(str(value))
+                        value = self._om_eval(str(value))
                     except Exception as err:
                         raise FASTConfigurationBadOpenMDAOInstructionError(err, key, value)
 
@@ -419,19 +427,20 @@ class FASTOADProblemConfigurator:
     def _set_configuration_modifier(self, modifier: "_IConfigurationModifier"):
         self._configuration_modifier = modifier
 
+    def _om_eval(self, string_to_eval: str):
+        """
+        Evaluates strings that assume `import openmdao.api as om` is done.
 
-def _om_eval(string_to_eval: str):
-    """
-    Evaluates strings that assume `import openmdao.api as om` is done.
+        eval() is used for that, as safely as possible.
 
-    eval() is used for that, as safely as possible.
-
-    :param string_to_eval:
-    :return: result of eval()
-    """
-    if "__" in string_to_eval:
-        raise ValueError("No double underscore allowed in evaluated string for security reasons")
-    return eval(string_to_eval, {"__builtins__": {}}, {"om": om})
+        :param string_to_eval:
+        :return: result of eval()
+        """
+        if "__" in string_to_eval:
+            raise ValueError(
+                "No double underscore allowed in evaluated string for security reasons"
+            )
+        return eval(string_to_eval, {"__builtins__": {}}, {"om": om, **self._imported_classes})
 
 
 class _IDictSerializer(ABC):

--- a/src/fastoad/io/configuration/configuration.py
+++ b/src/fastoad/io/configuration/configuration.py
@@ -181,8 +181,9 @@ class FASTOADProblemConfigurator:
                 module = import_module(module_name)
                 self._imported_classes[class_name] = getattr(module, class_name)
             except (ImportError, AttributeError) as e:
-                _LOGGER.warning(f"Warning: Failed to import {class_name} from {module_name}: {e}")
-                self._imported_classes[class_name] = None
+                raise ImportError(
+                    f"Failed to import {class_name} from {module_name} in configuration file: {e}"
+                )
 
         # Issue a simple warning for unknown keys at root level
         for key in self._data:

--- a/src/fastoad/io/configuration/configuration.py
+++ b/src/fastoad/io/configuration/configuration.py
@@ -282,12 +282,6 @@ class FASTOADProblemConfigurator:
             if driver_instance:
                 driver_instance = self._om_eval(driver_instance)
                 prob.driver = driver_instance
-            else:
-                # Raise error if no driver instance is provided
-                raise FASTConfigurationBaseKeyBuildingError(
-                    ValueError("No driver instance provided in configuration file"),
-                    KEY_DRIVER,
-                )
 
             # Iterate over all keys (attributes) in driver_config except for 'instance'
             for first_key, first_value in driver_config.items():

--- a/src/fastoad/io/configuration/configuration.py
+++ b/src/fastoad/io/configuration/configuration.py
@@ -67,7 +67,8 @@ class FASTOADProblemConfigurator:
 
     def __init__(self, conf_file_path: Union[str, PathLike] = None):
         self._serializer: _IDictSerializer = _YAMLSerializer()
-        # Store imported classes
+
+        # for storing imported classes
         self._imported_classes = {}
 
         # self._configuration_modifier offers a way to modify problems after

--- a/src/fastoad/io/configuration/configuration.py
+++ b/src/fastoad/io/configuration/configuration.py
@@ -431,6 +431,7 @@ class FASTOADProblemConfigurator:
     def _om_eval(self, string_to_eval: str):
         """
         Evaluates strings that assume `import openmdao.api as om` is done.
+        Evaluates also imports specified in the imports section of the configuration file (if any).
 
         eval() is used for that, as safely as possible.
 

--- a/src/fastoad/io/configuration/configuration.py
+++ b/src/fastoad/io/configuration/configuration.py
@@ -179,8 +179,8 @@ class FASTOADProblemConfigurator:
                 self._imported_classes[class_name] = getattr(module, class_name)
             except (ImportError, AttributeError) as e:
                 raise ImportError(
-                    f"Failed to import {class_name} from {module_name} in configuration file: {e}"
-                )
+                    f"Failed to import {class_name} from {module_name} in configuration file."
+                ) from e
 
         # Issue a simple warning for unknown keys at root level
         for key in self._data:

--- a/src/fastoad/io/configuration/configuration.py
+++ b/src/fastoad/io/configuration/configuration.py
@@ -169,10 +169,7 @@ class FASTOADProblemConfigurator:
         validate(self._data, json_schema)
 
         # Add paths to sys.path
-        sys_paths = self._data.get("sys_paths", [])
-        for path in sys_paths:
-            if path not in sys.path:
-                sys.path.append(path)
+        sys.path.extend(self._data.get("sys_paths", []))
 
         # Handle imports
         imports = self._data.get("imports", {})

--- a/src/fastoad/io/configuration/configuration.py
+++ b/src/fastoad/io/configuration/configuration.py
@@ -14,12 +14,12 @@ Module for building OpenMDAO problem from configuration file
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import sys
 import json
 import logging
+import sys
 from abc import ABC, abstractmethod
-from importlib.resources import open_text
 from importlib import import_module
+from importlib.resources import open_text
 from os import PathLike
 from pathlib import Path
 from typing import Dict, List, Optional, Union
@@ -45,7 +45,7 @@ KEY_FOLDERS = "module_folders"
 KEY_INPUT_FILE = "input_file"
 KEY_OUTPUT_FILE = "output_file"
 KEY_IMPORTS = "imports"
-KEY_SYSPATH = "sys_paths"
+KEY_SYSPATH = "sys.path"
 KEY_COMPONENT_ID = "id"
 KEY_CONNECTION_ID = "connections"
 KEY_MODEL = "model"

--- a/src/fastoad/io/configuration/configuration.py
+++ b/src/fastoad/io/configuration/configuration.py
@@ -181,7 +181,7 @@ class FASTOADProblemConfigurator:
                 module = import_module(module_name)
                 self._imported_classes[class_name] = getattr(module, class_name)
             except (ImportError, AttributeError) as e:
-                print(f"Warning: Failed to import {class_name} from {module_name}: {e}")
+                _LOGGER.warning(f"Warning: Failed to import {class_name} from {module_name}: {e}")
                 self._imported_classes[class_name] = None
 
         # Issue a simple warning for unknown keys at root level

--- a/src/fastoad/io/configuration/configuration.py
+++ b/src/fastoad/io/configuration/configuration.py
@@ -284,12 +284,9 @@ class FASTOADProblemConfigurator:
                 prob.driver = driver_instance
 
             # Iterate over all keys (attributes) in driver_config except for 'instance'
-            for first_key, first_value in driver_config.items():
-                if first_key != "instance":
-                    # Iterate over all keys (values) in first_value
-                    for second_key, second_value in first_value.items():
-                        # driver.<first_key>[<second_key>] = second_value
-                        getattr(prob.driver, first_key)[second_key] = second_value
+            for key, value in driver_config.items():
+                if key != "instance":
+                    getattr(prob.driver, key).update(value)
 
     def _make_absolute(self, path: Union[str, PathLike]) -> Path:
         """

--- a/src/fastoad/io/configuration/resources/configuration.json
+++ b/src/fastoad/io/configuration/resources/configuration.json
@@ -134,6 +134,12 @@
       "type": "string",
       "default": "./outputs.xml"
     },
+    "imports": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
     "driver": {
       "type": "string",
       "default": "om.ScipyOptimizeDriver(tol=1e-6, optimizer='SLSQP')"

--- a/src/fastoad/io/configuration/resources/configuration.json
+++ b/src/fastoad/io/configuration/resources/configuration.json
@@ -147,8 +147,30 @@
       }
     },
     "driver": {
-      "type": "string",
-      "default": "om.ScipyOptimizeDriver(tol=1e-6, optimizer='SLSQP')"
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "Old syntax for driver configuration"
+        },
+        {
+          "type": "object",
+          "properties": {
+            "instance": {
+              "type": "string",
+              "description": "Driver instance string"
+            },
+            "options": {
+              "type": "object",
+              "description": "Driver options",
+              "additionalProperties": {
+                "type": ["string", "number", "boolean"]
+              }
+            }
+          },
+          "required": ["instance"],
+          "additionalProperties": false
+        }
+      ]
     },
     "model_options": {
       "type": "object",

--- a/src/fastoad/io/configuration/resources/configuration.json
+++ b/src/fastoad/io/configuration/resources/configuration.json
@@ -168,7 +168,7 @@
             }
           },
           "required": ["instance"],
-          "additionalProperties": false
+          "additionalProperties": true
         }
       ]
     },

--- a/src/fastoad/io/configuration/resources/configuration.json
+++ b/src/fastoad/io/configuration/resources/configuration.json
@@ -134,6 +134,12 @@
       "type": "string",
       "default": "./outputs.xml"
     },
+    "sys_paths": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
     "imports": {
       "type": "object",
       "additionalProperties": {

--- a/src/fastoad/io/configuration/resources/configuration.json
+++ b/src/fastoad/io/configuration/resources/configuration.json
@@ -137,7 +137,7 @@
     "imports": {
       "type": "object",
       "properties": {
-        "sys_paths": {
+        "sys.path": {
           "type": "array",
           "items": {
             "type": "string"

--- a/src/fastoad/io/configuration/resources/configuration.json
+++ b/src/fastoad/io/configuration/resources/configuration.json
@@ -134,14 +134,16 @@
       "type": "string",
       "default": "./outputs.xml"
     },
-    "sys_paths": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
     "imports": {
       "type": "object",
+      "properties": {
+        "sys_paths": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
       "additionalProperties": {
         "type": "string"
       }
@@ -163,11 +165,17 @@
               "type": "object",
               "description": "Driver options",
               "additionalProperties": {
-                "type": ["string", "number", "boolean"]
+                "type": [
+                  "string",
+                  "number",
+                  "boolean"
+                ]
               }
             }
           },
-          "required": ["instance"],
+          "required": [
+            "instance"
+          ],
           "additionalProperties": true
         }
       ]

--- a/src/fastoad/io/configuration/tests/data/conf_with_imports.yml
+++ b/src/fastoad/io/configuration/tests/data/conf_with_imports.yml
@@ -5,8 +5,8 @@
 
 
   imports:
-      my_driver_1: MyDriver1
-      my_driver_2: MyDriver2
+      fastoad.io.configuration.tests.data.to_be_imported.my_driver_1: MyDriver1
+      "fastoad.io.configuration.tests.data.to_be_imported.my_driver_2": MyDriver2
 
   driver: MyDriver1(tol=1e-2, optimizer='COBYLA', maxiter=maxiter)
 

--- a/src/fastoad/io/configuration/tests/data/conf_with_imports.yml
+++ b/src/fastoad/io/configuration/tests/data/conf_with_imports.yml
@@ -1,0 +1,29 @@
+  title: Sample OAD Process
+
+  input_file: ../results/inputs.xml
+  output_file: ../results/outputs.xml
+
+
+  imports:
+      my_driver_1: MyDriver1
+      my_driver_2: MyDriver2
+
+  driver: MyDriver1(tol=1e-2, optimizer='COBYLA', maxiter=maxiter)
+
+  model:
+        assembled_jac_type: csc  # Tests the ability to set options for groups
+        connections:
+              - source: y1
+                target: yy1
+              - source: y2
+                target: yy2
+        cycle:
+              nonlinear_solver: om.NonlinearBlockGS(iprint=1)
+              linear_solver: om.ScipyKrylov()
+              disc1:
+                    id: configuration_test.sellar.disc1
+              disc2:
+                    id: configuration_test.sellar.disc2
+        functions:
+              id: configuration_test.sellar.functions
+              input_path: "translator.txt"

--- a/src/fastoad/io/configuration/tests/data/conf_with_imports.yml
+++ b/src/fastoad/io/configuration/tests/data/conf_with_imports.yml
@@ -5,6 +5,9 @@
 
 
   imports:
+      sys_paths:
+        - /path/to/local/code1
+        - /path/to/local/code2
       fastoad.io.configuration.tests.data.to_be_imported.my_driver_1: MyDriver1
       "fastoad.io.configuration.tests.data.to_be_imported.my_driver_2": MyDriver2
 

--- a/src/fastoad/io/configuration/tests/data/conf_with_imports.yml
+++ b/src/fastoad/io/configuration/tests/data/conf_with_imports.yml
@@ -5,7 +5,7 @@
 
 
   imports:
-      sys_paths:
+      sys.path:
         - /path/to/local/code1
         - /path/to/local/code2
       fastoad.io.configuration.tests.data.to_be_imported.my_driver_1: MyDriver1

--- a/src/fastoad/io/configuration/tests/data/to_be_imported/__init__.py
+++ b/src/fastoad/io/configuration/tests/data/to_be_imported/__init__.py
@@ -1,0 +1,12 @@
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
+#  Copyright (C) 2021 ONERA & ISAE-SUPAERO
+#  FAST is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.

--- a/src/fastoad/io/configuration/tests/data/to_be_imported/my_driver_1.py
+++ b/src/fastoad/io/configuration/tests/data/to_be_imported/my_driver_1.py
@@ -1,0 +1,2 @@
+class MyDriver1:
+    pass

--- a/src/fastoad/io/configuration/tests/data/to_be_imported/my_driver_2.py
+++ b/src/fastoad/io/configuration/tests/data/to_be_imported/my_driver_2.py
@@ -1,0 +1,2 @@
+class MyDriver2:
+    pass

--- a/src/fastoad/io/configuration/tests/test_configuration.py
+++ b/src/fastoad/io/configuration/tests/test_configuration.py
@@ -17,6 +17,7 @@ Test module for configuration.py
 import os
 import shutil
 from pathlib import Path
+import importlib.util
 
 import pytest
 import tomlkit
@@ -336,3 +337,35 @@ def test_set_optimization_definition(cleanup):
         conf_dict_opt = conf_dict["optimization"]
         # Should be equal
         assert optimization_conf == conf_dict_opt
+
+
+def test_imports_handling():
+    # Mock the importlib.import_module to return a dummy class
+    class DummyClass:
+        pass
+
+    # Create a dummy module and add it to sys.modules
+    dummy_module_spec = importlib.util.spec_from_loader("my_driver_1", loader=None)
+    dummy_module = importlib.util.module_from_spec(dummy_module_spec)
+    dummy_module.MyDriver1 = DummyClass
+    import sys
+
+    sys.modules["my_driver_1"] = dummy_module
+
+    dummy_module_spec = importlib.util.spec_from_loader("my_driver_2", loader=None)
+    dummy_module = importlib.util.module_from_spec(dummy_module_spec)
+    dummy_module.MyDriver2 = DummyClass
+    sys.modules["my_driver_2"] = dummy_module
+
+    conf = FASTOADProblemConfigurator()
+    conf.load(DATA_FOLDER_PATH / "conf_with_imports.yml")
+
+    # Check that the classes are correctly imported and stored
+    assert "MyDriver1" in conf._imported_classes
+    assert "MyDriver2" in conf._imported_classes
+    assert conf._imported_classes["MyDriver1"] == DummyClass
+    assert conf._imported_classes["MyDriver2"] == DummyClass
+
+    # Check that _om_eval can use the imported classes
+    result = conf._om_eval("MyDriver1()")
+    assert isinstance(result, DummyClass)

--- a/src/fastoad/io/configuration/tests/test_configuration.py
+++ b/src/fastoad/io/configuration/tests/test_configuration.py
@@ -400,7 +400,7 @@ def test_imports_handling():
 
 
 def test_driver_configuration():
-    # Test new syntax
+    # Test advanced syntax
     config_data_new = {
         "input_file": "./inputs.xml",
         "output_file": "./outputs.xml",
@@ -408,6 +408,7 @@ def test_driver_configuration():
         "driver": {
             "instance": "om.ScipyOptimizeDriver(optimizer='COBYLA')",
             "options": {"maxiter": 100, "tol": 1e-2},
+            "opt_settings": {"maxtime": 10},
         },
     }
 
@@ -423,10 +424,11 @@ def test_driver_configuration():
     assert problem.driver.options["optimizer"] == "COBYLA"
     assert problem.driver.options["maxiter"] == 100
     assert problem.driver.options["tol"] == 1e-2
+    assert problem.driver.opt_settings["maxtime"] == 10
 
     os.remove(temp_config_file_path)
 
-    # Test old syntax
+    # Test standard syntax
     config_data_old = {
         "input_file": "./inputs.xml",
         "output_file": "./outputs.xml",

--- a/src/fastoad/io/configuration/tests/test_configuration.py
+++ b/src/fastoad/io/configuration/tests/test_configuration.py
@@ -14,6 +14,9 @@ Test module for configuration.py
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import sys
+import tempfile
+import yaml
 import os
 import shutil
 from pathlib import Path
@@ -336,6 +339,34 @@ def test_set_optimization_definition(cleanup):
         conf_dict_opt = conf_dict["optimization"]
         # Should be equal
         assert optimization_conf == conf_dict_opt
+
+
+def test_sys_paths():
+    # Create a temporary configuration file
+    config_data = {
+        "input_file": "./inputs.xml",
+        "output_file": "./outputs.xml",
+        "model": {},
+        "sys_paths": ["/path/to/local/code1", "/path/to/local/code2"],
+    }
+
+    with tempfile.NamedTemporaryFile(delete=False, mode="w", suffix=".yaml") as temp_config_file:
+        yaml.dump(config_data, temp_config_file)
+        temp_config_file_path = temp_config_file.name
+
+    # Instantiate the configurator and load the configuration
+    configurator = FASTOADProblemConfigurator()
+    configurator.load(temp_config_file_path)
+
+    # Check if the paths are added to sys.path
+    for path in config_data["sys_paths"]:
+        assert path in sys.path
+
+    # Cleanup
+    sys.path = [p for p in sys.path if p not in config_data["sys_paths"]]
+
+    # Remove the temporary file
+    os.remove(temp_config_file_path)
 
 
 def test_imports_handling():

--- a/src/fastoad/io/configuration/tests/test_configuration.py
+++ b/src/fastoad/io/configuration/tests/test_configuration.py
@@ -386,7 +386,8 @@ def test_imports_handling():
     result1 = conf._om_eval("MyDriver1()")
     result2 = conf._om_eval("MyDriver2()")
 
-    # Imports are done here to verify that the classes are correctly imported
+    # Imports are done here to be sure the interpreter does not know
+    # these paths when the code above is run.
     from .data.to_be_imported.my_driver_1 import MyDriver1
     from .data.to_be_imported.my_driver_2 import MyDriver2
 

--- a/src/fastoad/io/configuration/tests/test_configuration.py
+++ b/src/fastoad/io/configuration/tests/test_configuration.py
@@ -353,6 +353,7 @@ def test_imports_handling():
     result1 = conf._om_eval("MyDriver1()")
     result2 = conf._om_eval("MyDriver2()")
 
+    # Imports are done here to verify that the classes are correctly imported
     from .data.to_be_imported.my_driver_1 import MyDriver1
     from .data.to_be_imported.my_driver_2 import MyDriver2
 


### PR DESCRIPTION
This PR proposes a way to specify custom imports in the configuration file and resolves #413.
It assumes the user has in his Python environment the necessary packages.