### PR TITLE
Fix CalcRunner

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,8 +164,14 @@ norecursedirs = ["dist", "build", ".tox", ".ipynb_checkpoints"]
 branch = true
 source = ["fastoad"]
 omit = ["*/test/*", "*/tests/*"]
+# Lines below according to https://pytest-cov.readthedocs.io/en/latest/subprocess-support.html#if-you-use-multiprocessing
+concurrency = ["multiprocessing"]
+parallel = true
+sigterm = true
+
 [tool.coverage.paths]
 source = ["src/"]
+
 [tool.coverage.report]
 # Regexes for lines to exclude from consideration
 exclude_lines = [

--- a/src/fastoad/cmd/calc_runner.py
+++ b/src/fastoad/cmd/calc_runner.py
@@ -61,6 +61,12 @@ class CalcRunner:
     #: For activating MDO instead MDA
     optimize: bool = False
 
+    def __post_init__(self):
+        # Let's ensure we have absolute paths
+        self.configuration_file_path = as_path(self.configuration_file_path).resolve()
+        if self.input_file_path:
+            self.input_file_path = as_path(self.input_file_path).resolve()
+
     def run(
         self,
         input_values: Optional[VariableList] = None,
@@ -141,7 +147,7 @@ class CalcRunner:
         :param overwrite_subfolders: if False, calculations that match existing subfolders won't be
                                      run (allows batch continuation)
         """
-        destination_folder = as_path(destination_folder)
+        destination_folder = as_path(destination_folder).resolve()
 
         use_MPI = use_MPI_if_available and HAVE_MPI
         if use_MPI_if_available and not HAVE_MPI:

--- a/src/fastoad/cmd/tests/data/inputs_alt.xml
+++ b/src/fastoad/cmd/tests/data/inputs_alt.xml
@@ -1,0 +1,4 @@
+<FASTOAD_model>
+  <x>10.0</x>
+  <z units="m**2">[10.0, 10.0]</z>
+</FASTOAD_model>


### PR DESCRIPTION
This PR is a follow-up of #554 and fixes some problems with CalcRunner class:
- computations could not run if a relative path was given for `input_file_path`
- input file was not modified for computations that were isolated in a local folder