### PR TITLE
Automated addition of taxi-out and takeoff phases is now deprecated.

### DIFF
--- a/src/fastoad/models/performances/mission/mission_definition/mission_builder/mission_builder.py
+++ b/src/fastoad/models/performances/mission/mission_definition/mission_builder/mission_builder.py
@@ -19,6 +19,7 @@ from os import PathLike
 from typing import Dict, List, Mapping, Optional, Union
 
 import pandas as pd
+from deprecated import deprecated
 
 from fastoad._utils.arrays import scalarize
 from fastoad.constants import EngineSetting
@@ -518,6 +519,12 @@ class MissionBuilder:
 
         return None
 
+    @deprecated(
+        version="1.8.2",
+        reason="Automated addition of taxi-out and takeoff phases will be removed in version 2.0. "
+        "Please ensure your mission definition contains a part with a target mass "
+        "(generally the takeoff mass variable).",
+    )
     def _add_default_taxi_takeoff(self, mission_name):
         definition = {
             "phases": {

--- a/src/fastoad/models/performances/mission/openmdao/resources/sizing_mission.yml
+++ b/src/fastoad/models/performances/mission/openmdao/resources/sizing_mission.yml
@@ -40,7 +40,7 @@ phases:
           true_airspeed: ~V2
       - segment: mass_input
         target:
-          mass: data:mission:sizing:TOW
+          mass: ~~TOW
 
   initial_climb:
     engine_setting: takeoff


### PR DESCRIPTION
Since FAST-OAD 1.4.0, the mission definition file can describe the whole mission, including the phases before reaching the "input weight", i.e. takeoff mass (TOW), generally. The point is to have a target mass in the definition, by adding a mass_input segment in the proper phase:

```yaml
      - segment: mass_input
        target:
          mass: ~~TOW
```