### PR TITLE
Allow non pickable object as propulsion component

### DIFF
--- a/src/fastoad/model_base/datacls.py
+++ b/src/fastoad/model_base/datacls.py
@@ -12,7 +12,7 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from dataclasses import asdict, dataclass
+from dataclasses import fields, dataclass
 
 #: To be put as default value for dataclass fields that should not have a default value.
 #: See :class:`BaseDataClass` for further information.
@@ -36,6 +36,7 @@ class BaseDataClass:
     """
 
     def __post_init__(self):
-        for name, value in asdict(self).items():
+        field_dict = {field.name: getattr(self, field.name) for field in fields(self)}
+        for name, value in field_dict.items():
             if value is MANDATORY_FIELD:
                 raise TypeError(f"__init__ missing 1 required argument: '{name}'")

--- a/src/fastoad/model_base/datacls.py
+++ b/src/fastoad/model_base/datacls.py
@@ -12,7 +12,7 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from dataclasses import fields, dataclass
+from dataclasses import dataclass, fields
 
 #: To be put as default value for dataclass fields that should not have a default value.
 #: See :class:`BaseDataClass` for further information.

--- a/src/fastoad/models/performances/mission/segments/registered/cruise.py
+++ b/src/fastoad/models/performances/mission/segments/registered/cruise.py
@@ -120,9 +120,16 @@ class ClimbAndCruiseSegment(CruiseSegment):
     maximum_flight_level: float = 500.0
 
     def compute_from_start_to_target(self, start: FlightPoint, target: FlightPoint) -> pd.DataFrame:
-        climb_segment = deepcopy(self.climb_segment)
-        if climb_segment is not None:
-            climb_segment.target = target
+        if self.climb_segment is not None:
+            attr_dict = {
+                key: val
+                for key, val in self.climb_segment.__dict__.items()
+                if not key.startswith("_")
+            }
+            attr_dict["target"] = target
+            climb_segment = AltitudeChangeSegment(**attr_dict)
+        else:
+            climb_segment = None
 
         cruise_segment = CruiseSegment(
             target=deepcopy(target),  # deepcopy needed because altitude will be modified.

--- a/src/fastoad/models/performances/mission/segments/registered/tests/conftest.py
+++ b/src/fastoad/models/performances/mission/segments/registered/tests/conftest.py
@@ -10,7 +10,8 @@
 #  GNU General Public License for more details.
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
-import os
+import shutil
+from pathlib import Path
 
 import numpy as np
 import pandas as pd
@@ -29,16 +30,23 @@ def polar() -> Polar:
     return Polar(cl, cd)
 
 
+TEMP_DIR = Path(__file__).parent / "data"
+DATA_FILE = TEMP_DIR / "data.txt"
+
+
 @pytest.fixture
 def data_file():
-    with open("data.txt", "w") as f:
+    """Creates a temporary folder with dummy data file to simulate an unpickable propulsion."""
+    Path.mkdir(TEMP_DIR, exist_ok=True)
+    with open(DATA_FILE, "w") as f:
         f.write("This is a test file for unpickable propulsion test.")
 
 
 @pytest.fixture
 def clean_data_file(data_file):
+    """Ensure the temporary folder is deleted after running the corresponding test"""
     yield data_file
-    os.remove("data.txt")
+    shutil.rmtree(TEMP_DIR, ignore_errors=True)
 
 
 def print_dataframe(df):
@@ -81,7 +89,8 @@ class DummyUnpickableEngine(DummyEngine):
         Unpickable dummy engine model, inherites from DummyEngine.
         """
         DummyEngine.__init__(self, max_thrust, max_sfc)
-        self.data = open("data.txt", "r")
+        self.data = open(DATA_FILE, "r")
 
     def close_file(self):
+        """Utility function to manually close the datafile."""
         self.data.close()

--- a/src/fastoad/models/performances/mission/segments/registered/tests/conftest.py
+++ b/src/fastoad/models/performances/mission/segments/registered/tests/conftest.py
@@ -10,8 +10,6 @@
 #  GNU General Public License for more details.
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
-import shutil
-from pathlib import Path
 
 import numpy as np
 import pandas as pd
@@ -28,25 +26,6 @@ def polar() -> Polar:
     cl = np.arange(0.0, 1.5, 0.01)
     cd = 0.5e-1 * cl**2 + 0.01
     return Polar(cl, cd)
-
-
-TEMP_DIR = Path(__file__).parent / "data"
-DATA_FILE = TEMP_DIR / "data.txt"
-
-
-@pytest.fixture
-def data_file():
-    """Creates a temporary folder with dummy data file to simulate an unpickable propulsion."""
-    Path.mkdir(TEMP_DIR, exist_ok=True)
-    with open(DATA_FILE, "w") as f:
-        f.write("This is a test file for unpickable propulsion test.")
-
-
-@pytest.fixture
-def clean_data_file(data_file):
-    """Ensure the temporary folder is deleted after running the corresponding test"""
-    yield data_file
-    shutil.rmtree(TEMP_DIR, ignore_errors=True)
 
 
 def print_dataframe(df):
@@ -84,12 +63,12 @@ class DummyEngine(AbstractFuelPropulsion):
 
 
 class DummyUnpickableEngine(DummyEngine):
-    def __init__(self, max_thrust, max_sfc):
+    def __init__(self, max_thrust, max_sfc, file_name):
         """
         Unpickable dummy engine model, inherites from DummyEngine.
         """
         DummyEngine.__init__(self, max_thrust, max_sfc)
-        self.data = open(DATA_FILE, "r")
+        self.data = open(file_name, "r")
 
     def close_file(self):
         """Utility function to manually close the datafile."""

--- a/src/fastoad/models/performances/mission/segments/registered/tests/conftest.py
+++ b/src/fastoad/models/performances/mission/segments/registered/tests/conftest.py
@@ -10,6 +10,7 @@
 #  GNU General Public License for more details.
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+import os
 
 import numpy as np
 import pandas as pd
@@ -26,6 +27,18 @@ def polar() -> Polar:
     cl = np.arange(0.0, 1.5, 0.01)
     cd = 0.5e-1 * cl**2 + 0.01
     return Polar(cl, cd)
+
+
+@pytest.fixture
+def data_file():
+    with open("data.txt", "w") as f:
+        f.write("This is a test file for unpickable propulsion test.")
+
+
+@pytest.fixture
+def clean_data_file(data_file):
+    yield data_file
+    os.remove("data.txt")
 
 
 def print_dataframe(df):
@@ -60,3 +73,15 @@ class DummyEngine(AbstractFuelPropulsion):
             flight_point.thrust = self.max_thrust * flight_point.thrust_rate
 
         flight_point.sfc = self.max_sfc * (1.0 + flight_point.thrust_rate) / 2.0
+
+
+class DummyUnpickableEngine(DummyEngine):
+    def __init__(self, max_thrust, max_sfc):
+        """
+        Unpickable dummy engine model, inherites from DummyEngine.
+        """
+        DummyEngine.__init__(self, max_thrust, max_sfc)
+        self.data = open("data.txt", "r")
+
+    def close_file(self):
+        self.data.close()

--- a/src/fastoad/models/performances/mission/segments/registered/tests/test_cruise.py
+++ b/src/fastoad/models/performances/mission/segments/registered/tests/test_cruise.py
@@ -11,14 +11,13 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-
+import pytest
 from numpy.testing import assert_allclose
 
 from fastoad.constants import EngineSetting
 from fastoad.model_base import FlightPoint
 from fastoad.model_base.propulsion import FuelEngineSet
-
-from .conftest import DummyEngine
+from .conftest import DummyEngine, DummyUnpickableEngine
 from ..altitude_change import AltitudeChangeSegment
 from ..cruise import (
     BreguetCruiseSegment,
@@ -161,6 +160,60 @@ def test_climb_and_cruise_at_optimal_flight_level(polar):
             engine_setting=EngineSetting.CLIMB,
         ),
     )
+
+    def run():
+        flight_points = segment.compute_from(
+            FlightPoint(mass=70000.0, altitude=8000.0, mach=0.78, ground_distance=1.0e6)
+        )
+
+        first_point = flight_points.iloc[0]
+        last_point = flight_points.iloc[-1]
+        # Note: reference values are obtained by running the process with 1.0s as time step
+
+        assert_allclose(first_point.altitude, 8000.0)
+        assert_allclose(first_point.thrust_rate, 0.9)
+        assert_allclose(first_point.true_airspeed, 240.3, atol=0.1)
+        assert first_point.engine_setting == EngineSetting.CLIMB
+
+        assert_allclose(flight_points.mach, 0.78)
+        assert_allclose(last_point.ground_distance, 11.0e6)
+        assert_allclose(last_point.altitude, 9753.6)
+        assert_allclose(last_point.time, 42659.0, rtol=1e-3)
+        assert_allclose(last_point.true_airspeed, 234.4, atol=0.1)
+        assert_allclose(last_point.mass, 48874.0, rtol=1e-4)
+        assert last_point.engine_setting == EngineSetting.CRUISE
+
+    run()
+
+    # A second call is done to ensure first run did not modify anything (like target definition)
+    run()
+
+
+def test_climb_and_cruise_at_optimal_flight_level_with_unpickable(polar, clean_data_file):
+    engine = DummyUnpickableEngine(0.5e5, 3.0e-5)
+    propulsion = FuelEngineSet(engine, 2)
+    reference_area = 120.0
+    try:
+        segment = ClimbAndCruiseSegment(
+            target=FlightPoint(
+                ground_distance=10.0e6, altitude=AltitudeChangeSegment.OPTIMAL_FLIGHT_LEVEL
+            ),
+            propulsion=propulsion,
+            reference_area=reference_area,
+            polar=polar,
+            engine_setting=EngineSetting.CRUISE,
+            climb_segment=AltitudeChangeSegment(
+                target=FlightPoint(),
+                propulsion=propulsion,
+                reference_area=reference_area,
+                polar=polar,
+                thrust_rate=0.9,
+                engine_setting=EngineSetting.CLIMB,
+            ),
+        )
+    except TypeError:
+        engine.close_file()
+        pytest.fail("Unpickable propulsion incorrectly handled")
 
     def run():
         flight_points = segment.compute_from(

--- a/src/fastoad/models/performances/mission/segments/registered/tests/test_cruise.py
+++ b/src/fastoad/models/performances/mission/segments/registered/tests/test_cruise.py
@@ -189,8 +189,16 @@ def test_climb_and_cruise_at_optimal_flight_level(polar):
     run()
 
 
-def test_climb_and_cruise_at_optimal_flight_level_with_unpickable(polar, clean_data_file):
-    engine = DummyUnpickableEngine(0.5e5, 3.0e-5)
+def test_climb_and_cruise_at_optimal_flight_level_with_unpickable(polar, tmp_path):
+    # Create temporary folder containing a dummy data file
+    d = tmp_path / "sub"
+    d.mkdir()
+    file = d / "data.txt"
+    with open(file, "w") as f:
+        f.write("This is a test file for unpickable propulsion test.")
+
+    # Actually try to run the cruise segment
+    engine = DummyUnpickableEngine(0.5e5, 3.0e-5, file)
     propulsion = FuelEngineSet(engine, 2)
     reference_area = 120.0
     try:

--- a/src/fastoad/models/performances/mission/segments/registered/tests/test_cruise.py
+++ b/src/fastoad/models/performances/mission/segments/registered/tests/test_cruise.py
@@ -17,6 +17,7 @@ from numpy.testing import assert_allclose
 from fastoad.constants import EngineSetting
 from fastoad.model_base import FlightPoint
 from fastoad.model_base.propulsion import FuelEngineSet
+
 from .conftest import DummyEngine, DummyUnpickableEngine
 from ..altitude_change import AltitudeChangeSegment
 from ..cruise import (


### PR DESCRIPTION
This modification allows the use of non pickable object as propulsion component in the mission.

This is a rather rare error but can happen with surrogate models using compiled code (for example when using GPX from the smt library). The error was essentially due to the function `deepcopy` that requires all object to be pickable. Two modifications were made to bypass the use of `deepcopy` without affecting the behaviour of the code.

For what it is worth, time execution of 1000 instanciation of ClimbAndCruiseSegment averaged over 5 repeatition: legacy code 2.539s, with new code: 2.133s

