### PR TITLE
Cleaning up code in mission module

### DIFF
--- a/src/fastoad/model_base/flight_point.py
+++ b/src/fastoad/model_base/flight_point.py
@@ -111,7 +111,7 @@ class FlightPoint:
 
     #: Covered ground distance in meters.
     ground_distance: float = field(
-        default=0.0, metadata={FIELD_DESCRIPTOR: _FieldDescriptor(unit="m")}
+        default=0.0, metadata={FIELD_DESCRIPTOR: _FieldDescriptor(is_cumulative=True, unit="m")}
     )
 
     #: Mass in kg.

--- a/src/fastoad/model_base/propulsion.py
+++ b/src/fastoad/model_base/propulsion.py
@@ -78,7 +78,7 @@ class IPropulsion(ABC):
               will be used according to :code:`thrust_is_regulated`.
 
 
-        :param flight_points: FlightPoint or DataFram instance
+        :param flight_points: FlightPoint or DataFrame instance
         :return: None (inputs are updated in-place)
         """
 

--- a/src/fastoad/models/performances/mission/mission_definition/mission_builder/mission_builder.py
+++ b/src/fastoad/models/performances/mission/mission_definition/mission_builder/mission_builder.py
@@ -20,6 +20,7 @@ from typing import Dict, List, Mapping, Optional, Union
 
 import pandas as pd
 
+from fastoad._utils.arrays import scalarize
 from fastoad.constants import EngineSetting
 from fastoad.model_base import FlightPoint
 from fastoad.model_base.propulsion import IPropulsion
@@ -139,7 +140,7 @@ class MissionBuilder:
 
     @reference_area.setter
     def reference_area(self, reference_area: float):
-        self._base_kwargs["reference_area"] = reference_area
+        self._base_kwargs["reference_area"] = scalarize(reference_area)
 
     @property
     def mission_name(self):

--- a/src/fastoad/models/performances/mission/openmdao/mission_run.py
+++ b/src/fastoad/models/performances/mission/openmdao/mission_run.py
@@ -19,7 +19,6 @@ import numpy as np
 from openmdao import api as om
 
 from fastoad._utils.files import make_parent_dir
-from fastoad._utils.pandas import apply_map
 from fastoad.model_base import FlightPoint
 from fastoad.model_base.propulsion import IOMPropulsionWrapper
 from fastoad.module_management.service_registry import RegisterPropulsion
@@ -104,12 +103,7 @@ class MissionComp(om.ExplicitComponent, BaseMissionComp):
         self._postprocess_flight_points(self.flight_points)
 
     def _postprocess_flight_points(self, flight_points):
-        def as_scalar(value):
-            if isinstance(value, np.ndarray):
-                return value.item()
-            return value
-
-        flight_points = apply_map(flight_points, as_scalar)
+        flight_points = flight_points.copy()  # local copy for renaming columns before CSV export
         rename_dict = {
             field_name: f"{field_name}{' ['+unit+']' if unit else ''}"
             for field_name, unit in FlightPoint.get_units().items()

--- a/src/fastoad/models/performances/mission/openmdao/mission_wrapper.py
+++ b/src/fastoad/models/performances/mission/openmdao/mission_wrapper.py
@@ -216,6 +216,10 @@ class MissionWrapper(MissionBuilder):
 
         names = part_name.split(":")
         mission_name, route_name, phase_name = names + [""] * (3 - len(names))
+        if not phase_name and route_name not in self.get_route_names():
+            phase_name = route_name
+            route_name = ""
+
         if route_name and phase_name:
             flight_part_desc = (
                 f'phase "{phase_name}" of route "{route_name}" in mission "{mission_name}"'

--- a/src/fastoad/models/performances/mission/openmdao/mission_wrapper.py
+++ b/src/fastoad/models/performances/mission/openmdao/mission_wrapper.py
@@ -1,6 +1,7 @@
 """
 Mission wrapper.
 """
+
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
 #  Copyright (C) 2024 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
@@ -35,20 +36,6 @@ from ..mission_definition.schema import (
     RESERVE_TAG,
     ROUTE_TAG,
 )
-
-
-#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2023 ONERA & ISAE-SUPAERO
-#  FAST is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#  You should have received a copy of the GNU General Public License
-#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 
 class MissionWrapper(MissionBuilder):

--- a/src/fastoad/models/performances/mission/segments/time_step_base.py
+++ b/src/fastoad/models/performances/mission/segments/time_step_base.py
@@ -150,7 +150,7 @@ class AbstractTimeStepFlightSegment(
                 0.5 * atm.density * flight_point.true_airspeed**2 * self.reference_area
             )
 
-            if self.polar:
+            if self.polar and reference_force:
                 modified_polar = self.polar_modifier.modify_polar(self.polar, flight_point)
                 flight_point.CL = flight_point.mass * g / reference_force
                 flight_point.CD = modified_polar.cd(flight_point.CL)

--- a/src/fastoad/models/performances/mission/segments/time_step_base.py
+++ b/src/fastoad/models/performances/mission/segments/time_step_base.py
@@ -162,6 +162,7 @@ class AbstractTimeStepFlightSegment(
         flight_point.slope_angle, flight_point.acceleration = self.get_gamma_and_acceleration(
             flight_point
         )
+        flight_point.scalarize()
 
     def compute_from_start_to_target(self, start: FlightPoint, target: FlightPoint) -> pd.DataFrame:
         flight_points = [start]

--- a/src/fastoad/models/performances/mission/tests/test_routes.py
+++ b/src/fastoad/models/performances/mission/tests/test_routes.py
@@ -25,19 +25,6 @@ from .conftest import ClimbPhase, DescentPhase, InitialClimbPhase
 from ..routes import RangedRoute
 from ..segments.registered.cruise import CruiseSegment
 
-#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
-#  FAST is free software: you can redistribute it and/or modify
-#  it under the terms of the GNU General Public License as published by
-#  the Free Software Foundation, either version 3 of the License, or
-#  (at your option) any later version.
-#  This program is distributed in the hope that it will be useful,
-#  but WITHOUT ANY WARRANTY; without even the implied warranty of
-#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#  GNU General Public License for more details.
-#  You should have received a copy of the GNU General Public License
-#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
 RESULTS_FOLDER_PATH = Path(__file__).parent / "results" / Path(__file__).stem
 
 


### PR DESCRIPTION
This PR does some adjustments to mission module.
In particular, it rationalizes a bit the "scalarize" operation.
It also fixes the status of FlightPoint.ground_distance (`is_cumulative` is True).
Another (very) minor fix is that, in description of variables related to phases outside routes, this phases were qualified as routes.