### PR TITLE
Add RunOnce solver as default for `run_system`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,10 @@ prof/
 # test results
 results/
 
+# OpenMDAO reports
+reports/
+*.openmdao_out
+
 # Build and docs folder/files
 build/*
 dist/*

--- a/src/fastoad/testing.py
+++ b/src/fastoad/testing.py
@@ -39,12 +39,16 @@ def run_system(
     :return: a FASTOADProblem instance
     """
 
-    if isinstance(component, om.ImplicitComponent) and "nonlinear_solver" not in kwargs:
-        kwargs["nonlinear_solver"] = "om.NewtonSolver"
-        kwargs["linear_solver"] = "om.DirectSolver"
+    if "nonlinear_solver" not in kwargs:
+        if isinstance(component, om.ImplicitComponent):
+            kwargs["nonlinear_solver"] = "om.NewtonSolver"
+            kwargs["linear_solver"] = "om.DirectSolver"
 
-        if kwargs.get("nonlinear_solver_options", {}).get("solve_subsystems") is None:
-            kwargs["nonlinear_solver_options"]["solve_subsystems"] = False
+            if kwargs.get("nonlinear_solver_options", {}).get("solve_subsystems") is None:
+                kwargs["nonlinear_solver_options"]["solve_subsystems"] = False
+
+        else:
+            kwargs["nonlinear_solver"] = "om.NonlinearRunOnce"
 
     problem = om.Problem()
     model = problem.model = BaseCycleGroup(**kwargs)


### PR DESCRIPTION
## Summary of Changes

When using the `run_system` metod to perform tests, the default solver of the `BaseCycleGroup` class is used which is `NonlinearBlockGS`. This means that all component tested using this method are ran at least twice (enough for the solver to consider it is done) even if there is no point in doing it. This commit change the default to NonLinearRunOnce which is used unless specified otherwise.

Tests for the CS25 repo have been ran using the fast-oad-core version on this branch and all tests still pass.

Additionally, the files generated by the OpenMDAO reports have been added to the .gitgnore

## Related Issues

Closes #623 

## Checklist

- [x] Have you followed the guidelines in our [Contributing](https://github.com/fast-aircraft-design/FAST-OAD/wiki/Development-environment) wiki?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [ ] Have you added new tests to cover your changes?
- [ ] Have you made corresponding changes to the documentation? If yes, please consider providing a link to the updated documentation.
- [x] Do the existing tests pass with your changes?
- [ ] Have you commented on hard-to-understand areas of the code?
- [ ] Does this PR introduce a breaking change?
