### PR TITLE
Payload range module can now handles mission files with several mission

### DIFF
--- a/src/fastoad/models/performances/mission/openmdao/mission_wrapper.py
+++ b/src/fastoad/models/performances/mission/openmdao/mission_wrapper.py
@@ -97,7 +97,7 @@ class MissionWrapper(MissionBuilder):
 
     def force_all_block_fuel_usage(self):
         """Modifies mission definition to set block fuel as target fuel consumption."""
-        if self.mission_name:
+        if self._mission_name:
             self.definition.force_all_block_fuel_usage(self.mission_name)
             self._update_structure_builders()
 

--- a/src/fastoad/models/performances/mission/openmdao/tests/data/test_payload_range.yml
+++ b/src/fastoad/models/performances/mission/openmdao/tests/data/test_payload_range.yml
@@ -103,3 +103,9 @@ missions:
       - phase: takeoff
       - route: main_route
       - route: diversion
+  dummy:
+    parts:
+      - phase: start
+      - phase: taxi_out
+      - phase: takeoff
+      - route: main_route


### PR DESCRIPTION
Resolves #561.

Asking for `self.mission_name property` too soon was a problem.