### PR TITLE
Watchman tests now ignore the pyproject toml requirements

### DIFF
--- a/.github/workflows/watchman_tests.yml
+++ b/.github/workflows/watchman_tests.yml
@@ -35,8 +35,8 @@ jobs:
         # Development version of OpenMDAO is installed to ensure preview of any problem.
         # Installing pytest-cov is needed because of pytest.ini
         run: |
-          pip install git+https://github.com/OpenMDAO/OpenMDAO.git
           pip install .
+          pip install git+https://github.com/OpenMDAO/OpenMDAO.git
           pip install pytest pytest-cov nbval
         shell: bash
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Summary of Changes

This small modification of the Watchman test allows the tests to install the latest version of OpenMDAO without considering the possible requirements specified in the `pyproject.toml` file. As expected, the test now fails because the latest version of OpenMDAO is still incompatible with FAST at the time of writing this PR.