### PR TITLE
Mission module: transition segment can now handle a payload decrease

### DIFF
--- a/docs/documentation/mission_module/mission_file/segments.rst
+++ b/docs/documentation/mission_module/mission_file/segments.rst
@@ -433,15 +433,15 @@ Typically, it will be used as last segment to compute a reserve based on the Zer
       altitude: 0.
       mach: 0.
 
-Mass loss without fuel consumption
+Mass change without fuel consumption
 ----------------------------------
 
 .. versionadded:: 1.8.2
 
 Using :code:`delta_mass` allows to simulate a fuel consumption equivalent to the mass loss.
 
-For cases where mass loss should be simulated without fuel consumption, it is possible to set to
-:code:`False` the parameter :code:`fuel_is_consumed`.
+For cases where mass variation should be simulated without fuel consumption, it is possible to set
+to :code:`False` the parameter :code:`fuel_is_consumed`.
 
 **Example:**
 
@@ -449,7 +449,7 @@ For cases where mass loss should be simulated without fuel consumption, it is po
 
     segment: transition
     target:
-      delta_mass: 100.
+      delta_mass: -100.
       fuel_is_consumed: False
 
 .. seealso::

--- a/docs/documentation/mission_module/mission_file/segments.rst
+++ b/docs/documentation/mission_module/mission_file/segments.rst
@@ -389,7 +389,7 @@ last point of the flight segment will simply uses these values.
       delta_altitude:           # 35 ft above start point
         value: 35
         unit: ft
-      delta_mass: -80.0         # 80kg lost from start point
+      delta_mass: -80.0         # 80kg lost from start point (implicitly 80kg consumed fuel)
       true_airspeed: 85         # 85m/s at end of segment.
 
 Usage of a mass ratio
@@ -433,9 +433,29 @@ Typically, it will be used as last segment to compute a reserve based on the Zer
       altitude: 0.
       mach: 0.
 
+Mass loss without fuel consumption
+----------------------------------
+
+.. versionadded:: 1.8.2
+
+Using :code:`delta_mass` allows to simulate a fuel consumption equivalent to the mass loss.
+
+For cases where mass loss should be simulated without fuel consumption, it is possible to set to
+:code:`False` the parameter :code:`fuel_is_consumed`.
+
+**Example:**
+
+.. code-block:: yaml
+
+    segment: transition
+    target:
+      delta_mass: 100.
+      fuel_is_consumed: False
+
 .. seealso::
 
     Python documentation: :class:`~fastoad.models.performances.mission.segments.registered.transition.DummyTransitionSegment`
+
 
 .. _segment-ground_speed_change:
 

--- a/src/fastoad/models/performances/mission/segments/registered/transition.py
+++ b/src/fastoad/models/performances/mission/segments/registered/transition.py
@@ -49,14 +49,18 @@ class DummyTransitionSegment(AbstractFlightSegment):
     #: of segment.
     reserve_mass_ratio: float = 0.0
 
+    #: If False, the mass variation during the segment is not considered as a fuel consumption.
+    #:  (True by default
+    fuel_is_consumed: bool = True
+
     def compute_from_start_to_target(self, start: FlightPoint, target: FlightPoint) -> pd.DataFrame:
         end = deepcopy(target)
         end.name = self.name
-
+        end.consumed_fuel = start.consumed_fuel
         if end.mass is None:
             self.consume_fuel(end, previous=start, mass_ratio=self.mass_ratio)
-        else:
-            end.consumed_fuel = start.consumed_fuel + start.mass - end.mass
+        elif self.fuel_is_consumed:
+            end.consumed_fuel += start.mass - end.mass
 
         self.complete_flight_point_from(end, start)
         self.complete_flight_point(end)


### PR DESCRIPTION
This PR allows to simulate a mass loss that is not linked to fuel consumption.


Documentation preview: https://fast-oad.readthedocs.io/en/delta-payload-in-segment-transition/documentation/mission_module/mission_file/segments.html#mass-loss-without-fuel-consumption