### PR TITLE
Minor fixes in mission module

### DIFF
--- a/src/fastoad/models/performances/mission/segments/registered/altitude_change.py
+++ b/src/fastoad/models/performances/mission/segments/registered/altitude_change.py
@@ -24,13 +24,16 @@ from fastoad.models.performances.mission.exceptions import FastFlightSegmentInco
 from fastoad.models.performances.mission.segments.base import (
     RegisterSegment,
 )
-from fastoad.models.performances.mission.segments.time_step_base import AbstractManualThrustSegment
+from fastoad.models.performances.mission.segments.time_step_base import (
+    AbstractManualThrustSegment,
+    AbstractLiftFromWeightSegment,
+)
 from fastoad.models.performances.mission.util import get_closest_flight_level
 
 
 @RegisterSegment("altitude_change")
 @dataclass
-class AltitudeChangeSegment(AbstractManualThrustSegment):
+class AltitudeChangeSegment(AbstractManualThrustSegment, AbstractLiftFromWeightSegment):
     """
     Computes a flight path segment where altitude is modified with constant speed.
 

--- a/src/fastoad/models/performances/mission/segments/registered/cruise.py
+++ b/src/fastoad/models/performances/mission/segments/registered/cruise.py
@@ -1,6 +1,6 @@
 """Classes for simulating cruise segments."""
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2023 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -116,7 +116,8 @@ class ClimbAndCruiseSegment(CruiseSegment):
 
     def compute_from_start_to_target(self, start: FlightPoint, target: FlightPoint) -> pd.DataFrame:
         climb_segment = deepcopy(self.climb_segment)
-        climb_segment.target = target
+        if climb_segment is not None:
+            climb_segment.target = target
 
         cruise_segment = CruiseSegment(
             target=deepcopy(target),  # deepcopy needed because altitude will be modified.

--- a/src/fastoad/models/performances/mission/segments/registered/cruise.py
+++ b/src/fastoad/models/performances/mission/segments/registered/cruise.py
@@ -26,11 +26,15 @@ from fastoad.models.performances.mission.segments.base import (
 )
 from fastoad.models.performances.mission.util import get_closest_flight_level
 from .altitude_change import AltitudeChangeSegment
-from ..time_step_base import AbstractRegulatedThrustSegment, AbstractTimeStepFlightSegment
+from ..time_step_base import (
+    AbstractRegulatedThrustSegment,
+    AbstractTimeStepFlightSegment,
+    AbstractLiftFromWeightSegment,
+)
 
 
 @dataclass
-class CruiseSegment(AbstractRegulatedThrustSegment):
+class CruiseSegment(AbstractRegulatedThrustSegment, AbstractLiftFromWeightSegment):
     """
     Class for computing cruise flight segment at constant altitude and speed.
 

--- a/src/fastoad/models/performances/mission/segments/registered/hold.py
+++ b/src/fastoad/models/performances/mission/segments/registered/hold.py
@@ -1,6 +1,6 @@
 """Class for simulating hold segment."""
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2023 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -20,12 +20,15 @@ from fastoad.models.performances.mission.segments.base import (
 from fastoad.models.performances.mission.segments.time_step_base import (
     AbstractFixedDurationSegment,
     AbstractRegulatedThrustSegment,
+    AbstractLiftFromWeightSegment,
 )
 
 
 @RegisterSegment("holding")
 @dataclass
-class HoldSegment(AbstractRegulatedThrustSegment, AbstractFixedDurationSegment):
+class HoldSegment(
+    AbstractRegulatedThrustSegment, AbstractFixedDurationSegment, AbstractLiftFromWeightSegment
+):
     """
     Class for computing hold flight segment.
 

--- a/src/fastoad/models/performances/mission/segments/registered/speed_change.py
+++ b/src/fastoad/models/performances/mission/segments/registered/speed_change.py
@@ -20,12 +20,15 @@ from fastoad.models.performances.mission.exceptions import FastFlightSegmentInco
 from fastoad.models.performances.mission.segments.base import (
     RegisterSegment,
 )
-from fastoad.models.performances.mission.segments.time_step_base import AbstractManualThrustSegment
+from fastoad.models.performances.mission.segments.time_step_base import (
+    AbstractManualThrustSegment,
+    AbstractLiftFromWeightSegment,
+)
 
 
 @RegisterSegment("speed_change")
 @dataclass
-class SpeedChangeSegment(AbstractManualThrustSegment):
+class SpeedChangeSegment(AbstractManualThrustSegment, AbstractLiftFromWeightSegment):
     """
     Computes a flight path segment where speed is modified with no change in altitude.
 

--- a/src/fastoad/models/performances/mission/segments/registered/taxi.py
+++ b/src/fastoad/models/performances/mission/segments/registered/taxi.py
@@ -1,6 +1,6 @@
 """Classes for Taxi sequences."""
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2023 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -25,12 +25,15 @@ from fastoad.models.performances.mission.segments.base import (
 from fastoad.models.performances.mission.segments.time_step_base import (
     AbstractFixedDurationSegment,
     AbstractManualThrustSegment,
+    AbstractLiftFromAoASegment,
 )
 
 
 @RegisterSegment("taxi")
 @dataclass
-class TaxiSegment(AbstractManualThrustSegment, AbstractFixedDurationSegment):
+class TaxiSegment(
+    AbstractManualThrustSegment, AbstractFixedDurationSegment, AbstractLiftFromAoASegment
+):  # noqa: F821
     """
     Class for computing Taxi phases.
 

--- a/src/fastoad/models/performances/mission/segments/registered/tests/test_hold.py
+++ b/src/fastoad/models/performances/mission/segments/registered/tests/test_hold.py
@@ -1,5 +1,5 @@
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2023 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -34,21 +34,23 @@ def test_hold(polar):
 
     def run():
         flight_points = segment.compute_from(
-            FlightPoint(altitude=500.0, equivalent_airspeed=250.0, mass=60000.0)
+            FlightPoint(altitude=500.0, equivalent_airspeed=120.0, mass=60000.0)
         )
 
         last_point = flight_points.iloc[-1]
         assert_allclose(last_point.time, 3000.0)
         assert_allclose(last_point.altitude, 500.0)
-        assert_allclose(last_point.equivalent_airspeed, 250.0, atol=0.1)
-        assert_allclose(last_point.mass, 57776.0, rtol=1e-4)
+        assert_allclose(last_point.equivalent_airspeed, 120.0, atol=0.1)
+        assert_allclose(last_point.mass, 58986.5, rtol=1e-4)
         if segment.isa_offset == 0.0:
-            assert_allclose(last_point.true_airspeed, 256.1, atol=0.1)
-            assert_allclose(last_point.ground_distance, 768323.0, rtol=1.0e-3)
+            assert_allclose(last_point.true_airspeed, 122.9, atol=0.1)
+            assert_allclose(last_point.ground_distance, 368795.0, rtol=1.0e-3)
         if segment.isa_offset == 15.0:
-            assert_allclose(last_point.true_airspeed, 262.8, atol=0.1)
-            assert_allclose(last_point.ground_distance, 788289.0, rtol=1.0e-3)
+            assert_allclose(last_point.true_airspeed, 126.1, atol=0.1)
+            assert_allclose(last_point.ground_distance, 378379.0, rtol=1.0e-3)
         assert last_point.engine_setting == EngineSetting.CRUISE
+        assert_allclose(last_point.CL, 0.5465, rtol=1.0e-3)
+        assert_allclose(last_point.CD, 0.024936, rtol=1.0e-3)
 
     run()
 
@@ -57,4 +59,40 @@ def test_hold(polar):
 
     # Test with non-zero dISA
     segment.isa_offset = 15.0
+    run()
+
+
+def test_hold_with_additional_load(polar):
+    """
+    We simulate a constant 1.5g turn
+    """
+    propulsion = FuelEngineSet(DummyEngine(0.5e5, 2.0e-5), 2)
+
+    segment = HoldSegment(
+        target=FlightPoint(time=3000.0),
+        propulsion=propulsion,
+        reference_area=120.0,
+        polar=polar,
+        load_factor=1.5,
+    )
+
+    def run():
+        flight_points = segment.compute_from(
+            FlightPoint(altitude=500.0, equivalent_airspeed=120.0, mass=60000.0)
+        )
+
+        last_point = flight_points.iloc[-1]
+        assert_allclose(last_point.time, 3000.0)
+        assert_allclose(last_point.altitude, 500.0)
+        assert_allclose(last_point.equivalent_airspeed, 120.0, atol=0.1)
+        assert_allclose(last_point.mass, 57975.4, rtol=1e-4)
+        assert_allclose(last_point.true_airspeed, 122.9, atol=0.1)
+        assert_allclose(last_point.ground_distance, 368795.0, rtol=1.0e-3)
+
+        assert_allclose(last_point.CL, 0.8058, rtol=1.0e-3)
+        assert_allclose(last_point.CD, 0.04246, rtol=1.0e-3)
+
+    run()
+
+    # A second call is done to ensure first run did not modify anything (like target definition)
     run()

--- a/src/fastoad/models/performances/mission/segments/time_step_base.py
+++ b/src/fastoad/models/performances/mission/segments/time_step_base.py
@@ -411,8 +411,11 @@ class AbstractLiftFromWeightSegment(AbstractTimeStepFlightSegment, ABC):
     Class for computing segments where lift is computed from aircraft weight.
     """
 
+    #: Lift is computed so it is equal to load_factor * weight
+    load_factor: float = 1.0
+
     def compute_lift(self, flight_point: FlightPoint, reference_force: float, polar: Polar):
-        flight_point.lift = flight_point.mass * g
+        flight_point.lift = flight_point.mass * g * self.load_factor
         flight_point.CL = flight_point.lift / reference_force
 
 

--- a/src/fastoad/models/performances/mission/segments/time_step_base.py
+++ b/src/fastoad/models/performances/mission/segments/time_step_base.py
@@ -1,6 +1,6 @@
 """Base classes for time-step segments"""
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2023 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or
@@ -156,6 +156,7 @@ class AbstractTimeStepFlightSegment(
                 flight_point.CD = modified_polar.cd(flight_point.CL)
             else:
                 flight_point.CL = flight_point.CD = 0.0
+            flight_point.lift = flight_point.CL * reference_force
             flight_point.drag = flight_point.CD * reference_force
         flight_point.engine_setting = self.engine_setting
         self.compute_propulsion(flight_point)

--- a/src/fastoad/models/performances/mission/segments/time_step_base.py
+++ b/src/fastoad/models/performances/mission/segments/time_step_base.py
@@ -20,6 +20,7 @@ from typing import List, Optional, Tuple
 import numpy as np
 import pandas as pd
 from deprecated import deprecated
+from numpy import sin, cos
 from scipy.constants import g
 from scipy.optimize import root_scalar
 
@@ -68,6 +69,10 @@ class AbstractTimeStepFlightSegment(
     #: Used time step for computation (actual time step can be lower at some particular times of
     #: the flight path).
     time_step: float = DEFAULT_TIME_STEP
+
+    #: If True, the segment computes lift as equal to weight. If False, alpha is used
+    #: to get CL from polar.
+    lift_equals_weight: bool = True
 
     # The maximum lift coefficient for optimal climb and cruise segments
     maximum_CL: float = None
@@ -144,6 +149,8 @@ class AbstractTimeStepFlightSegment(
 
     def complete_flight_point(self, flight_point: FlightPoint):
         super().complete_flight_point(flight_point)
+        flight_point.engine_setting = self.engine_setting
+
         if flight_point.altitude is not None:
             atm = self._get_atmosphere_point(flight_point.altitude)
             reference_force = (
@@ -152,13 +159,15 @@ class AbstractTimeStepFlightSegment(
 
             if self.polar and reference_force:
                 modified_polar = self.polar_modifier.modify_polar(self.polar, flight_point)
-                flight_point.CL = flight_point.mass * g / reference_force
+                if self.lift_equals_weight:
+                    flight_point.CL = flight_point.mass * g / reference_force
+                else:
+                    flight_point.CL = modified_polar.cl(flight_point.alpha)
                 flight_point.CD = modified_polar.cd(flight_point.CL)
             else:
                 flight_point.CL = flight_point.CD = 0.0
             flight_point.lift = flight_point.CL * reference_force
             flight_point.drag = flight_point.CD * reference_force
-        flight_point.engine_setting = self.engine_setting
         self.compute_propulsion(flight_point)
         flight_point.slope_angle, flight_point.acceleration = self.get_gamma_and_acceleration(
             flight_point
@@ -401,9 +410,35 @@ class AbstractTakeOffSegment(AbstractManualThrustSegment, ABC):
     # Default time step for this dynamic segment
     time_step: float = 0.1
 
+    # Here, AoA drives CL
+    lift_equals_weight: bool = False
+
     def compute_from_start_to_target(self, start: FlightPoint, target: FlightPoint) -> pd.DataFrame:
         self.polar_modifier.ground_altitude = start.altitude
         return super().compute_from_start_to_target(start, target)
+
+    def get_gamma_and_acceleration(self, flight_point: FlightPoint):
+        """
+        Redefinition : computes slope angle derivative (gamma_dot) and x-acceleration.
+        Replaces CL, CD, lift dan drag values (for ground effect and accelerated flight)
+
+        :param flight_point: parameters after propulsion model has been called
+                             (i.e. mass, thrust and drag are available)
+        """
+        thrust = flight_point.thrust
+        mass = flight_point.mass
+        airspeed = flight_point.true_airspeed
+        alpha = flight_point.alpha
+        gamma = flight_point.slope_angle
+        drag = flight_point.drag
+        lift = flight_point.lift
+
+        gamma_dot = (thrust * sin(alpha) + lift - mass * g * cos(gamma)) / mass / airspeed
+        acceleration = (thrust * cos(alpha) - drag - mass * g * sin(gamma)) / mass
+
+        flight_point.slope_angle_derivative = gamma_dot
+
+        return gamma, acceleration
 
 
 @dataclass
@@ -434,36 +469,6 @@ class AbstractGroundSegment(AbstractTakeOffSegment, ABC):
         acceleration = (thrust - drag) / mass
 
         return 0.0, acceleration
-
-    def complete_flight_point(self, flight_point: FlightPoint):
-        """
-        Computes data for provided flight point using AoA and apply polar modification if any
-
-        :param flight_point: the flight point that will be completed in-place
-        """
-        self._complete_speed_values(flight_point)
-
-        # Ground segment may force engine setting like reverse or idle
-        flight_point.engine_setting = self.engine_setting
-
-        atm = self._get_atmosphere_point(flight_point.altitude)
-        reference_force = 0.5 * atm.density * flight_point.true_airspeed**2 * self.reference_area
-
-        if self.polar:
-            alpha = flight_point.alpha
-            modified_polar = self.polar_modifier.modify_polar(self.polar, flight_point)
-            flight_point.CL = modified_polar.cl(alpha)
-            flight_point.CD = modified_polar.cd(flight_point.CL)
-        else:
-            flight_point.CL = flight_point.CD = 0.0
-
-        flight_point.drag = flight_point.CD * reference_force
-        flight_point.lift = flight_point.CL * reference_force
-
-        self.compute_propulsion(flight_point)
-        flight_point.slope_angle, flight_point.acceleration = self.get_gamma_and_acceleration(
-            flight_point
-        )
 
 
 @deprecated(


### PR DESCRIPTION
This PR addresses 2 small problems:
 - lift value was generally not computed (knowing CL can be enough), though the column is always in csv files.
 - in ClimbAndCruise segment, the target of inner climb segment could be set without guarantee the climb segment was not None.

Additionally, some refactoring has been done to have CL and CD computed in only one location. For this purpose, abstract classes `AbstractLiftFromWeightSegment` and `AbstractLiftFromAoASegment` have been created, in the same purpose as `AbstractManualThrustSegment` and `AbstractRegulatedThrustSegment`.

BTW, the `load_factor` attribute has been added to `AbstractLiftFromWeightSegment`. It's an easy addition that allows to simulate segments with load factors different from 1.