### PR TITLE
Fix inconsistent behaviour of the get_val method when not providing units of measure

### DIFF
--- a/src/fastoad/openmdao/tests/test_variables.py
+++ b/src/fastoad/openmdao/tests/test_variables.py
@@ -14,7 +14,6 @@ Module for testing VariableList.py
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from collections.abc import Iterable
 from pathlib import Path
 from typing import List
 
@@ -850,13 +849,14 @@ def test_get_val():
     vars["qux"] = {"value": np.array([1.0, 2.0]), "units": "m"}
     vars["quux"] = {"value": [[1.0, 2.0], [2.0, 3.0]], "units": "m"}
     data = vars["bar"].get_val()
-    assert not isinstance(data, Iterable) and not isinstance(data, np.ndarray)
+    assert not isinstance(data, list) and not isinstance(data, np.ndarray)
     assert_allclose(data, 1, rtol=1e-3, atol=1e-5)
-    data = vars["baq"].get_val()
-    assert not isinstance(data, Iterable) and not isinstance(data, np.ndarray)
     units = "km"
     data = vars["bar"].get_val(new_units=units)
     assert_allclose(data, 1e-3, rtol=1e-3, atol=1e-5)
+    data = vars["baq"].get_val()
+    assert not isinstance(data, list) and not isinstance(data, np.ndarray)
+    assert_allclose(data, 1, rtol=1e-3, atol=1e-5)
     with pytest.raises(TypeError):
         data = vars["foo"].get_val(new_units=units)
     data = vars["baz"].get_val(new_units=units)

--- a/src/fastoad/openmdao/tests/test_variables.py
+++ b/src/fastoad/openmdao/tests/test_variables.py
@@ -153,8 +153,8 @@ def test_ivc_from_to_variables():
     problem = om.Problem()
     problem.model.add_subsystem("ivc", ivc, promotes=["*"])
     problem.setup()
-    assert problem["a"] == 5
-    assert problem["b"] == 2.5
+    assert problem.get_val("a") == 5
+    assert problem.get_val("b") == 2.5
     assert problem.get_val("b", units="cm") == 250
     assert problem.get_val("c", units="kg/ms") == -0.0032
 

--- a/src/fastoad/openmdao/tests/test_variables.py
+++ b/src/fastoad/openmdao/tests/test_variables.py
@@ -14,6 +14,7 @@ Module for testing VariableList.py
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from collections.abc import Iterable
 from pathlib import Path
 from typing import List
 
@@ -842,13 +843,17 @@ def test_get_variables_from_problem_sellar_with_promotion_and_connect():
 def test_get_val():
     vars = VariableList()
     vars["bar"] = {"value": 1.0, "units": "m"}
+    vars["baq"] = {"value": np.array([1.0])}
     vars["foo"] = {"value": 1.0, "units": "m**2"}
     vars["baz"] = {"value": [1.0, 2.0], "units": "m"}
     vars["bat"] = {"value": (1.0, 2.0), "units": "m"}
     vars["qux"] = {"value": np.array([1.0, 2.0]), "units": "m"}
     vars["quux"] = {"value": [[1.0, 2.0], [2.0, 3.0]], "units": "m"}
     data = vars["bar"].get_val()
+    not isinstance(data, Iterable) and not isinstance(data, np.ndarray)
     assert_allclose(data, 1, rtol=1e-3, atol=1e-5)
+    data = vars["baq"].get_val()
+    not isinstance(data, Iterable) and not isinstance(data, np.ndarray)
     units = "km"
     data = vars["bar"].get_val(new_units=units)
     assert_allclose(data, 1e-3, rtol=1e-3, atol=1e-5)

--- a/src/fastoad/openmdao/tests/test_variables.py
+++ b/src/fastoad/openmdao/tests/test_variables.py
@@ -154,8 +154,8 @@ def test_ivc_from_to_variables():
     problem = om.Problem()
     problem.model.add_subsystem("ivc", ivc, promotes=["*"])
     problem.setup()
-    assert problem.get_val("a") == 5
-    assert problem.get_val("b") == 2.5
+    assert problem["a"] == 5
+    assert problem["b"] == 2.5
     assert problem.get_val("b", units="cm") == 250
     assert problem.get_val("c", units="kg/ms") == -0.0032
 
@@ -850,10 +850,10 @@ def test_get_val():
     vars["qux"] = {"value": np.array([1.0, 2.0]), "units": "m"}
     vars["quux"] = {"value": [[1.0, 2.0], [2.0, 3.0]], "units": "m"}
     data = vars["bar"].get_val()
-    not isinstance(data, Iterable) and not isinstance(data, np.ndarray)
+    assert not isinstance(data, Iterable) and not isinstance(data, np.ndarray)
     assert_allclose(data, 1, rtol=1e-3, atol=1e-5)
     data = vars["baq"].get_val()
-    not isinstance(data, Iterable) and not isinstance(data, np.ndarray)
+    assert not isinstance(data, Iterable) and not isinstance(data, np.ndarray)
     units = "km"
     data = vars["bar"].get_val(new_units=units)
     assert_allclose(data, 1e-3, rtol=1e-3, atol=1e-5)

--- a/src/fastoad/openmdao/variables/variable.py
+++ b/src/fastoad/openmdao/variables/variable.py
@@ -141,7 +141,7 @@ class Variable(Hashable):
         """Returns the variable value converted in the `new_units`"""
         if new_units:
             return scalarize(convert_units(np.asarray(self.value), self.units, new_units))
-        return self.value
+        return scalarize(self.value)
 
     @classmethod
     def read_variable_descriptions(

--- a/src/fastoad/openmdao/variables/variable.py
+++ b/src/fastoad/openmdao/variables/variable.py
@@ -138,7 +138,18 @@ class Variable(Hashable):
             self.description = self._variable_descriptions[self.name]
 
     def get_val(self, new_units: Optional[str] = None) -> Union[float, np.ndarray]:
-        """Returns the variable value converted in the `new_units`"""
+        """
+        Returns the variable value converted in the `new_units`. One dimensional lists and np.array
+        are scalarized.
+
+        Note that this method should not be confused with OpenMDAO's `problem.get_val()`.
+        While they have similar behavior, this method applies to a Variable instance rather
+        than to a Problem instance.
+
+        :param new_units: units to convert the value to. If None, the value will be returned with
+                          its original units.
+        :return: the variable value, converted to new_units if specified.
+        """
         if new_units:
             return scalarize(convert_units(np.asarray(self.value), self.units, new_units))
         return scalarize(self.value)


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Summary of Changes

<!-- Provide a concise description of the changes introduced by this PR -->
Fixed the consistency of the `get_val` method. This PR introduces a small breaking change: previously, if the FAST-OAD output was a 1D iterable (i.e., a scalar), `get_val` would return an iterable, while requesting the same value with unit conversion would return a scalar. This inconsistency has been fixed, so it is no longer necessary to do `prob.get_val("var_name")[0]` to extract the scalar value. If the exact raw value from the FAST-OAD output is needed, it can still be accessed using `prob["var_name"]`.


## Related Issues

<!-- List related issues and use keywords to automatically close them, e.g., closes #123, more info here:  -->
<!-- https://docs.github.com/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue -->
<!-- This project only accepts pull requests related to open issues -->
<!-- If suggesting a new feature or change, please discuss it in an issue first -->
closes #606 
## New Dependencies

<!-- List any new dependencies and explain why they are necessary -->

## Checklist

- [x] Have you followed the guidelines in our [Contributing](https://github.com/fast-aircraft-design/FAST-OAD/wiki/Development-environment) wiki?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [x] Have you added new tests to cover your changes?
- [x] Do the existing tests pass with your changes?
- [x] Does this PR introduce a breaking change?
