### PR TITLE
Ruff linting it2

### DIFF
--- a/devutils/rename_vars.py
+++ b/devutils/rename_vars.py
@@ -64,8 +64,8 @@ def convert_xml(file_path: str, translator: VarXpathTranslator):
     :param translator:
     """
     reader = VariableIO(file_path, formatter=VariableXmlBaseFormatter(translator))
-    vars = reader.read()
-    VariableIO(file_path).write(vars)
+    variables = reader.read()
+    VariableIO(file_path).write(variables)
 
 
 def replace_var_names(file_path, var_names_match):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,7 +55,7 @@ def setup(app):
 
 # -- Project information -----------------------------------------------------
 project = "FAST-OAD"
-copyright = "2025, ONERA & ISAE-SUPAERO"
+copyright = "2025, ONERA & ISAE-SUPAERO"  # noqa: A001 copyright is a keyword for the sphinx setup
 
 # -- General configuration ---------------------------------------------------
 

--- a/docs/directives/segment_attributes.py
+++ b/docs/directives/segment_attributes.py
@@ -96,7 +96,7 @@ class ListSegmentsForAttribute(AbstractLinkList):
         attribute_name = self.content[0].strip()
 
         class_dict = RegisterSegment.get_classes()
-        segment_keywords = sorted(list(class_dict))
+        segment_keywords = sorted(class_dict)
 
         valid_keywords = [
             keyword for keyword in segment_keywords if hasattr(class_dict[keyword], attribute_name)
@@ -153,8 +153,9 @@ def check_targets(app, doctree):
             continue
 
         child_nodes = _generate_hyperlink_list(app, doctree, target_list)
-
-        directive_location += child_nodes
+        # Reassigning directive_location by appending children directly to the docutils node.
+        # This is intentional and required to inject generated content into the document tree.
+        directive_location += child_nodes  # noqa: PLW2901
 
 
 def _generate_hyperlink_list(app, doctree, target_list):

--- a/ruff.toml
+++ b/ruff.toml
@@ -14,18 +14,43 @@ select = [
     "FA",  # Check if a type is used in the module that can be rewritten using PEP 563.
     "PTH", # A plugin for flake8 finding use of functions that can be replaced by pathlib module.
     "RUF", # Ruff-specific rules.
+    "C4",  # Catch incorrect use of comprehensions, dict, list, etc.
+    "A",   # Detect shadowed builtins.
+    "COM", # Detect missing trailing comma (usually is implemented in the ruff formatter).
+    "ISC", # Good use of string concatenation.
+    "ERA", # Find large commented-out code.
+    "PD",  # Provides opinionated linting for pandas code.
+    "SIM", # flake8-simplify.
+    "ICN", # Use common import conventions eg. no import numpy as nump.
+    "NPY", # Some numpy-specific things.
+    "PL",  # Pylint checks for errors, enforces a coding standard, looks for code smells, and can make suggestions about how the code could be refactored
+    "S",   # Bandit: automated security testing built right into your workflow.
+    "N",   # Enforce PEP8 naming convention.
+    "E",   # pycodestyle is a tool to check your Python code against some of the style conventions in PEP 8.
+    # "ANN", # Enforce function annotations.
+    # "D",   # Pydocstyle is a static analysis tool for checking compliance with Python docstring conventions.
+    # "DOC", # Pydoclint (still in preview so not yet active).
     "E4",
     "E7",
     "E9",
 ]
 
 # No rules are ignored by default. Specify rule codes here to suppress them.
-ignore = []
+ignore = [
+    "ANN002", # No type annotation for *args 
+    "ANN003", # No type annotation for *kwargs 
+    "ANN204", # No type annotation on "special" methods, like __init__ 
+    "N806",   # Checks for the use of non-lowercase variable names in functions.
+    "D105",   # Missing docstring in magic method
+    "D212",   #Multi-line docstring summary should start at the first line
+]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.
 fixable = ["ALL"]
 
-unfixable = []
+unfixable = [
+    "D", # Dont fix docstyle
+]
 
 # Allow unused variables when underscore-prefixed.
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
@@ -34,7 +59,46 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 # We prefer clarity over efficency in notebook examples
 "*.ipynb" = ["RET504"]
 "*/fastoad/notebooks/*" = ["RET504"]
+# Tests
+"tests/*" = [
+    "PLR0913", # Too many arguments in function definition
+    "PLR0915", # Too many statements
+    "PLR2004", # Enabling magic value to be used in test comparison
+    "S101",    # Enable assert in tests
+    "ANN",     # No annotation on tests
+    "D",       # No doc in tests
+]
+"*/test*.py" = [
+    "PLR0913", # Too many arguments in function definition
+    "PLR0915", # Too many statements
+    "PLR2004", # Enabling magic value to be used in test comparison
+    "S101",    # Enable assert in tests
+    "ANN",     # No annotation on tests
+    "D",       # No doc in tests
+]
 
 [lint.isort] # Add optional configurations for import organization
 case-sensitive = true
 relative-imports-order = "closest-to-furthest"
+
+[lint.pylint] # Add optional configurations for pylint
+max-args = 8
+
+[lint.pep8-naming] # A list of names (or patterns) to ignore when considering pep8-naming violations. Supports glob patterns.
+ignore-names = [
+    "*MTOW*",
+    "*TOW*",
+    "*OWE*",
+    "*2D*",
+    "*3D*",
+    "*AR*",
+    "*CL*",
+    "*CD*",
+    "*TAS*",
+    "*EAS*",
+    "*IAS*",
+    "*CAS*",
+    "*Mach*",
+    "*MPI*",
+    "I_*",
+]

--- a/ruff.toml
+++ b/ruff.toml
@@ -16,7 +16,6 @@ select = [
     "RUF", # Ruff-specific rules.
     "C4",  # Catch incorrect use of comprehensions, dict, list, etc.
     "A",   # Detect shadowed builtins.
-    "COM", # Detect missing trailing comma (usually is implemented in the ruff formatter).
     "ISC", # Good use of string concatenation.
     "ERA", # Find large commented-out code.
     "PD",  # Provides opinionated linting for pandas code.
@@ -42,7 +41,9 @@ ignore = [
     "ANN204", # No type annotation on "special" methods, like __init__ 
     "N806",   # Checks for the use of non-lowercase variable names in functions.
     "D105",   # Missing docstring in magic method
-    "D212",   #Multi-line docstring summary should start at the first line
+    "D212",   # Multi-line docstring summary should start at the first line
+    "PD901",  # df is ok as a name
+    "PD002",  # We want to use inplace for pandas
 ]
 
 # Allow fix for all enabled rules (when `--fix`) is provided.
@@ -56,15 +57,24 @@ unfixable = [
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
 [lint.per-file-ignores]
-# We prefer clarity over efficency in notebook examples
-"*.ipynb" = ["RET504"]
-"*/fastoad/notebooks/*" = ["RET504"]
+
+"*.ipynb" = [
+    "RET504", # We prefer clarity over efficency in notebook examples
+    "E501",   # no long line check
+    "ERA001", # no check for commented code
+]
+"*/fastoad/notebooks/*" = [
+    "RET504", # We prefer clarity over efficency in notebook examples
+    "E501",   # no long line check
+    "ERA001", # no check for commented code
+]
 # Tests
 "tests/*" = [
     "PLR0913", # Too many arguments in function definition
     "PLR0915", # Too many statements
     "PLR2004", # Enabling magic value to be used in test comparison
     "S101",    # Enable assert in tests
+    "PD901",   # Avoid using the generic variable name `df` for DataFrames
     "ANN",     # No annotation on tests
     "D",       # No doc in tests
 ]
@@ -73,6 +83,7 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
     "PLR0915", # Too many statements
     "PLR2004", # Enabling magic value to be used in test comparison
     "S101",    # Enable assert in tests
+    "PD901",   # Avoid using the generic variable name `df` for DataFrames
     "ANN",     # No annotation on tests
     "D",       # No doc in tests
 ]

--- a/src/fastoad/_utils/resource_management/contents.py
+++ b/src/fastoad/_utils/resource_management/contents.py
@@ -65,7 +65,7 @@ class PackageReader:
                 else:
                     # Here we assume non-existence
                     self.exists = False
-            except Exception:  # pylint: disable = W0703
+            except Exception:
                 # Here we catch any Python error that may happen when reading the loaded code.
                 # Thus, we ensure to not break the application if a module is incorrectly written.
                 self.has_error = True

--- a/src/fastoad/_utils/sellar/disc1.py
+++ b/src/fastoad/_utils/sellar/disc1.py
@@ -34,7 +34,6 @@ class BasicDisc1(om.ExplicitComponent):
     def setup_partials(self):
         self.declare_partials("*", "*", method="fd")
 
-    # pylint: disable=invalid-name
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
         """
         Evaluates the equation

--- a/src/fastoad/_utils/sellar/disc2.py
+++ b/src/fastoad/_utils/sellar/disc2.py
@@ -27,7 +27,6 @@ class BasicDisc2(om.ExplicitComponent):
     def setup_partials(self):
         self.declare_partials("*", "*", method="fd")
 
-    # pylint: disable=invalid-name
     def compute(self, inputs, outputs, discrete_inputs=None, discrete_outputs=None):
         """
         Evaluates the equation

--- a/src/fastoad/_utils/tests/test_get_float_list_from_string.py
+++ b/src/fastoad/_utils/tests/test_get_float_list_from_string.py
@@ -15,11 +15,11 @@ from ..strings import get_float_list_from_string
 
 
 def test_get_float_list_from_string():
-    assert [1.0, 2.0, 3.0] == get_float_list_from_string("[ 1, 2., 3]")
-    assert [[1.0, 2.0], [3.0, 4.0]] == get_float_list_from_string("[[ 1, 2.],[  3, 4]]")
-    assert [[1.0, 2.0], [3.0, 4.0]] == get_float_list_from_string("[[ 1,\n 2.],\n[  3, 4]]\n")
-    assert [1.0, 2.0, 3.0] == get_float_list_from_string(" 1, 2., 3")
-    assert [1.0, 2.0] == get_float_list_from_string(" 1 2 ")
-    assert [1.0] == get_float_list_from_string(" 1     ")
+    assert get_float_list_from_string("[ 1, 2., 3]") == [1.0, 2.0, 3.0]
+    assert get_float_list_from_string("[[ 1, 2.],[  3, 4]]") == [[1.0, 2.0], [3.0, 4.0]]
+    assert get_float_list_from_string("[[ 1,\n 2.],\n[  3, 4]]\n") == [[1.0, 2.0], [3.0, 4.0]]
+    assert get_float_list_from_string(" 1, 2., 3") == [1.0, 2.0, 3.0]
+    assert get_float_list_from_string(" 1 2 ") == [1.0, 2.0]
+    assert get_float_list_from_string(" 1     ") == [1.0]
     assert get_float_list_from_string(" dummy ") is None
     assert get_float_list_from_string("") is None

--- a/src/fastoad/cmd/cli.py
+++ b/src/fastoad/cmd/cli.py
@@ -41,7 +41,7 @@ from . import api
 NOTEBOOK_FOLDER_NAME = "FAST-OAD_notebooks"
 
 
-@click.group(context_settings=dict(help_option_names=["-h", "--help"]))
+@click.group(context_settings={"help_option_names": ["-h", "--help"]})
 @click.version_option(fastoad.__version__, "-v", "--version")
 def fast_oad():
     """FAST-OAD main program"""

--- a/src/fastoad/cmd/tests/test_cli.py
+++ b/src/fastoad/cmd/tests/test_cli.py
@@ -48,16 +48,16 @@ def test_plugin_info(with_dummy_plugins):
     assert result.exit_code == 0
 
     expected_info = pd.DataFrame(
-        dict(
-            installed_package=[f"dummy-dist-{i}" for i in [1, 2, 3]],
-            has_models=[False, True, True],
-            has_notebooks=[True, False, True],
-            configurations=[
+        {
+            "installed_package": [f"dummy-dist-{i}" for i in [1, 2, 3]],
+            "has_models": [False, True, True],
+            "has_notebooks": [True, False, True],
+            "configurations": [
                 ["dummy_conf_1-1.yml"],
                 ["dummy_conf_2-1.yml", "dummy_conf_3-1.yml", "dummy_conf_3-2.yaml"],
                 [],
             ],
-            source_data_files=[
+            "source_data_files": [
                 ["dummy_source_data_4-1.xml"],
                 [
                     "dummy_source_data_3-1.xml",
@@ -66,7 +66,7 @@ def test_plugin_info(with_dummy_plugins):
                 ],
                 [],
             ],
-        )
+        }
     )
     assert result.output == expected_info.to_markdown(index=False) + "\n"
 

--- a/src/fastoad/exceptions.py
+++ b/src/fastoad/exceptions.py
@@ -46,7 +46,7 @@ class FastUnknownEngineSettingError(FastError):
     """
 
 
-class FastUnexpectedKeywordArgument(FastError):
+class FastUnexpectedKeywordArgumentError(FastError):
     """
     Raised when an instantiation is done with an incorrect keyword argument.
     """

--- a/src/fastoad/gui/analysis_and_plots.py
+++ b/src/fastoad/gui/analysis_and_plots.py
@@ -59,14 +59,11 @@ def wing_geometry_plot(
     mean_aerodynamic_chord = variables["data:geometry:wing:MAC:length"].value[0]
     mac25_x_position = variables["data:geometry:wing:MAC:at25percent:x"].value[0]
     distance_root_mac_chords = variables["data:geometry:wing:MAC:leading_edge:x:local"].value[0]
-    # pylint: disable=invalid-name # that's a common naming
     y = np.array(
         [0, wing_root_y, wing_kink_y, wing_tip_y, wing_tip_y, wing_kink_y, wing_root_y, 0, 0]
     )
-    # pylint: disable=invalid-name # that's a common naming
     y = np.concatenate((-y, y))
 
-    # pylint: disable=invalid-name # that's a common naming
     x = np.array(
         [
             0,
@@ -82,7 +79,6 @@ def wing_geometry_plot(
     )
 
     x = x + mac25_x_position - 0.25 * mean_aerodynamic_chord - distance_root_mac_chords
-    # pylint: disable=invalid-name # that's a common naming
     x = np.concatenate((x, x))
 
     if fig is None:
@@ -92,7 +88,7 @@ def wing_geometry_plot(
 
     fig.add_trace(scatter)
 
-    fig.layout = go.Layout(yaxis=dict(scaleanchor="x", scaleratio=1))
+    fig.layout = go.Layout(yaxis={"scaleanchor": "x", "scaleratio": 1})
 
     fig = go.FigureWidget(fig)
 
@@ -204,14 +200,10 @@ def aircraft_geometry_plot(
     x_wing = x_wing + wing_25mac_x - 0.25 * wing_mac_length - local_wing_mac_le_x
     x_ht = x_ht + wing_25mac_x + ht_distance_from_wing - local_ht_25mac_x
 
-    # pylint: disable=invalid-name # that's a common naming
     x = np.concatenate((x_fuselage, x_wing, x_ht))
-    # pylint: disable=invalid-name # that's a common naming
     y = np.concatenate((y_fuselage, y_wing, y_ht))
 
-    # pylint: disable=invalid-name # that's a common naming
     y = np.concatenate((-y, y))
-    # pylint: disable=invalid-name # that's a common naming
     x = np.concatenate((x, x))
 
     if fig is None:
@@ -221,7 +213,7 @@ def aircraft_geometry_plot(
 
     fig.add_trace(scatter)
 
-    fig.layout = go.Layout(yaxis=dict(scaleanchor="x", scaleratio=1))
+    fig.layout = go.Layout(yaxis={"scaleanchor": "x", "scaleratio": 1})
 
     fig = go.FigureWidget(fig)
 
@@ -247,14 +239,13 @@ def drag_polar_plot(
     """
     variables = VariableIO(aircraft_file_path, file_formatter).read()
 
-    # pylint: disable=invalid-name # that's a common naming
     cd = np.asarray(variables["data:aerodynamics:aircraft:cruise:CD"].value)
-    # pylint: disable=invalid-name # that's a common naming
     cl = np.asarray(variables["data:aerodynamics:aircraft:cruise:CL"].value)
 
     # TODO: remove filtering one models provide proper bounds
-    cd_short = cd[cd <= 2.0]
-    cl_short = cl[cd <= 2.0]
+    CD_UPPER = 2.0
+    cd_short = cd[cd <= CD_UPPER]
+    cl_short = cl[cd <= CD_UPPER]
 
     if fig is None:
         fig = go.Figure()
@@ -301,7 +292,6 @@ def mass_breakdown_bar_plot(
         "data:weight:aircraft:sizing_onboard_fuel_at_input_weight": "kg",
     }
 
-    # pylint: disable=unbalanced-tuple-unpacking # It is balanced for the parameters provided
     mtow, owe, payload, fuel_mission = _get_variable_values_with_new_units(
         variables, var_names_and_new_units
     )
@@ -416,7 +406,7 @@ def _get_TOW_sunburst_plot(variables: VariableList, input_mass_name, mission_nam
         if mission_tow_var not in variables.names():  # Check if the provided mission_name exists
             raise ValueError(
                 f"The provided mission_name {mission_name} does not correspond to an existing "
-                + "mission. The available mission(s) are: {missions_set}."
+                "mission. The available mission(s) are: {missions_set}."
             )
         payload_var_name = f"data:mission:{mission_name}:payload"
         if payload_var_name not in variables.names():  # If mission_name is a sizing mission
@@ -485,7 +475,7 @@ def _get_OWE_sunburst_plot(variables: VariableList):
     sub_categories_parent = []
     for variable in variables.names():
         name_split = variable.split(":")
-        if isinstance(name_split, list) and len(name_split) >= 5:
+        if isinstance(name_split, list) and len(name_split) >= 5:  # noqa: PLR2004
             parent_name = name_split[2]
             if parent_name in categories_names and name_split[-1] == "mass":
                 variable_name = "_".join(name_split[3:-1])
@@ -563,7 +553,7 @@ def payload_range_plot(
         x=convert_units(range_, "m", "NM"),
         y=convert_units(payload, "kg", "t"),
         mode="lines+markers",
-        line=dict(color="black", width=3),
+        line={"color": "black", "width": 3},
         showlegend=False,
         name=name,
     )
@@ -576,7 +566,7 @@ def payload_range_plot(
         x=convert_units(range_mask, "m", "NM"),
         y=convert_units(payload_mask, "kg", "t"),
         mode="lines",
-        line=dict(color="#E5ECF6", width=3),
+        line={"color": "#E5ECF6", "width": 3},
         showlegend=False,
         name=name,
         fill="toself",
@@ -616,13 +606,13 @@ def payload_range_plot(
                 x=x,
                 y=y,
                 z=z,
-                contours=dict(start=min_z, end=max_z, size=(max_z - min_z) / 20),
-                colorbar=dict(
-                    title=f"{variable_of_interest_legend} [{variable_of_interest_unit}]",
-                    titleside="right",
-                    titlefont=dict(size=15, family="Arial, sans-serif"),
-                    tickformat=".1e",
-                ),
+                contours={"start": min_z, "end": max_z, "size": (max_z - min_z) / 20},
+                colorbar={
+                    "title": f"{variable_of_interest_legend} [{variable_of_interest_unit}]",
+                    "titleside": "right",
+                    "titlefont": {"size": 15, "family": "Arial, sans-serif"},
+                    "tickformat": ".1e",
+                },
                 colorscale="RdBu_r",
                 contours_coloring="heatmap",
             )
@@ -682,21 +672,24 @@ def _data_weight_decomposition(variables: VariableList, owe=None):
     owe_subcategory_names = []
     for variable in variables.names():
         name_split = variable.split(":")
-        if isinstance(name_split, list) and len(name_split) == 4:
-            if (
+        if (
+            isinstance(name_split, list)
+            and len(name_split) == 4  # noqa: PLR2004
+            and (
                 name_split[0] + name_split[1] + name_split[3] == "dataweightmass"
                 and "aircraft" not in name_split[2]
-            ):
-                category_values.append(
-                    convert_units(variables[variable].value[0], variables[variable].units, "kg")
+            )
+        ):
+            category_values.append(
+                convert_units(variables[variable].value[0], variables[variable].units, "kg")
+            )
+            category_names.append(name_split[2])
+            if owe:
+                owe_subcategory_names.append(
+                    _get_sunburst_mass_label(
+                        name_split[2], variables[variable].value[0], parent_value=owe
+                    ),
                 )
-                category_names.append(name_split[2])
-                if owe:
-                    owe_subcategory_names.append(
-                        _get_sunburst_mass_label(
-                            name_split[2], variables[variable].value[0], parent_value=owe
-                        ),
-                    )
     if owe:
         result = category_values, category_names, owe_subcategory_names
     else:

--- a/src/fastoad/gui/exceptions.py
+++ b/src/fastoad/gui/exceptions.py
@@ -17,5 +17,5 @@ Exception for GUI
 from fastoad.exceptions import FastError
 
 
-class FastMissingFile(FastError):
+class FastMissingFileError(FastError):
     """Raised when a file does not exist"""

--- a/src/fastoad/gui/mission_viewer.py
+++ b/src/fastoad/gui/mission_viewer.py
@@ -101,7 +101,6 @@ class MissionViewer:
 
         return display(toolbar, self._output_widget)  # UI
 
-    # pylint: disable=unused-argument # change has to be there for observe() to work
     def _show_plot(self, change=None, layout_dict=None, *, layout_overwrite=False, **kwargs):
         """
         Updates and shows the plots
@@ -124,9 +123,7 @@ class MissionViewer:
             for mission_name in self.missions:
                 if fig is None:
                     fig = go.Figure()
-                # pylint: disable=invalid-name # that's a common naming
                 x = self.missions[mission_name][x_name]
-                # pylint: disable=invalid-name # that's a common naming
                 y = self.missions[mission_name][y_name]
 
                 scatter = go.Scatter(x=x, y=y, mode="lines", name=mission_name)

--- a/src/fastoad/gui/tests/test_analysis_and_plots.py
+++ b/src/fastoad/gui/tests/test_analysis_and_plots.py
@@ -149,15 +149,19 @@ def test_mass_breakdown_sun_plot_specific_mission():
 
     # Plot 1
     # Specific mission plot
-    f = mass_breakdown_sun_plot(filename, mission_name=mission_1)
-    # f.show()
+    mass_breakdown_sun_plot(filename, mission_name=mission_1)
+    # Debug
+    # f = mass_breakdown_sun_plot(filename, mission_name=mission_1)  # noqa: ERA001
+    # f.show()  # noqa: ERA001
 
     mission_2 = "MTOW_mission"
 
     # Plot 2
     # Specific mission plot (sizing mission)
-    f = mass_breakdown_sun_plot(filename, mission_name=mission_2)  # noqa: F841
-    # f.show()
+    mass_breakdown_sun_plot(filename, mission_name=mission_2)
+    # Debug
+    # f = mass_breakdown_sun_plot(filename, mission_name=mission_2)  # noqa: ERA001
+    # f.show()  # noqa: ERA001
 
     mission_3 = "not_a_mission_name"
 

--- a/src/fastoad/gui/tests/test_optimization_viewer.py
+++ b/src/fastoad/gui/tests/test_optimization_viewer.py
@@ -23,7 +23,7 @@ from fastoad.cmd import api
 from fastoad.io.configuration.configuration import FASTOADProblemConfigurator
 
 from .. import OptimizationViewer
-from ..exceptions import FastMissingFile
+from ..exceptions import FastMissingFileError
 
 DATA_FOLDER_PATH = Path(__file__).parent / "data"
 RESULTS_FOLDER_PATH = Path(__file__).parent / "results"
@@ -46,7 +46,7 @@ def test_optimization_viewer_load(cleanup):
     optim_viewer = OptimizationViewer()
 
     # No input file exists
-    with pytest.raises(FastMissingFile):
+    with pytest.raises(FastMissingFileError):
         optim_viewer.load(problem_configuration)
 
     api.generate_inputs(filename, DATA_FOLDER_PATH / "inputs.xml", overwrite=True)

--- a/src/fastoad/gui/tests/test_variable_viewer.py
+++ b/src/fastoad/gui/tests/test_variable_viewer.py
@@ -38,7 +38,6 @@ def test_variable_reader_display():
     """
     filename = DATA_FOLDER_PATH / "problem_outputs.xml"
 
-    # pylint: disable=invalid-name # that's a common naming
     df = VariableViewer()
     df.load(filename)
 

--- a/src/fastoad/io/configuration/configuration.py
+++ b/src/fastoad/io/configuration/configuration.py
@@ -194,7 +194,7 @@ class FASTOADProblemConfigurator:
 
         # Issue a simple warning for unknown keys at root level
         for key in self._data:
-            if key not in json_schema["properties"].keys():
+            if key not in json_schema["properties"]:
                 _LOGGER.warning('Configuration file: "%s" is not a FAST-OAD key.', key)
 
         # Looking for modules to register
@@ -276,7 +276,7 @@ class FASTOADProblemConfigurator:
         """
         subpart = {}
         for key, value in optimization_definition.items():
-            subpart[key] = [value for _, value in optimization_definition[key].items()]
+            subpart[key] = [val for _, val in value.items()]
         subpart = {"optimization": subpart}
         self._data.update(subpart)
 
@@ -463,15 +463,13 @@ class FASTOADProblemConfigurator:
             _LOGGER.error(log_err)
             raise log_err
 
-    def _parse_problem_table(self, group: om.Group, table: dict):
+    def _parse_problem_table(self, group: om.Group, table: dict):  # noqa: PLR0912
         """
         Feeds provided *group*, using definition in provided TOML *table*.
 
         :param group:
         :param table:
         """
-        # assert isinstance(table, dict), "table should be a dictionary"
-
         for key, value in table.items():
             if isinstance(value, dict):  # value defines a sub-component
                 if KEY_COMPONENT_ID in value:
@@ -500,7 +498,7 @@ class FASTOADProblemConfigurator:
                 # value may have to be literally interpreted
                 if key.endswith(("solver", "driver")):
                     try:
-                        value = self._om_eval(str(value))
+                        value = self._om_eval(str(value))  # noqa: PLW2901
                     except Exception as err:
                         raise FASTConfigurationBadOpenMDAOInstructionError(err, key, value)
 
@@ -600,7 +598,7 @@ class FASTOADProblemConfigurator:
             raise ValueError(
                 "No double underscore allowed in evaluated string for security reasons"
             )
-        return eval(string_to_eval, {"__builtins__": {}}, {"om": om, **self._imported_classes})
+        return eval(string_to_eval, {"__builtins__": {}}, {"om": om, **self._imported_classes})  # noqa: S307
 
 
 class _IDictSerializer(ABC):

--- a/src/fastoad/io/configuration/tests/test_configuration.py
+++ b/src/fastoad/io/configuration/tests/test_configuration.py
@@ -206,7 +206,10 @@ def test_problem_definition_with_xml_ref(cleanup, caplog):
 
 
 def test_problem_definition_with_xml_ref_with_indep(cleanup):
-    """Tests what happens when writing inputs of a problem with indeps using data from existing XML file"""
+    """
+    Tests what happens when writing inputs of a problem with indeps using data from existing XML
+    file
+    """
     for extension in ["toml", "yml"]:
         clear_openmdao_registry()
         conf = FASTOADProblemConfigurator(DATA_FOLDER_PATH / f"valid_sellar_with_indep.{extension}")
@@ -448,8 +451,8 @@ def test_imports_handling(added_sys_path):
 
     # Imports are done here to be sure the interpreter does not know
     # these paths when the code above is run.
-    from .data.to_be_imported.my_driver_1 import MyDriver1
-    from .data.to_be_imported.my_driver_2 import MyDriver2
+    from .data.to_be_imported.my_driver_1 import MyDriver1  # noqa: PLC0415
+    from .data.to_be_imported.my_driver_2 import MyDriver2  # noqa: PLC0415
 
     assert conf._imported_classes["MyDriver1"] == MyDriver1
     assert conf._imported_classes["MyDriver2"] == MyDriver2

--- a/src/fastoad/io/variable_io.py
+++ b/src/fastoad/io/variable_io.py
@@ -41,7 +41,7 @@ class VariableIO:
     def __init__(
         self,
         data_source: str | PathLike | IO | None,
-        formatter: IVariableIOFormatter = None,
+        formatter: IVariableIOFormatter | None = None,
     ):
         if isinstance(data_source, (str, PathLike)):
             data_source = as_path(data_source)
@@ -57,7 +57,7 @@ class VariableIO:
         return self._formatter
 
     @formatter.setter
-    def formatter(self, formatter: IVariableIOFormatter):
+    def formatter(self, formatter: IVariableIOFormatter | None):
         self._formatter = formatter if formatter else VariableXmlStandardFormatter()
 
     def read(self, only: list[str] | None = None, ignore: list[str] | None = None) -> VariableList:
@@ -159,7 +159,7 @@ class DataFile(VariableList):
     def __init__(
         self,
         data_source: str | PathLike | IO | list | None = None,
-        formatter: IVariableIOFormatter = None,
+        formatter: IVariableIOFormatter | None = None,
         load_data: bool = True,  # noqa: FBT001, FBT002 no breaking changes in API functions
     ):
         """
@@ -227,7 +227,7 @@ class DataFile(VariableList):
     def save_as(
         self,
         file_path: str | PathLike,
-        formatter: IVariableIOFormatter = None,
+        formatter: IVariableIOFormatter | None = None,
         overwrite=False,  # noqa: FBT002 no breaking changes in API functions
     ):
         """

--- a/src/fastoad/io/xml/exceptions.py
+++ b/src/fastoad/io/xml/exceptions.py
@@ -22,13 +22,13 @@ class FastXPathEvalError(FastError):
     """
 
 
-class FastXpathTranslatorInconsistentLists(FastError):
+class FastXpathTranslatorInconsistentListsError(FastError):
     """
     Raised when list of variable names and list of XPaths have not the same length
     """
 
 
-class FastXpathTranslatorDuplicates(FastError):
+class FastXpathTranslatorDuplicatesError(FastError):
     """
     Raised when list of variable names or list of XPaths have duplicate entries
     """

--- a/src/fastoad/io/xml/tests/test_translator.py
+++ b/src/fastoad/io/xml/tests/test_translator.py
@@ -19,8 +19,8 @@ from pathlib import Path
 import pytest
 
 from ..exceptions import (
-    FastXpathTranslatorDuplicates,
-    FastXpathTranslatorInconsistentLists,
+    FastXpathTranslatorDuplicatesError,
+    FastXpathTranslatorInconsistentListsError,
     FastXpathTranslatorVariableError,
     FastXpathTranslatorXPathError,
 )
@@ -39,7 +39,7 @@ def test_translator_with_set():
 
     # test with lists of different lengths -> error
     var_list2 = ["var0", *var_list]
-    with pytest.raises(FastXpathTranslatorInconsistentLists):
+    with pytest.raises(FastXpathTranslatorInconsistentListsError):
         translator.set(var_list2, xpath_list)
 
     # test with duplicate var names -> error
@@ -47,7 +47,7 @@ def test_translator_with_set():
     other_xpaths = ["xpath42", "xpath404", "xpath0"]
     var_list3 = var_list + duplicate_vars
     xpath_list3 = xpath_list + other_xpaths
-    with pytest.raises(FastXpathTranslatorDuplicates) as exc_info:
+    with pytest.raises(FastXpathTranslatorDuplicatesError) as exc_info:
         translator.set(var_list3, xpath_list3)
     assert exc_info.value.args[1] == set(duplicate_vars)
 
@@ -56,7 +56,7 @@ def test_translator_with_set():
     duplicate_xpaths = ["xpath5", "xpath2"]
     var_list4 = var_list + other_vars
     xpath_list4 = xpath_list + duplicate_xpaths
-    with pytest.raises(FastXpathTranslatorDuplicates) as exc_info:
+    with pytest.raises(FastXpathTranslatorDuplicatesError) as exc_info:
         translator.set(var_list4, xpath_list4)
     assert exc_info.value.args[1] == set(duplicate_xpaths)
 

--- a/src/fastoad/io/xml/tests/test_variable_io_base.py
+++ b/src/fastoad/io/xml/tests/test_variable_io_base.py
@@ -35,7 +35,7 @@ def cleanup():
     shutil.rmtree(RESULTS_FOLDER_PATH, ignore_errors=True)
 
 
-def _check_basic_vars(outputs: VariableList):
+def _check_basic_variables(outputs: VariableList):
     """Checks that provided IndepVarComp instance matches content of data/custom.xml file"""
 
     assert len(outputs) == 5
@@ -82,14 +82,14 @@ def test_custom_xml_read_and_write_from_ivc(cleanup):
     translator = VarXpathTranslator(variable_names=var_names, xpaths=xpaths)
     xml_read = VariableIO(file_path, formatter=VariableXmlBaseFormatter(translator))
     var_list = xml_read.read()
-    _check_basic_vars(var_list)
+    _check_basic_variables(var_list)
 
     # test with a non-exhaustive translation table (missing variable name in the translator)
     # we expect that the variable is not included in the ivc
     file_path = DATA_FOLDER_PATH / "custom_additional_var.xml"
     xml_read = VariableIO(file_path, formatter=VariableXmlBaseFormatter(translator))
     var_list = xml_read.read()
-    _check_basic_vars(var_list)
+    _check_basic_variables(var_list)
 
     # test with setting a translation with an additional var not present in the xml
     file_path = DATA_FOLDER_PATH / "custom.xml"
@@ -102,7 +102,7 @@ def test_custom_xml_read_and_write_from_ivc(cleanup):
         ),
     )
     var_list = xml_read.read()
-    _check_basic_vars(var_list)
+    _check_basic_variables(var_list)
 
     # Check using text file object --------------------
     with Path.open(file_path) as text_file_io:
@@ -127,7 +127,7 @@ def test_custom_xml_read_and_write_from_ivc(cleanup):
     translator.set(var_names, xpaths)
     xml_check = VariableIO(new_filename, formatter=VariableXmlBaseFormatter(translator))
     new_ivc = xml_check.read()
-    _check_basic_vars(new_ivc)
+    _check_basic_variables(new_ivc)
 
 
 def test_custom_xml_read_and_write_with_translation_table(cleanup):
@@ -142,12 +142,12 @@ def test_custom_xml_read_and_write_with_translation_table(cleanup):
     filename = DATA_FOLDER_PATH / "custom.xml"
     translator = VarXpathTranslator(source=DATA_FOLDER_PATH / "custom_translation.txt")
     xml_read = VariableIO(filename, formatter=VariableXmlBaseFormatter(translator))
-    vars = xml_read.read()
-    _check_basic_vars(vars)
+    variables = xml_read.read()
+    _check_basic_variables(variables)
 
     new_filename = result_folder / "custom.xml"
     xml_write = VariableIO(new_filename, formatter=VariableXmlBaseFormatter(translator))
-    xml_write.write(vars)
+    xml_write.write(variables)
 
 
 def test_custom_xml_read_and_write_with_only_or_ignore(cleanup):

--- a/src/fastoad/io/xml/tests/test_variable_io_standard.py
+++ b/src/fastoad/io/xml/tests/test_variable_io_standard.py
@@ -37,59 +37,59 @@ def cleanup():
     shutil.rmtree(RESULTS_FOLDER_PATH, ignore_errors=True)
 
 
-def _check_basic_vars(vars: VariableList):
+def _check_basic_variables(variables: VariableList):
     """Checks that provided IndepVarComp instance matches content of data/basic.xml file"""
 
     # Using pytest.approx for numerical reason, but also because it works even if sequence types
     # are different (lists, tuples, numpy arrays)
-    assert_allclose(780.3, vars["geometry:total_surface"].value)
-    assert vars["geometry:total_surface"].units == "m**2"
-    assert vars["geometry:total_surface"].description == "scalar 1"
+    assert_allclose(780.3, variables["geometry:total_surface"].value)
+    assert variables["geometry:total_surface"].units == "m**2"
+    assert variables["geometry:total_surface"].description == "scalar 1"
 
-    assert_allclose(42, vars["geometry:wing:span"].value)
-    assert vars["geometry:wing:span"].units == "m"
-    assert vars["geometry:wing:span"].description == "scalar 2"
+    assert_allclose(42, variables["geometry:wing:span"].value)
+    assert variables["geometry:wing:span"].units == "m"
+    assert variables["geometry:wing:span"].description == "scalar 2"
 
-    assert_allclose(9.8, vars["geometry:wing:aspect_ratio"].value)
-    assert vars["geometry:wing:aspect_ratio"].units is None
-    assert vars["geometry:wing:aspect_ratio"].description == ""
+    assert_allclose(9.8, variables["geometry:wing:aspect_ratio"].value)
+    assert variables["geometry:wing:aspect_ratio"].units is None
+    assert variables["geometry:wing:aspect_ratio"].description == ""
 
-    assert_allclose(40.0, vars["geometry:fuselage:length"].value)
-    assert vars["geometry:fuselage:length"].units == "m"
-    assert vars["geometry:fuselage:length"].description == ""
+    assert_allclose(40.0, variables["geometry:fuselage:length"].value)
+    assert variables["geometry:fuselage:length"].units == "m"
+    assert variables["geometry:fuselage:length"].description == ""
 
-    assert_allclose(-42.0, vars["constants"].value)
-    assert vars["constants"].units is None
-    assert vars["constants"].description == "value with children tags"
+    assert_allclose(-42.0, variables["constants"].value)
+    assert variables["constants"].units is None
+    assert variables["constants"].description == "value with children tags"
 
-    assert_allclose([1.0, 2.0, 3.0], vars["constants:k1"].value)
-    assert vars["constants:k1"].units == "kg"
-    assert vars["constants:k1"].description == ""
+    assert_allclose([1.0, 2.0, 3.0], variables["constants:k1"].value)
+    assert variables["constants:k1"].units == "kg"
+    assert variables["constants:k1"].description == ""
 
-    assert_allclose([10.0, 20.0], vars["constants:k2"].value)
-    assert vars["constants:k2"].units is None
-    assert vars["constants:k2"].description == ""
+    assert_allclose([10.0, 20.0], variables["constants:k2"].value)
+    assert variables["constants:k2"].units is None
+    assert variables["constants:k2"].description == ""
 
-    assert_allclose([100.0, 200.0, 300.0, 400.0], vars["constants:k3"].value)
-    assert vars["constants:k3"].units == "m/s"
-    assert vars["constants:k3"].description == "value list, space-separated"
+    assert_allclose([100.0, 200.0, 300.0, 400.0], variables["constants:k3"].value)
+    assert variables["constants:k3"].units == "m/s"
+    assert variables["constants:k3"].description == "value list, space-separated"
 
-    assert_allclose([-1, -2, -3], vars["constants:k4"].value)
-    assert vars["constants:k4"].units is None
-    assert vars["constants:k4"].description == "value list, brackets + comma-separated"
+    assert_allclose([-1, -2, -3], variables["constants:k4"].value)
+    assert variables["constants:k4"].units is None
+    assert variables["constants:k4"].description == "value list, brackets + comma-separated"
 
-    assert_allclose([100, 200, 400, 500, 600], vars["constants:k5"].value)
-    assert vars["constants:k5"].units is None
-    assert vars["constants:k5"].description == "value list, comma-separated"
+    assert_allclose([100, 200, 400, 500, 600], variables["constants:k5"].value)
+    assert variables["constants:k5"].units is None
+    assert variables["constants:k5"].description == "value list, comma-separated"
 
-    assert_allclose([[1e2, 3.4e5], [5.4e3, 2.1]], vars["constants:k8"].value)
-    assert vars["constants:k8"].units is None
-    assert vars["constants:k8"].description == "2D list"
+    assert_allclose([[1e2, 3.4e5], [5.4e3, 2.1]], variables["constants:k8"].value)
+    assert variables["constants:k8"].units is None
+    assert variables["constants:k8"].description == "2D list"
 
-    assert len(vars) == 11
+    assert len(variables) == 11
 
 
-def test_basic_xml_read_and_write_from_vars(cleanup):
+def test_basic_xml_read_and_write_from_variables(cleanup):
     """
     Tests the creation of an XML file from a VariableList instance
     """
@@ -130,14 +130,14 @@ def test_basic_xml_read_and_write_from_vars(cleanup):
     xml_check = VariableIO(file_path, formatter=VariableXmlStandardFormatter())
     xml_check.path_separator = ":"
     new_var_list = xml_check.read()
-    _check_basic_vars(new_var_list)
+    _check_basic_variables(new_var_list)
 
     # Check reading hand-made XML (with some format twists)
     file_path = DATA_FOLDER_PATH / "basic.xml"
     xml_read = VariableIO(file_path, formatter=VariableXmlStandardFormatter())
     xml_read.path_separator = ":"
     var_list = xml_read.read()
-    _check_basic_vars(var_list)
+    _check_basic_variables(var_list)
 
     # write it (with existing destination folder)
     new_file_path = result_folder / "basic.xml"
@@ -149,7 +149,7 @@ def test_basic_xml_read_and_write_from_vars(cleanup):
     xml_check = VariableIO(new_file_path, formatter=VariableXmlStandardFormatter())
     xml_check.path_separator = ":"
     new_var_list = xml_check.read()
-    _check_basic_vars(new_var_list)
+    _check_basic_variables(new_var_list)
 
     # try to write with bad separator
     xml_write.formatter.path_separator = "/"
@@ -167,7 +167,7 @@ def test_basic_xml_read_and_write_from_vars(cleanup):
     assert var_list_3 == var_list
 
 
-def test_basic_xml_partial_read_and_write_from_vars(cleanup):
+def test_basic_xml_partial_read_and_write_from_variables(cleanup):
     """
     Tests the creation of an XML file from an IndepVarComp instance with only and ignore options
     """
@@ -176,16 +176,18 @@ def test_basic_xml_partial_read_and_write_from_vars(cleanup):
     # Read full IndepVarComp
     filename = DATA_FOLDER_PATH / "basic.xml"
     xml_read = VariableIO(filename, formatter=VariableXmlStandardFormatter())
-    vars = xml_read.read(ignore=["does_not_exist"])
-    _check_basic_vars(vars)
+    variables = xml_read.read(ignore=["does_not_exist"])
+    _check_basic_variables(variables)
 
     # Add something to ignore and write it
-    vars["should_be_ignored:pointless"] = {"value": 0.0}
-    vars["should_also_be_ignored"] = {"value": -10.0}
+    variables["should_be_ignored:pointless"] = {"value": 0.0}
+    variables["should_also_be_ignored"] = {"value": -10.0}
 
     badvar_filename = result_folder / "with_bad_var.xml"
     xml_write = VariableIO(badvar_filename, formatter=VariableXmlStandardFormatter())
-    xml_write.write(vars, ignore=["does_not_exist"])  # Check with non-existent var in ignore list
+    xml_write.write(
+        variables, ignore=["does_not_exist"]
+    )  # Check with non-existent var in ignore list
 
     tree = etree.parse(badvar_filename.as_posix())
     assert float(tree.xpath("should_be_ignored/pointless")[0].text.strip()) == 0.0
@@ -193,11 +195,11 @@ def test_basic_xml_partial_read_and_write_from_vars(cleanup):
 
     # Check partial reading with 'ignore'
     xml_read = VariableIO(badvar_filename, formatter=VariableXmlStandardFormatter())
-    new_vars = xml_read.read(ignore=["should_be_ignored:pointless", "should_also_be_ignored"])
-    _check_basic_vars(new_vars)
+    new_variables = xml_read.read(ignore=["should_be_ignored:pointless", "should_also_be_ignored"])
+    _check_basic_variables(new_variables)
 
     # Check partial reading with 'only'
-    ok_vars = [
+    ok_variables = [
         "geometry:total_surface",
         "geometry:wing:span",
         "geometry:wing:aspect_ratio",
@@ -210,23 +212,23 @@ def test_basic_xml_partial_read_and_write_from_vars(cleanup):
         "constants:k5",
         "constants:k8",
     ]
-    new_vars2 = xml_read.read(only=ok_vars)
-    _check_basic_vars(new_vars2)
+    new_variables2 = xml_read.read(only=ok_variables)
+    _check_basic_variables(new_variables2)
 
     # Check partial writing with 'ignore'
     varok_filename = result_folder / "with_bad_var.xml"
     xml_write = VariableIO(varok_filename, formatter=VariableXmlStandardFormatter())
-    xml_write.write(vars, ignore=["should_be_ignored:pointless", "should_also_be_ignored"])
+    xml_write.write(variables, ignore=["should_be_ignored:pointless", "should_also_be_ignored"])
 
     xml_read = VariableIO(varok_filename, formatter=VariableXmlStandardFormatter())
-    new_vars = xml_read.read()
-    _check_basic_vars(new_vars)
+    new_variables = xml_read.read()
+    _check_basic_variables(new_variables)
 
     # Check partial writing with 'only'
     varok2_filename = result_folder / "with_bad_var.xml"
     xml_write = VariableIO(varok2_filename, formatter=VariableXmlStandardFormatter())
-    xml_write.write(vars, only=ok_vars)
+    xml_write.write(variables, only=ok_variables)
 
     xml_read = VariableIO(varok2_filename, formatter=VariableXmlStandardFormatter())
-    new_vars = xml_read.read()
-    _check_basic_vars(new_vars)
+    new_variables = xml_read.read()
+    _check_basic_variables(new_variables)

--- a/src/fastoad/io/xml/translator.py
+++ b/src/fastoad/io/xml/translator.py
@@ -22,8 +22,8 @@ from typing import IO
 import numpy as np
 
 from fastoad.io.xml.exceptions import (
-    FastXpathTranslatorDuplicates,
-    FastXpathTranslatorInconsistentLists,
+    FastXpathTranslatorDuplicatesError,
+    FastXpathTranslatorInconsistentListsError,
     FastXpathTranslatorVariableError,
     FastXpathTranslatorXPathError,
 )
@@ -60,21 +60,22 @@ class VarXpathTranslator:
         :param xpaths: List of XML Paths
         """
         if len(variable_names) != len(xpaths):
-            raise FastXpathTranslatorInconsistentLists(
-                f"lists var_names and xpaths have not the same length ({len(variable_names)} and {len(xpaths)})"
+            raise FastXpathTranslatorInconsistentListsError(
+                f"lists var_names and xpaths have not the same length ({len(variable_names)} "
+                f"and {len(xpaths)})"
             )
 
         # check duplicate variable names
         dupe_vars = self._get_duplicates(variable_names)
         if dupe_vars:
-            raise FastXpathTranslatorDuplicates(
+            raise FastXpathTranslatorDuplicatesError(
                 f"Following variable names are provided more than once: {dupe_vars}", dupe_vars
             )
 
         # check duplicate XPaths
         dupe_xpaths = self._get_duplicates(xpaths)
         if dupe_xpaths:
-            raise FastXpathTranslatorDuplicates(
+            raise FastXpathTranslatorDuplicatesError(
                 f"Following variable names are provided more than once: {dupe_xpaths}",
                 dupe_xpaths,
             )

--- a/src/fastoad/io/xml/variable_io_base.py
+++ b/src/fastoad/io/xml/variable_io_base.py
@@ -29,7 +29,7 @@ from lxml.etree import (
     XPathEvalError,
     _Comment,
     _Element,
-)  # pylint: disable=protected-access  # Useful for type hinting
+)  # Useful for type hinting
 from openmdao.vectors.vector import Vector
 
 from fastoad._utils.files import make_parent_dir

--- a/src/fastoad/model_base/atmosphere.py
+++ b/src/fastoad/model_base/atmosphere.py
@@ -60,7 +60,6 @@ class Atmosphere:
         >>> viscosities = atm.kinematic_viscosity # viscosities for all defined altitudes
     """
 
-    # pylint: disable=too-many-instance-attributes  # Needed for avoiding redoing computations
     def __init__(
         self,
         altitude: float | Sequence[float],

--- a/src/fastoad/model_base/flight_point.py
+++ b/src/fastoad/model_base/flight_point.py
@@ -141,11 +141,9 @@ class FlightPoint:
         default=None, metadata={FIELD_DESCRIPTOR: _FieldDescriptor()}
     )
 
-    # pylint: disable=invalid-name
     #: Lift coefficient.
     CL: float = field(default=None, metadata={FIELD_DESCRIPTOR: _FieldDescriptor(unit="-")})
 
-    # pylint: disable=invalid-name
     #: Drag coefficient.
     CD: float = field(default=None, metadata={FIELD_DESCRIPTOR: _FieldDescriptor(unit="-")})
 

--- a/src/fastoad/model_base/propulsion.py
+++ b/src/fastoad/model_base/propulsion.py
@@ -70,13 +70,14 @@ class IPropulsion(ABC):
               defined one between :code:`thrust_rate` and :code:`thrust` (if both are provided,
               :code:`thrust_rate` will be used)
 
-            - if :code:`thrust_is_regulated` is :code:`True` or :code:`False` (i.e., not a sequence),
-              the considered input will be taken accordingly, and should of course be defined.
+            - if :code:`thrust_is_regulated` is :code:`True` or :code:`False` (i.e., not a
+              sequence), the considered input will be taken accordingly, and should of course
+              be defined.
 
-            - if there are several flight points, :code:`thrust_is_regulated` is a sequence or array,
-              :code:`thrust_rate` and :code:`thrust` should be provided and have the same shape as
-              :code:`thrust_is_regulated:code:`. The method will consider for each element which input
-              will be used according to :code:`thrust_is_regulated`.
+            - if there are several flight points, :code:`thrust_is_regulated` is a sequence or
+              array, :code:`thrust_rate` and :code:`thrust` should be provided and have the same
+              shape as :code:`thrust_is_regulated:code:`. The method will consider for each element
+              which input will be used according to :code:`thrust_is_regulated`.
 
 
         :param flight_points: FlightPoint or DataFrame instance

--- a/src/fastoad/model_base/tests/test_atmosphere.py
+++ b/src/fastoad/model_base/tests/test_atmosphere.py
@@ -157,7 +157,8 @@ def test_speed_conversions():
         [270, 266.0652, 150.4692],
         [400, 394.1707, 222.9173],
     ]
-    # expected_CAS = [  # currently unused
+    # ruff:noqa ERA001
+    # expected_CAS = [  # currently unused TODO erase it
     #     [100.0, 98.5799, 56.3313],
     #     [200.0, 197.3624, 116.1973],
     #     [270, 161.8971, 266.6984],

--- a/src/fastoad/model_base/tests/test_flight_point.py
+++ b/src/fastoad/model_base/tests/test_flight_point.py
@@ -43,7 +43,7 @@ def test_add_remove_field():
 
 
 def test_create():
-    df = pd.DataFrame(dict(time=[0.0, 1.0, 2.0], mach=[0.0, 0.02, 0.05]))
+    df = pd.DataFrame({"time": [0.0, 1.0, 2.0], "mach": [0.0, 0.02, 0.05]})
 
     flight_point = FlightPoint.create(df.iloc[1])
     assert flight_point.time == 1.0
@@ -51,7 +51,7 @@ def test_create():
 
 
 def test_create_list():
-    df = pd.DataFrame(dict(time=[0.0, 1.0, 2.0], mach=[0.0, 0.02, 0.05]))
+    df = pd.DataFrame({"time": [0.0, 1.0, 2.0], "mach": [0.0, 0.02, 0.05]})
 
     flight_points = FlightPoint.create_list(df)
     assert flight_points[0].time == 0.0

--- a/src/fastoad/models/performances/mission/exceptions.py
+++ b/src/fastoad/models/performances/mission/exceptions.py
@@ -12,22 +12,22 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-from fastoad.exceptions import FastError, FastUnexpectedKeywordArgument
+from fastoad.exceptions import FastError, FastUnexpectedKeywordArgumentError
 
 
-class FastFlightSegmentUnexpectedKeywordArgument(FastUnexpectedKeywordArgument):
+class FastFlightSegmentUnexpectedKeywordArgumentError(FastUnexpectedKeywordArgumentError):
     """
     Raised when a segment is instantiated with an incorrect keyword argument.
     """
 
 
-class FastFlightPointUnexpectedKeywordArgument(FastUnexpectedKeywordArgument):
+class FastFlightPointUnexpectedKeywordArgumentError(FastUnexpectedKeywordArgumentError):
     """
     Raised when a FlightPoint is instantiated with an incorrect keyword argument.
     """
 
 
-class FastFlightSegmentIncompleteFlightPoint(FastError):
+class FastFlightSegmentIncompleteFlightPointError(FastError):
     """
     Raised when a segment computation encounters a FlightPoint instance without needed parameters.
     """

--- a/src/fastoad/models/performances/mission/mission.py
+++ b/src/fastoad/models/performances/mission/mission.py
@@ -75,7 +75,7 @@ class Mission(FlightSequence):
     def compute_from(self, start: FlightPoint) -> pd.DataFrame:
         if self.target_fuel_consumption is None:
             self._flight_points = super().compute_from(start)
-            self._flight_points.loc[self._flight_points.name.isnull(), "name"] = ""
+            self._flight_points.loc[self._flight_points.name.isna(), "name"] = ""
             self._compute_reserve(self._flight_points)
         else:
             self._solve_cruise_distance(start)
@@ -152,7 +152,7 @@ class Mission(FlightSequence):
         """
         self.first_route.cruise_distance = cruise_distance
         flight_points = super().compute_from(start)
-        flight_points.loc[flight_points.name.isnull(), "name"] = ""
+        flight_points.loc[flight_points.name.isna(), "name"] = ""
         self._compute_reserve(flight_points)
         self._flight_points = flight_points
         return self.target_fuel_consumption - self.consumed_fuel

--- a/src/fastoad/models/performances/mission/mission_definition/mission_builder/input_definition.py
+++ b/src/fastoad/models/performances/mission/mission_definition/mission_builder/input_definition.py
@@ -20,6 +20,7 @@ from numbers import Number
 
 import numpy as np
 from openmdao import api as om
+from openmdao.vectors.vector import Vector
 
 from fastoad._utils.arrays import scalarize
 from fastoad.model_base import FlightPoint
@@ -172,7 +173,7 @@ class InputDefinition:
                 # We authorize colons next to "~", but we do as they were not present.
                 var_name = var_name.replace(":~", "~").replace("~:", "~")
                 parts = var_name.replace(":~", "~").split("~")
-                if len(parts) > 2:
+                if len(parts) > 2:  # noqa: PLR2004
                     # Hidden feature for now: using a double tilda (~~) will trigger
                     # a replacement by the mission name only
                     # (useful for backward compatibility since we need to provide
@@ -198,7 +199,7 @@ class InputDefinition:
         else:
             self._variable_name = None
 
-    def set_variable_value(self, inputs: Mapping):
+    def set_variable_value(self, inputs: Mapping | Vector):
         """
         Sets numerical value from OpenMDAO inputs.
 
@@ -208,8 +209,8 @@ class InputDefinition:
         """
         if self.variable_name:
             value = scalarize(
-                # Note: OpenMDAO `inputs` object has no `get()` method, so we need to do this:
-                inputs[self.variable_name] if self.variable_name in inputs else self.default_value
+                # Note: OpenMDAO `Vector` object has no `get()` method, so we need to do this:
+                inputs[self.variable_name] if self.variable_name in inputs else self.default_value  # noqa: SIM401
             )
 
             if self._use_opposite:

--- a/src/fastoad/models/performances/mission/mission_definition/mission_builder/mission_builder.py
+++ b/src/fastoad/models/performances/mission/mission_definition/mission_builder/mission_builder.py
@@ -435,7 +435,7 @@ class MissionBuilder:
         for key, value in part_kwargs.items():
             if key == POLAR_TAG:
                 modifier_kwargs = deepcopy(value.get("modifier"))
-                value = Polar(
+                new_value = Polar(
                     cl=value["CL"].value,
                     cd=value["CD"].value,
                     alpha=value["alpha"].value if "alpha" in value else None,
@@ -455,10 +455,14 @@ class MissionBuilder:
                     relative_fields = [
                         param.parameter_name for param in value.values() if param.is_relative
                     ]
-                    value = FlightPoint(**target_parameters)
-                    value.set_as_relative(relative_fields)
+                    new_value = FlightPoint(**target_parameters)
+                    new_value.set_as_relative(relative_fields)
+                else:
+                    new_value = value
+            else:
+                new_value = value
 
-            part_kwargs[key] = value
+            part_kwargs[key] = new_value
 
         self._replace_input_definitions_by_values(part_kwargs)
 

--- a/src/fastoad/models/performances/mission/mission_definition/mission_builder/tests/test_mission_builder.py
+++ b/src/fastoad/models/performances/mission/mission_definition/mission_builder/tests/test_mission_builder.py
@@ -366,15 +366,15 @@ def test_get_reserve(custom_segment_class):
     )
 
     flight_points = pd.DataFrame(
-        dict(
-            mass=[70000, 65000, 55000, 45000],
-            name=[
+        {
+            "mass": [70000, 65000, 55000, 45000],
+            "name": [
                 "data:mission:sizing:main:start",
                 "data:mission:sizing:main:climb",
                 "data:mission:sizing:other:start",
                 "data:mission:sizing:other:climb",
             ],
-        )
+        }
     )
     assert_allclose(mission_builder.get_reserve(flight_points, "sizing"), 5000 * 0.03)
 

--- a/src/fastoad/models/performances/mission/openmdao/base.py
+++ b/src/fastoad/models/performances/mission/openmdao/base.py
@@ -31,7 +31,6 @@ from fastoad.models.performances.mission.openmdao import resources
 from fastoad.models.performances.mission.openmdao.mission_wrapper import MissionWrapper
 
 
-# pylint: disable=too-few-public-methods
 class NeedsOWE(System, metaclass=ABCMeta):
     """To be inherited when Operating Weight Empty variable is used."""
 
@@ -45,7 +44,6 @@ class NeedsOWE(System, metaclass=ABCMeta):
         )
 
 
-# pylint: disable=too-few-public-methods
 class NeedsMTOW(System, metaclass=ABCMeta):
     """To be inherited when Max TakeOff Weight variable is used."""
 
@@ -59,7 +57,6 @@ class NeedsMTOW(System, metaclass=ABCMeta):
         )
 
 
-# pylint: disable=too-few-public-methods
 class NeedsMFW(System, metaclass=ABCMeta):
     """To be inherited when Max Fuel Weight variable is used."""
 

--- a/src/fastoad/models/performances/mission/openmdao/mission_run.py
+++ b/src/fastoad/models/performances/mission/openmdao/mission_run.py
@@ -13,6 +13,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import logging
 from os import PathLike
 
@@ -29,6 +30,8 @@ from ..polar import Polar
 from ..segments.registered.cruise import BreguetCruiseSegment
 
 _LOGGER = logging.getLogger(__name__)  # Logger for this module
+
+DUMMY_MAX_LOD = 10.0  # Used as initial LoD in _get_initial_polar()
 
 
 class MissionComp(om.ExplicitComponent, BaseMissionComp):
@@ -64,10 +67,8 @@ class MissionComp(om.ExplicitComponent, BaseMissionComp):
             self.mission_name
         )
 
-        try:
+        with contextlib.suppress(ValueError):
             self.add_input(self.options["reference_area_variable"], np.nan, units="m**2")
-        except ValueError:
-            pass
 
         # Global mission outputs
         self.add_output(
@@ -224,8 +225,8 @@ class AdvancedMissionComp(MissionComp):
         """
         At computation start, polar may be irrelevant and give a very low lift/drag ratio.
 
-        In that case, this method returns a fake polar that has 10.0 as max lift drag ratio.
-        Otherwise, the actual cruise polar is returned.
+        In that case, this method returns a fake polar that has DUMMY_MAX_LOD as max lift drag
+        ratio. Otherwise, the actual cruise polar is returned.
         """
         high_speed_polar = Polar(
             inputs["data:aerodynamics:aircraft:cruise:CL"],
@@ -235,13 +236,13 @@ class AdvancedMissionComp(MissionComp):
         try:
             if (
                 high_speed_polar.optimal_cl / high_speed_polar.cd(high_speed_polar.optimal_cl)
-                < 10.0
+                < DUMMY_MAX_LOD
             ):
                 use_minimum_l_d_ratio = True
         except ZeroDivisionError:
             use_minimum_l_d_ratio = True
         if use_minimum_l_d_ratio:
-            # We replace by a polar that has at least 10.0 as max L/D ratio
+            # We replace by a polar that has at least DUMMY_MAX_LOD as max L/D ratio
             high_speed_polar = Polar(np.array([0.0, 0.5, 1.0]), np.array([0.1, 0.05, 1.0]))
 
         return high_speed_polar

--- a/src/fastoad/models/performances/mission/openmdao/tests/test_mission.py
+++ b/src/fastoad/models/performances/mission/openmdao/tests/test_mission.py
@@ -36,8 +36,9 @@ def cleanup():
 
 
 def plot_flight(flight_points, fig_filename):
-    from matplotlib import pyplot as plt
-    from matplotlib.ticker import MultipleLocator
+    # This function is used only for debug, so lazy imports are accepted
+    from matplotlib import pyplot as plt  # noqa: PLC0415
+    from matplotlib.ticker import MultipleLocator  # noqa: PLC0415
 
     plt.figure(figsize=(12, 12))
     ax1 = plt.subplot(2, 1, 1)
@@ -108,7 +109,8 @@ def test_mission_component(cleanup, with_dummy_plugin_2):
         ),
         ivc,
     )
-    # plot_flight(problem.model.component.flight_points, "test_mission.png")
+    # Useful for debugging
+    # plot_flight(problem.model.component.flight_points, "test_mission.png")  # noqa: ERA001
 
     # Note: tested value are obtained by asking 1 meter of accuracy for distance routes
     assert_allclose(problem["data:mission:operational:taxi_out:fuel"], 100.0, atol=1.0)
@@ -160,8 +162,8 @@ def test_mission_component(cleanup, with_dummy_plugin_2):
 
 def test_mission_component_breguet(cleanup, with_dummy_plugin_2):
     input_file_path = DATA_FOLDER_PATH / "test_mission.xml"
-    vars = DataFile(input_file_path)
-    ivc = vars.to_ivc()
+    variables = DataFile(input_file_path)
+    ivc = variables.to_ivc()
     ivc.add_output("data:mission:operational:ramp_weight", 70100.0, units="kg")
 
     problem = run_system(
@@ -177,7 +179,8 @@ def test_mission_component_breguet(cleanup, with_dummy_plugin_2):
         ),
         ivc,
     )
-    # plot_flight(problem.model.component.flight_points, "test_mission_component_breguet.png")
+    # Useful for debugging
+    # plot_flight(problem.model.component.flight_points, "test_mission_component_breguet.png")  # noqa: E501, ERA001
     assert_allclose(problem["data:mission:operational:needed_block_fuel"], 6256.0, atol=1.0)
 
     assert_allclose(problem["data:mission:operational:taxi_out:fuel"], 100.0, atol=1.0)
@@ -265,9 +268,9 @@ def test_mission_group_breguet_without_fuel_adjustment(cleanup, with_dummy_plugi
 
 def test_mission_group_with_fuel_adjustment(cleanup, with_dummy_plugin_2):
     input_file_path = DATA_FOLDER_PATH / "test_mission.xml"
-    vars = DataFile(input_file_path)
-    del vars["data:mission:operational:TOW"]
-    ivc = vars.to_ivc()
+    variables = DataFile(input_file_path)
+    del variables["data:mission:operational:TOW"]
+    ivc = variables.to_ivc()
 
     problem = run_system(
         OMMission(
@@ -312,9 +315,9 @@ def test_mission_group_breguet_with_fuel_adjustment(cleanup, with_dummy_plugin_2
     # Also checking behavior when is_sizing is True
 
     input_file_path = DATA_FOLDER_PATH / "test_breguet.xml"
-    vars = DataFile(input_file_path)
-    del vars["data:mission:operational:ramp_weight"]
-    ivc = vars.to_ivc()
+    variables = DataFile(input_file_path)
+    del variables["data:mission:operational:ramp_weight"]
+    ivc = variables.to_ivc()
 
     problem = run_system(
         OMMission(
@@ -357,8 +360,8 @@ def test_mission_group_breguet_with_fuel_adjustment(cleanup, with_dummy_plugin_2
 
 def test_mission_group_with_fuel_objective(cleanup, with_dummy_plugin_2):
     input_file_path = DATA_FOLDER_PATH / "test_mission.xml"
-    vars = DataFile(input_file_path)
-    ivc = vars.to_ivc()
+    variables = DataFile(input_file_path)
+    ivc = variables.to_ivc()
 
     problem = run_system(
         OMMission(
@@ -395,10 +398,10 @@ def test_mission_group_with_fuel_objective(cleanup, with_dummy_plugin_2):
 
 def test_mission_group_with_CL_limitation(cleanup, with_dummy_plugin_2):
     input_file_path = DATA_FOLDER_PATH / "test_mission.xml"
-    vars = DataFile(input_file_path)
+    variables = DataFile(input_file_path)
 
     # Activate CL limitation during cruise and climb
-    vars["data:mission:operational:max_CL"].value = 0.45
+    variables["data:mission:operational:max_CL"].value = 0.45
 
     problem = run_system(
         AdvancedMissionComp(
@@ -411,7 +414,7 @@ def test_mission_group_with_CL_limitation(cleanup, with_dummy_plugin_2):
             ),
             reference_area_variable="data:geometry:aircraft:reference_area",
         ),
-        vars,
+        variables,
     )
 
     flight_points = problem.model.component.flight_points
@@ -419,17 +422,18 @@ def test_mission_group_with_CL_limitation(cleanup, with_dummy_plugin_2):
     CL_end_climb = climb_points.CL.iloc[-1]
     altitude_end_climb = climb_points.altitude.iloc[-1]
 
-    # check CL and flight level, CL is lower than 0.45 because the climb phase stops at the closest flight level.
+    # check CL and flight level, CL is lower than 0.45 because the climb phase stops at
+    # the closest flight level.
     assert_allclose(CL_end_climb, 0.445, atol=1e-3)
     assert_allclose(altitude_end_climb, 9753.6, atol=1e-1)
 
     # Now check climbing cruise with constant CL
-    vars.add_var("data:mission:operational_optimal:max_CL", val=0.45)
-    vars.add_var("data:mission:operational_optimal:taxi_out:thrust_rate", val=0.3)
-    vars.add_var("data:mission:operational_optimal:taxi_out:duration", val=300, units="s")
-    vars.add_var("data:mission:operational_optimal:takeoff:fuel", val=100, units="kg")
-    vars.add_var("data:mission:operational_optimal:takeoff:V2", val=70, units="m/s")
-    vars.add_var("data:mission:operational_optimal:TOW", val=70000, units="kg")
+    variables.add_var("data:mission:operational_optimal:max_CL", val=0.45)
+    variables.add_var("data:mission:operational_optimal:taxi_out:thrust_rate", val=0.3)
+    variables.add_var("data:mission:operational_optimal:taxi_out:duration", val=300, units="s")
+    variables.add_var("data:mission:operational_optimal:takeoff:fuel", val=100, units="kg")
+    variables.add_var("data:mission:operational_optimal:takeoff:V2", val=70, units="m/s")
+    variables.add_var("data:mission:operational_optimal:TOW", val=70000, units="kg")
 
     problem = run_system(
         AdvancedMissionComp(
@@ -442,7 +446,7 @@ def test_mission_group_with_CL_limitation(cleanup, with_dummy_plugin_2):
             ),
             reference_area_variable="data:geometry:aircraft:reference_area",
         ),
-        vars,
+        variables,
     )
 
     flight_points = problem.model.component.flight_points

--- a/src/fastoad/models/performances/mission/openmdao/tests/test_mission_run.py
+++ b/src/fastoad/models/performances/mission/openmdao/tests/test_mission_run.py
@@ -47,7 +47,8 @@ def test_mission_run(cleanup, with_dummy_plugin_2):
         ),
         ivc,
     )
-    # plot_flight(problem.model.component.flight_points, "test_mission.png")
+    # Useful for debugging
+    # plot_flight(problem.model.component.flight_points, "test_mission.png")  # noqa: ERA001
 
     # Note: tested value are obtained by asking 1 meter of accuracy for distance routes
 

--- a/src/fastoad/models/performances/mission/openmdao/tests/test_mission_takeoff.py
+++ b/src/fastoad/models/performances/mission/openmdao/tests/test_mission_takeoff.py
@@ -36,8 +36,9 @@ def cleanup():
 
 
 def plot_flight(flight_points, fig_filename):
-    from matplotlib import pyplot as plt
-    from matplotlib.ticker import MultipleLocator
+    # This function is used only for debug, so lazy imports are accepted
+    from matplotlib import pyplot as plt  # noqa: PLC0415
+    from matplotlib.ticker import MultipleLocator  # noqa: PLC0415
 
     plt.figure(figsize=(12, 12))
     ax1 = plt.subplot(2, 1, 1)
@@ -111,7 +112,8 @@ def test_mission_component(cleanup, with_dummy_plugin_2):
         ),
         ivc,
     )
-    # plot_flight(problem.model.component.flight_points, "test_mission.png")
+    # Useful for debugging
+    # plot_flight(problem.model.component.flight_points, "test_mission.png")  # noqa: ERA001
     take_off_distance = problem[
         "data:mission:operational_wo_gnd_effect:takeoff_wo_gnd_effect:distance"
     ]
@@ -156,7 +158,8 @@ def test_ground_effect(cleanup, with_dummy_plugin_2):
         ),
         ivc,
     )
-    # plot_flight(problem.model.component.flight_points, "test_mission.png")
+    # Useful for debugging
+    # plot_flight(problem.model.component.flight_points, "test_mission.png")  # noqa: ERA001
     take_off_distance = problem["data:mission:operational:takeoff:distance"]
     assert_allclose(take_off_distance, 1762, atol=1.0)
     assert_allclose(problem["data:mission:operational:takeoff:fuel"], 122.1, atol=1e-1)
@@ -188,7 +191,8 @@ def test_start_stop(cleanup, with_dummy_plugin_2):
         ),
         ivc,
     )
-    # plot_flight(problem.model.component.flight_points, "test_mission.png")
+    # Useful for debugging
+    # plot_flight(problem.model.component.flight_points, "test_mission.png")  # noqa: ERA001
     start_stop_distance = problem["data:mission:start_stop_mission:start_stop:distance"]
     assert_allclose(start_stop_distance, 1659, atol=1.0)
     assert_allclose(problem["data:mission:start_stop_mission:start_stop:duration"], 42.8, atol=1e-1)

--- a/src/fastoad/models/performances/mission/openmdao/tests/test_sizing_mission.py
+++ b/src/fastoad/models/performances/mission/openmdao/tests/test_sizing_mission.py
@@ -24,6 +24,8 @@ from ..mission import OMMission
 
 RESULTS_FOLDER_PATH = Path(__file__).parent / "results" / Path(__file__).stem
 
+# ruff:noqa ERA001
+
 
 @pytest.fixture(scope="module")
 def cleanup():
@@ -71,6 +73,7 @@ def test_sizing_mission(cleanup, with_dummy_plugin_2):
         ),
         ivc,
     )
+    # Useful for debugging
     # import pandas as pd
     #
     # plot_flight(

--- a/src/fastoad/models/performances/mission/segments/base.py
+++ b/src/fastoad/models/performances/mission/segments/base.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import contextlib
 from abc import ABC, abstractmethod
 from copy import deepcopy
 from dataclasses import dataclass, field
@@ -28,7 +29,7 @@ from fastoad.model_base import FlightPoint
 from fastoad.model_base.datacls import MANDATORY_FIELD
 
 from ..base import IFlightPart, RegisterElement
-from ..exceptions import FastFlightSegmentIncompleteFlightPoint
+from ..exceptions import FastFlightSegmentIncompleteFlightPointError
 
 
 class RegisterSegment(RegisterElement, base_class=IFlightPart):
@@ -138,10 +139,10 @@ class AbstractFlightSegment(IFlightPart, ABC):
     isa_offset: float = 0.0
 
     #: Using this value will tell to keep the associated parameter constant.
-    CONSTANT_VALUE = "constant"  # pylint: disable=invalid-name # used as constant
+    CONSTANT_VALUE = "constant"
 
     # To be noted: this one is not a dataclass field, but an actual class attribute
-    _attribute_units: ClassVar[dict] = dict(reference_area="m**2", time_step="s")
+    _attribute_units: ClassVar[dict] = {"reference_area": "m**2", "time_step": "s"}
 
     @abstractmethod
     def compute_from_start_to_target(self, start, target) -> pd.DataFrame:
@@ -206,10 +207,8 @@ class AbstractFlightSegment(IFlightPart, ABC):
         start_copy = deepcopy(start)
 
         if start_copy.altitude is not None:
-            try:
+            with contextlib.suppress(FastFlightSegmentIncompleteFlightPointError):
                 self.complete_flight_point(start_copy)
-            except FastFlightSegmentIncompleteFlightPoint:
-                pass
         start_copy.scalarize()
         start_copy.isa_offset = self.isa_offset
 
@@ -310,7 +309,7 @@ class AbstractFlightSegment(IFlightPart, ABC):
             elif flight_point.equivalent_airspeed is not None:
                 atm.equivalent_airspeed = flight_point.equivalent_airspeed
             elif raise_error_on_missing_speeds:
-                raise FastFlightSegmentIncompleteFlightPoint(
+                raise FastFlightSegmentIncompleteFlightPointError(
                     "Flight point should be defined for true_airspeed, "
                     "equivalent_airspeed, or mach."
                 )

--- a/src/fastoad/models/performances/mission/segments/macro_segments.py
+++ b/src/fastoad/models/performances/mission/segments/macro_segments.py
@@ -86,9 +86,9 @@ class MacroSegmentBase(FlightSequence):
             }
             segment_kwargs = {
                 name: value
-                for name, value in dict(
-                    (cls_field.name, getattr(self, cls_field.name)) for cls_field in fields(self)
-                ).items()
+                for name, value in {
+                    cls_field.name: getattr(self, cls_field.name) for cls_field in fields(self)
+                }.items()
                 if name in segment_field_names
             }
             segment_kwargs["target"] = FlightPoint()

--- a/src/fastoad/models/performances/mission/segments/registered/altitude_change.py
+++ b/src/fastoad/models/performances/mission/segments/registered/altitude_change.py
@@ -21,7 +21,9 @@ import pandas as pd
 from scipy.constants import foot, g
 
 from fastoad.model_base import FlightPoint
-from fastoad.models.performances.mission.exceptions import FastFlightSegmentIncompleteFlightPoint
+from fastoad.models.performances.mission.exceptions import (
+    FastFlightSegmentIncompleteFlightPointError,
+)
 from fastoad.models.performances.mission.segments.base import (
     RegisterSegment,
 )
@@ -81,11 +83,11 @@ class AltitudeChangeSegment(AbstractManualThrustSegment, AbstractLiftFromWeightS
     _original_target_altitude: str | None = field(default=None, init=False)
 
     #: Using this value will tell to target the altitude with max lift/drag ratio.
-    OPTIMAL_ALTITUDE = "optimal_altitude"  # pylint: disable=invalid-name # used as constant
+    OPTIMAL_ALTITUDE = "optimal_altitude"  # used as constant
 
     #: Using this value will tell to target the nearest flight level to altitude
     #: with max lift/drag ratio.
-    OPTIMAL_FLIGHT_LEVEL = "optimal_flight_level"  # pylint: disable=invalid-name # used as constant
+    OPTIMAL_FLIGHT_LEVEL = "optimal_flight_level"  # used as constant
 
     def compute_from_start_to_target(self, start: FlightPoint, target: FlightPoint) -> pd.DataFrame:
         if target.altitude is not None:
@@ -148,7 +150,7 @@ class AltitudeChangeSegment(AbstractManualThrustSegment, AbstractLiftFromWeightS
                 distance_to_target = target.mach - current.mach
 
         if distance_to_target is None:
-            raise FastFlightSegmentIncompleteFlightPoint(
+            raise FastFlightSegmentIncompleteFlightPointError(
                 "No valid target definition for altitude change."
             )
         return distance_to_target

--- a/src/fastoad/models/performances/mission/segments/registered/ground_speed_change.py
+++ b/src/fastoad/models/performances/mission/segments/registered/ground_speed_change.py
@@ -15,7 +15,9 @@
 from dataclasses import dataclass
 
 from fastoad.model_base import FlightPoint
-from fastoad.models.performances.mission.exceptions import FastFlightSegmentIncompleteFlightPoint
+from fastoad.models.performances.mission.exceptions import (
+    FastFlightSegmentIncompleteFlightPointError,
+)
 from fastoad.models.performances.mission.segments.base import RegisterSegment
 from fastoad.models.performances.mission.segments.time_step_base import AbstractGroundSegment
 
@@ -39,6 +41,6 @@ class GroundSpeedChangeSegment(AbstractGroundSegment):
         if target.mach is not None:
             return target.mach - flight_points[-1].mach
 
-        raise FastFlightSegmentIncompleteFlightPoint(
+        raise FastFlightSegmentIncompleteFlightPointError(
             "No valid target definition for airspeed change at takeoff."
         )

--- a/src/fastoad/models/performances/mission/segments/registered/speed_change.py
+++ b/src/fastoad/models/performances/mission/segments/registered/speed_change.py
@@ -15,7 +15,9 @@
 from dataclasses import dataclass
 
 from fastoad.model_base import FlightPoint
-from fastoad.models.performances.mission.exceptions import FastFlightSegmentIncompleteFlightPoint
+from fastoad.models.performances.mission.exceptions import (
+    FastFlightSegmentIncompleteFlightPointError,
+)
 from fastoad.models.performances.mission.segments.base import (
     RegisterSegment,
 )
@@ -45,7 +47,7 @@ class SpeedChangeSegment(AbstractManualThrustSegment, AbstractLiftFromWeightSegm
         if target.mach is not None:
             return target.mach - flight_points[-1].mach
 
-        raise FastFlightSegmentIncompleteFlightPoint(
+        raise FastFlightSegmentIncompleteFlightPointError(
             "No valid target definition for altitude change."
         )
 

--- a/src/fastoad/models/performances/mission/segments/registered/start.py
+++ b/src/fastoad/models/performances/mission/segments/registered/start.py
@@ -17,7 +17,9 @@ from dataclasses import dataclass
 import pandas as pd
 
 from fastoad.model_base import FlightPoint
-from fastoad.models.performances.mission.exceptions import FastFlightSegmentIncompleteFlightPoint
+from fastoad.models.performances.mission.exceptions import (
+    FastFlightSegmentIncompleteFlightPointError,
+)
 from fastoad.models.performances.mission.segments.base import AbstractFlightSegment, RegisterSegment
 
 
@@ -40,7 +42,7 @@ class Start(AbstractFlightSegment):
 
         try:
             self.complete_flight_point(target)
-        except FastFlightSegmentIncompleteFlightPoint:
+        except FastFlightSegmentIncompleteFlightPointError:
             target.true_airspeed = 0.0
             self.complete_flight_point(target)
 

--- a/src/fastoad/models/performances/mission/segments/registered/takeoff/end_of_takeoff.py
+++ b/src/fastoad/models/performances/mission/segments/registered/takeoff/end_of_takeoff.py
@@ -15,7 +15,9 @@
 from dataclasses import dataclass
 
 from fastoad.model_base import FlightPoint
-from fastoad.models.performances.mission.exceptions import FastFlightSegmentIncompleteFlightPoint
+from fastoad.models.performances.mission.exceptions import (
+    FastFlightSegmentIncompleteFlightPointError,
+)
 from fastoad.models.performances.mission.segments.base import RegisterSegment
 from fastoad.models.performances.mission.segments.time_step_base import AbstractTakeOffSegment
 
@@ -63,7 +65,7 @@ class EndOfTakeoffSegment(AbstractTakeOffSegment):
         if target.altitude is not None:
             return target.altitude - current.altitude
 
-        raise FastFlightSegmentIncompleteFlightPoint(
+        raise FastFlightSegmentIncompleteFlightPointError(
             "No valid target definition for altitude change."
         )
 

--- a/src/fastoad/models/performances/mission/segments/registered/tests/test_altitude_change.py
+++ b/src/fastoad/models/performances/mission/segments/registered/tests/test_altitude_change.py
@@ -714,7 +714,7 @@ def test_descent_to_fixed_EAS_at_constant_mach(polar):
         reference_area=100.0,
         polar=polar,
         thrust_rate=0.1,
-        # time_step=5.0, # we use default time step
+        # time_step=5.0, # we use default time step  # noqa: ERA001
     )
 
     def run():

--- a/src/fastoad/models/performances/mission/segments/registered/tests/test_takeoff_segments.py
+++ b/src/fastoad/models/performances/mission/segments/registered/tests/test_takeoff_segments.py
@@ -208,11 +208,11 @@ def test_takeoff(polar, polar_modifier):
         reference_area=120.0,
         polar=polar,
         polar_modifier=polar_modifier,
-        # engine_setting=EngineSetting.CLIMB,   # using default value
+        # engine_setting=EngineSetting.CLIMB,   # using default value  # noqa: ERA001
         rotation_equivalent_airspeed=75.0,
         rotation_rate=0.05,
         rotation_alpha_limit=0.1,
-        # thrust_rate=1.0,                      # using default value
+        # thrust_rate=1.0,                      # using default value  # noqa: ERA001
         time_step=0.2,
     )
 

--- a/src/fastoad/models/performances/mission/segments/time_step_base.py
+++ b/src/fastoad/models/performances/mission/segments/time_step_base.py
@@ -145,7 +145,7 @@ class AbstractTimeStepFlightSegment(
     def get_next_alpha(
         self,
         previous_point: FlightPoint,
-        time_step: float,  # pylint: disable=unused-argument
+        time_step: float,
     ) -> float:
         """
         Determine the next angle of attack.

--- a/src/fastoad/models/performances/mission/tests/conftest.py
+++ b/src/fastoad/models/performances/mission/tests/conftest.py
@@ -14,7 +14,6 @@
 from __future__ import annotations
 
 from dataclasses import InitVar, dataclass, field
-from pathlib import Path
 
 import numpy as np
 import pandas as pd
@@ -26,6 +25,7 @@ from fastoad.model_base import FlightPoint
 from fastoad.model_base.datacls import MANDATORY_FIELD
 from fastoad.model_base.propulsion import FuelEngineSet, IPropulsion
 from fastoad.models.performances.mission.base import FlightSequence
+from tests.dummy_plugins.dist_2.dummy_plugin_2.models.subpackage.dummy_engine import DummyEngine
 
 from ..polar import Polar
 from ..segments.registered.altitude_change import AltitudeChangeSegment
@@ -35,8 +35,6 @@ from ..segments.registered.taxi import TaxiSegment
 
 @pytest.fixture(scope="module")
 def propulsion():
-    from tests.dummy_plugins.dist_2.dummy_plugin_2.models.subpackage.dummy_engine import DummyEngine
-
     return FuelEngineSet(DummyEngine(1.0e5, 1.0e-4), 2)
 
 
@@ -64,52 +62,6 @@ def print_dataframe(df, max_rows=20):
     ):
         print()
         print(df)
-
-
-def plot_flight(flight_points, fig_filename, results_folder_path):
-    """Utility for plotting mission profile."""
-    from matplotlib import pyplot as plt
-    from matplotlib.ticker import MultipleLocator
-
-    plt.figure(figsize=(12, 12))
-    ax1 = plt.subplot(2, 1, 1)
-    plt.plot(flight_points.ground_distance / 1000.0, flight_points.altitude / foot, "o-")
-    plt.xlabel("distance [km]")
-    plt.ylabel("altitude [ft]")
-    ax1.xaxis.set_minor_locator(MultipleLocator(50))
-    ax1.yaxis.set_minor_locator(MultipleLocator(500))
-    plt.grid(which="major", color="k")
-    plt.grid(which="minor")
-
-    ax2 = plt.subplot(2, 1, 2)
-    lines = []
-    lines += plt.plot(
-        flight_points.ground_distance / 1000.0, flight_points.true_airspeed, "b-", label="TAS [m/s]"
-    )
-    lines += plt.plot(
-        flight_points.ground_distance / 1000.0,
-        flight_points.equivalent_airspeed / knot,
-        "g--",
-        label="EAS [kt]",
-    )
-    plt.xlabel("distance [km]")
-    plt.ylabel("speed")
-    ax2.xaxis.set_minor_locator(MultipleLocator(50))
-    ax2.yaxis.set_minor_locator(MultipleLocator(5))
-    plt.grid(which="major", color="k")
-    plt.grid(which="minor")
-
-    plt.twinx(ax2)
-    lines += plt.plot(
-        flight_points.ground_distance / 1000.0, flight_points.mach, "r.-", label="Mach"
-    )
-    plt.ylabel("Mach")
-
-    labels = [line.get_label() for line in lines]
-    plt.legend(lines, labels, loc=0)
-
-    plt.savefig(Path(results_folder_path, fig_filename))
-    plt.close()
 
 
 # We define here in Python the flight phases that feed the test of RangedRoute ===========

--- a/src/fastoad/models/performances/mission/tests/test_flight_sequence.py
+++ b/src/fastoad/models/performances/mission/tests/test_flight_sequence.py
@@ -21,7 +21,7 @@ from ..base import FlightSequence
 from ..segments.registered.mass_input import MassTargetSegment
 from ..segments.registered.taxi import TaxiSegment
 
-# ruff: noqa: RUF005
+# ruff: noqa: RUF005 In this test it is clearer with +
 
 
 def get_taxi_definition(propulsion, target_mass=None):

--- a/src/fastoad/models/performances/mission/tests/test_mission.py
+++ b/src/fastoad/models/performances/mission/tests/test_mission.py
@@ -27,7 +27,7 @@ def test_mission(low_speed_polar, high_speed_polar, propulsion):
     first_route_distance = 2.0e6
     second_route_distance = 5.0e5
 
-    kwargs = dict(propulsion=propulsion, reference_area=120.0)
+    kwargs = {"propulsion": propulsion, "reference_area": 120.0}
 
     taxi_out = TaxiPhase(  # This phase is here to test when mission do not start with route
         time=300.0,
@@ -120,7 +120,8 @@ def test_mission(low_speed_polar, high_speed_polar, propulsion):
 
     flight_points = mission_1.compute_from(start)
 
-    # plot_flight(flight_points, "test_ranged_flight.png")
+    # Useful for debugging
+    # plot_flight(flight_points, "test_ranged_flight.png")  # noqa: ERA001
 
     assert_allclose(
         flight_points.iloc[-1].ground_distance,
@@ -145,7 +146,8 @@ def test_mission(low_speed_polar, high_speed_polar, propulsion):
 
     flight_points = mission_2.compute_from(start)
 
-    # plot_flight(flight_points, "test_ranged_flight.png")
+    # Useful for debugging
+    # plot_flight(flight_points, "test_ranged_flight.png")  # noqa: ERA001
 
     assert_allclose(
         flight_points.iloc[-1].ground_distance,

--- a/src/fastoad/models/performances/mission/tests/test_routes.py
+++ b/src/fastoad/models/performances/mission/tests/test_routes.py
@@ -37,7 +37,7 @@ def cleanup():
 def test_ranged_route(low_speed_polar, high_speed_polar, propulsion, cleanup):
     total_distance = 2.0e6
 
-    kwargs = dict(propulsion=propulsion, reference_area=120.0)
+    kwargs = {"propulsion": propulsion, "reference_area": 120.0}
     initial_climb = InitialClimbPhase(
         **kwargs, polar=low_speed_polar, thrust_rate=1.0, name="initial_climb", time_step=0.2
     )
@@ -79,7 +79,8 @@ def test_ranged_route(low_speed_polar, high_speed_polar, propulsion, cleanup):
     )
     flight_points = flight_calculator.compute_from(start)
 
-    # plot_flight(flight_points, "test_ranged_flight.png", RESULTS_FOLDER_PATH)
+    # Useful for debugging
+    # plot_flight(flight_points, "test_ranged_flight.png", RESULTS_FOLDER_PATH)  # noqa: ERA001
 
     assert_allclose(
         flight_points.iloc[-1].ground_distance,

--- a/src/fastoad/models/performances/mission/util.py
+++ b/src/fastoad/models/performances/mission/util.py
@@ -47,10 +47,7 @@ def get_closest_flight_level(altitude, base_level=0, level_step=10, *, up_direct
     :param up_direction: True if next flight level is upper. False if lower
     :return: the altitude in meters of the asked flight level.
     """
-    if up_direction:
-        func = np.ceil
-    else:
-        func = np.floor
+    func = np.ceil if up_direction else np.floor
 
     base_altitude = FLIGHT_LEVEL * base_level
     return base_altitude + FLIGHT_LEVEL * level_step * func(

--- a/src/fastoad/module_management/_bundle_loader.py
+++ b/src/fastoad/module_management/_bundle_loader.py
@@ -200,12 +200,12 @@ class BundleLoader:
                         )
                     else:
                         for prop_name, prop_value in properties.items():
-                            if prop_name not in factory_properties.keys():
+                            if prop_name not in factory_properties:
                                 to_be_kept = False
                                 break
                             factory_prop_value = factory_properties[prop_name]
                             if isinstance(prop_value, str):
-                                prop_value = prop_value.lower()
+                                prop_value = prop_value.lower()  # noqa: PLW2901
                                 factory_prop_value = factory_prop_value.lower()
                             if prop_value != factory_prop_value:
                                 to_be_kept = False
@@ -331,10 +331,7 @@ class BundleLoader:
 
         # Dev Note: simple wrapper for BundleContext.get_all_service_references()
 
-        if case_sensitive:
-            operator = "="
-        else:
-            operator = "~="
+        operator = "=" if case_sensitive else "~="
 
         if not properties:
             ldap_filter = None

--- a/src/fastoad/module_management/_plugins.py
+++ b/src/fastoad/module_management/_plugins.py
@@ -64,7 +64,7 @@ class DistributionNameDict(AbstractNormalizedDict):
     """
 
     @staticmethod
-    def normalize(dist_name: str | None):  # pylint: disable=arguments-differ
+    def normalize(dist_name: str | None):
         """
         Returns a normalized distribution name for PEP-426-compliant comparison of distribution
         names.
@@ -343,13 +343,13 @@ class DistributionPluginDefinition(dict):
         )
         conf_files = [item.name for item in self.get_configuration_file_list()]
         source_data_files = [item.name for item in self.get_source_data_file_list()]
-        return dict(
-            installed_package=self.dist_name,
-            has_models=has_models,
-            has_notebooks=has_notebooks,
-            configurations=sorted(conf_files),
-            source_data_files=sorted(source_data_files),
-        )
+        return {
+            "installed_package": self.dist_name,
+            "has_models": has_models,
+            "has_notebooks": has_notebooks,
+            "configurations": sorted(conf_files),
+            "source_data_files": sorted(source_data_files),
+        }
 
 
 class FastoadLoader(BundleLoader):

--- a/src/fastoad/module_management/exceptions.py
+++ b/src/fastoad/module_management/exceptions.py
@@ -73,7 +73,8 @@ class FastIncompatibleServiceClassError(FastError):
         :param base_class: the unmatched interface
         """
         super().__init__(
-            f'Trying to register {registered_class!s} as service "{service_id}" but it does not inherit from {base_class!s}'
+            f'Trying to register {registered_class!s} as service "{service_id}" but it does not '
+            f"inherit from {base_class!s}"
         )
         self.registered_class = registered_class
         self.service_id = service_id
@@ -105,7 +106,8 @@ class FastTooManySubmodelsError(FastError):
         :param candidates:
         """
         super().__init__(
-            f'Submodel requirement "{service_id}" needs a choice among following candidates: {candidates}'
+            f'Submodel requirement "{service_id}" needs a choice among following '
+            f"candidates: {candidates}"
         )
         self.service_id = service_id
         self.candidates = candidates

--- a/src/fastoad/module_management/service_registry.py
+++ b/src/fastoad/module_management/service_registry.py
@@ -481,12 +481,7 @@ class RegisterSubmodel(_RegisterOpenMDAOService):
 
             submodel_id = submodel_ids[0]
 
-        if submodel_id:
-            instance = super().get_system(submodel_id, options)
-        else:
-            instance = om.Group()
-
-        return instance
+        return super().get_system(submodel_id, options) if submodel_id else om.Group()  # istance
 
     @classmethod
     def cancel_submodel_deactivations(cls):

--- a/src/fastoad/module_management/tests/test_bundle_loader.py
+++ b/src/fastoad/module_management/tests/test_bundle_loader.py
@@ -121,7 +121,7 @@ def test_install_packages_on_faulty_install(delete_framework):
     loader = BundleLoader()
 
     # Create the buggy numpy install
-    import sys
+    import sys  # noqa: PLC0415 # import should stay here
 
     sys.modules["numpy.random.mtrand"].__path__ = None
 

--- a/src/fastoad/notebooks/01_Quick_start/modules/stresses.py
+++ b/src/fastoad/notebooks/01_Quick_start/modules/stresses.py
@@ -47,8 +47,5 @@ class Stress(om.ExplicitComponent):
         s = inputs["data:material:yield_stress"]
 
         # Max bending location along the beam
-        if w * L - F > 0:
-            y_max = (w * L - F) / w
-        else:
-            y_max = 0
+        y_max = (w * L - F) / w if w * L - F > 0 else 0
         outputs["data:geometry:Ixx"] = (L - y_max) * (F - 0.5 * w * (L - y_max)) * h / (2 * s)

--- a/src/fastoad/notebooks/02_From_Python_to_FAST-OAD/02_pure_Python.ipynb
+++ b/src/fastoad/notebooks/02_From_Python_to_FAST-OAD/02_pure_Python.ipynb
@@ -331,7 +331,7 @@
     ")\n",
     "fig.add_trace(old_mtow_scatter)\n",
     "fig.layout = go.Layout(\n",
-    "    yaxis=dict(scaleanchor=\"x\", scaleratio=0.8),\n",
+    "    yaxis={\"scaleanchor\": \"x\", \"scaleratio\": 0.8},\n",
     "    height=800,\n",
     "    title_text=\"Graphic resolution\",\n",
     "    title_x=0.42,\n",

--- a/src/fastoad/notebooks/02_From_Python_to_FAST-OAD/05_FAST-OAD.ipynb
+++ b/src/fastoad/notebooks/02_From_Python_to_FAST-OAD/05_FAST-OAD.ipynb
@@ -419,7 +419,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": ".venv (3.12.9)",
    "language": "python",
    "name": "python3"
   },
@@ -433,7 +433,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,

--- a/src/fastoad/notebooks/02_From_Python_to_FAST-OAD/modules/OpenMDAO/aerodynamics/sub_components/compute_profile_drag.py
+++ b/src/fastoad/notebooks/02_From_Python_to_FAST-OAD/modules/OpenMDAO/aerodynamics/sub_components/compute_profile_drag.py
@@ -26,7 +26,8 @@ class ComputeProfileDrag(om.ExplicitComponent):
         # Profile drag coefficient of the aircraft without the wings
         cd0_other = 0.022
 
-        # Constant linking the wing profile drag to its wet area, and by extension, its reference area
+        # Constant linking the wing profile drag to its wet area, and by extension, its reference
+        # area
         c = 0.0004
 
         # Computation of the profile drag

--- a/src/fastoad/notebooks/02_From_Python_to_FAST-OAD/modules/pure_python/aerodynamics/sub_components/compute_lift_to_drag_ratio.py
+++ b/src/fastoad/notebooks/02_From_Python_to_FAST-OAD/modules/pure_python/aerodynamics/sub_components/compute_lift_to_drag_ratio.py
@@ -5,7 +5,8 @@ from fastoad.model_base.atmosphere import Atmosphere
 
 def compute_l_d(cruise_altitude, cruise_speed, cd0, k, mtow, wing_area):
     """
-    Computes the lift to drag ratio considering a lift equilibrium in cruise and a simple quadratic model
+    Computes the lift to drag ratio considering a lift equilibrium in cruise and a simple quadratic
+    model
 
     :param cruise_altitude: Cruise altitude, in m
     :param cruise_speed: Cruise speed, in m/s

--- a/src/fastoad/notebooks/02_From_Python_to_FAST-OAD/modules/python_for_scipy/compute_fuel_scipy.py
+++ b/src/fastoad/notebooks/02_From_Python_to_FAST-OAD/modules/python_for_scipy/compute_fuel_scipy.py
@@ -8,8 +8,8 @@ def compute_fuel_scipy(
     x, wing_loading, cruise_altitude, cruise_speed, mission_range, payload, tsfc
 ):
     """
-    Gather all the module main functions in the program main function that will compute the fuel consumed for the given
-    MTOW
+    Gather all the module main functions in the program main function that will compute the fuel
+    consumed for the given MTOW
 
     :param x: Tuple containing the Old Max Take-Off Weight, in kg and the aspect ration with no unit
     :param wing_loading: Wing loading, in kg/m2

--- a/src/fastoad/openmdao/exceptions.py
+++ b/src/fastoad/openmdao/exceptions.py
@@ -26,7 +26,7 @@ class FASTNanInInputsError(FastError):
 
     def __init__(self, input_file_path: [str, PathLike], nan_variable_names: Iterable[str]):
         self.input_file_path = as_path(input_file_path)
-        self.nan_variable_names = sorted(list(nan_variable_names))
+        self.nan_variable_names = sorted(nan_variable_names)
 
         msg = (
             f"NaN values found in inputs. Please check that {input_file_path} contains "

--- a/src/fastoad/openmdao/tests/test_variables.py
+++ b/src/fastoad/openmdao/tests/test_variables.py
@@ -130,12 +130,12 @@ def test_ivc_from_to_variables():
     """
     Tests VariableList.to_ivc() and VariableList.from_ivc()
     """
-    vars = VariableList()
-    vars["a"] = {"value": 5}
-    vars["b"] = {"value": 2.5, "units": "m"}
-    vars["c"] = {"value": -3.2, "units": "kg/s", "desc": "some test"}
+    variables = VariableList()
+    variables["a"] = {"value": 5}
+    variables["b"] = {"value": 2.5, "units": "m"}
+    variables["c"] = {"value": -3.2, "units": "kg/s", "desc": "some test"}
 
-    ivc = vars.to_ivc()
+    ivc = variables.to_ivc()
     problem = om.Problem(reports=False)
     problem.model.add_subsystem("ivc", ivc, promotes=["*"])
     problem.setup()
@@ -144,10 +144,10 @@ def test_ivc_from_to_variables():
     assert problem.get_val("b", units="cm") == 250
     assert problem.get_val("c", units="kg/ms") == -0.0032
 
-    ivc = vars.to_ivc()
-    new_vars = VariableList.from_ivc(ivc)
-    assert vars.names() == new_vars.names()
-    for var, new_var in zip(vars, new_vars):
+    ivc = variables.to_ivc()
+    new_variables = VariableList.from_ivc(ivc)
+    assert variables.names() == new_variables.names()
+    for var, new_var in zip(variables, new_variables):
         assert var == new_var
 
 
@@ -155,13 +155,13 @@ def test_df_from_to_variables():
     """
     Tests VariableList.to_dataframe() and VariableList.from_dataframe()
     """
-    vars = VariableList()
-    vars["a"] = {"val": 5}
-    vars["b"] = {"val": np.array([1.0, 2.0, 3.0]), "units": "m"}
-    vars["c"] = {"val": [1.0, 2.0, 3.0], "units": "kg/s", "desc": "some test"}
-    vars["d"] = {"val": "my value is a string"}
+    variables = VariableList()
+    variables["a"] = {"val": 5}
+    variables["b"] = {"val": np.array([1.0, 2.0, 3.0]), "units": "m"}
+    variables["c"] = {"val": [1.0, 2.0, 3.0], "units": "kg/s", "desc": "some test"}
+    variables["d"] = {"val": "my value is a string"}
 
-    df = vars.to_dataframe()
+    df = variables.to_dataframe()
     assert np.all(df["name"] == ["a", "b", "c", "d"])
     assert np.all(
         df["val"]
@@ -170,51 +170,53 @@ def test_df_from_to_variables():
     assert np.all(df["units"].to_list() == [None, "m", "kg/s", None])
     assert np.all(df["desc"].to_list() == ["", "", "some test", ""])
 
-    new_vars = VariableList.from_dataframe(df)
+    new_variables = VariableList.from_dataframe(df)
 
-    assert vars.names() == new_vars.names()
-    for var, new_var in zip(vars, new_vars):
+    assert variables.names() == new_variables.names()
+    for var, new_var in zip(variables, new_variables):
         assert var == new_var
 
 
-def _compare_variable_lists(vars: list[Variable], expected_vars: list[Variable]):
+def _compare_variable_lists(variables: list[Variable], expected_variables: list[Variable]):
     def sort_key(v):
         return v.name
 
-    vars.sort(key=sort_key)
-    expected_vars.sort(key=sort_key)
-    assert vars == expected_vars
+    variables.sort(key=sort_key)
+    expected_variables.sort(key=sort_key)
+    assert variables == expected_variables
 
     # is_input is willingly ignored when checking equality of variables, but here, we want to
     # test it.
-    vars_dict = {var.name: var.is_input for var in vars}
-    expected_vars_dict = {var.name: var.is_input for var in expected_vars}
-    assert vars_dict == expected_vars_dict
+    variables_dict = {var.name: var.is_input for var in variables}
+    expected_variables_dict = {var.name: var.is_input for var in expected_variables}
+    assert variables_dict == expected_variables_dict
 
-    vars_dict = {var.name: var.description for var in vars}
-    expected_vars_dict = {var.name: var.description for var in expected_vars}
-    assert vars_dict == expected_vars_dict
+    variables_dict = {var.name: var.description for var in variables}
+    expected_variables_dict = {var.name: var.description for var in expected_variables}
+    assert variables_dict == expected_variables_dict
 
 
 def test_get_variables_from_problem_with_an_explicit_component():
     problem = om.Problem(reports=False)
     problem.model.add_subsystem("disc1", Disc1(), promotes=["*"])
 
-    vars_before_setup = VariableList.from_problem(
+    variables_before_setup = VariableList.from_problem(
         problem, use_initial_values=False, get_promoted_names=True
     )
     problem.setup()
-    vars = VariableList.from_problem(problem, use_initial_values=False, get_promoted_names=True)
-    assert vars_before_setup == vars
+    variables = VariableList.from_problem(
+        problem, use_initial_values=False, get_promoted_names=True
+    )
+    assert variables_before_setup == variables
 
-    expected_vars = [
+    expected_variables = [
         Variable(name="x", val=np.array([np.nan]), units=None, desc="input x", is_input=True),
         Variable(name="y2", val=np.array([1.0]), units=None, is_input=True, desc="variable y2"),
         Variable(name="z", val=np.array([5.0, 2.0]), units="m**2", is_input=True),
         Variable(name="y1", val=np.array([1.0]), units=None, is_input=False, desc="variable y1"),
     ]
 
-    _compare_variable_lists(vars, expected_vars)
+    _compare_variable_lists(variables, expected_variables)
 
 
 def test_get_variables_from_problem_with_a_group():
@@ -222,14 +224,16 @@ def test_get_variables_from_problem_with_a_group():
     group.add_subsystem("disc1", Disc1(), promotes=["*"])
     group.add_subsystem("disc2", Disc2(), promotes=["*"])
     problem = om.Problem(group, reports=False)
-    vars_before_setup = VariableList.from_problem(
+    variables_before_setup = VariableList.from_problem(
         problem, use_initial_values=False, get_promoted_names=True
     )
     problem.setup()
-    vars = VariableList.from_problem(problem, use_initial_values=False, get_promoted_names=True)
-    assert vars_before_setup == vars
+    variables = VariableList.from_problem(
+        problem, use_initial_values=False, get_promoted_names=True
+    )
+    assert variables_before_setup == variables
 
-    expected_vars = [
+    expected_variables = [
         Variable(name="x", val=np.array([np.nan]), units=None, is_input=True, desc="input x"),
         Variable(name="y1", val=np.array([1.0]), units=None, is_input=False, desc="variable y1"),
         Variable(name="y2", val=np.array([1.0]), units=None, is_input=False, desc="variable y2"),
@@ -238,7 +242,7 @@ def test_get_variables_from_problem_with_a_group():
         ),
     ]
 
-    _compare_variable_lists(vars, expected_vars)
+    _compare_variable_lists(variables, expected_variables)
 
 
 def test_get_variables_from_problem_sellar_with_promotion_without_computation():
@@ -257,7 +261,7 @@ def test_get_variables_from_problem_sellar_with_promotion_without_computation():
         problem.setup()
         problem.final_setup()
 
-    expected_vars_promoted = [
+    expected_variables_promoted = [
         Variable(name="x", val=np.array([1.0]), units="Pa", is_input=True, desc="input x"),
         Variable(
             name="z", val=np.array([5.0, 2.0]), units="m**2", is_input=True, desc="variable z"
@@ -268,7 +272,7 @@ def test_get_variables_from_problem_sellar_with_promotion_without_computation():
         Variable(name="g2", val=np.array([1.0]), units=None, is_input=False),
         Variable(name="f", val=np.array([1.0]), units=None, is_input=False),
     ]
-    expected_vars_non_promoted = [
+    expected_variables_non_promoted = [
         Variable(name="indeps.x", val=np.array([1.0]), units="Pa", is_input=True),
         Variable(name="indeps.z", val=np.array([5.0, 2.0]), units="m**2", is_input=True),
         Variable(name="disc1.x", val=np.array([np.nan]), units=None, is_input=True, desc="input x"),
@@ -295,18 +299,24 @@ def test_get_variables_from_problem_sellar_with_promotion_without_computation():
         Variable(name="constraint2.g2", val=np.array([1.0]), units=None, is_input=False),
     ]
 
-    vars = VariableList.from_problem(problem, use_initial_values=True, get_promoted_names=True)
-    _compare_variable_lists(vars, expected_vars_promoted)
+    variables = VariableList.from_problem(problem, use_initial_values=True, get_promoted_names=True)
+    _compare_variable_lists(variables, expected_variables_promoted)
 
-    vars = VariableList.from_problem(problem, use_initial_values=True, get_promoted_names=False)
-    _compare_variable_lists(vars, expected_vars_non_promoted)
+    variables = VariableList.from_problem(
+        problem, use_initial_values=True, get_promoted_names=False
+    )
+    _compare_variable_lists(variables, expected_variables_non_promoted)
 
     # use_initial_values=False should have no effect while problem has not been run
-    vars = VariableList.from_problem(problem, use_initial_values=False, get_promoted_names=True)
-    _compare_variable_lists(vars, expected_vars_promoted)
+    variables = VariableList.from_problem(
+        problem, use_initial_values=False, get_promoted_names=True
+    )
+    _compare_variable_lists(variables, expected_variables_promoted)
 
-    vars = VariableList.from_problem(problem, use_initial_values=False, get_promoted_names=False)
-    _compare_variable_lists(vars, expected_vars_non_promoted)
+    variables = VariableList.from_problem(
+        problem, use_initial_values=False, get_promoted_names=False
+    )
+    _compare_variable_lists(variables, expected_variables_non_promoted)
 
 
 def test_get_variables_from_problem_sellar_with_promotion_with_computation():
@@ -325,7 +335,7 @@ def test_get_variables_from_problem_sellar_with_promotion_with_computation():
         problem.setup()
         problem.final_setup()
 
-    expected_vars_promoted_initial = [
+    expected_variables_promoted_initial = [
         Variable(name="x", val=np.array([1.0]), units="Pa", is_input=True, desc="input x"),
         Variable(
             name="z", val=np.array([5.0, 2.0]), units="m**2", is_input=True, desc="variable z"
@@ -336,7 +346,7 @@ def test_get_variables_from_problem_sellar_with_promotion_with_computation():
         Variable(name="g2", val=np.array([1.0]), units=None, is_input=False),
         Variable(name="f", val=np.array([1.0]), units=None, is_input=False),
     ]
-    expected_vars_promoted_computed = [
+    expected_variables_promoted_computed = [
         Variable(name="x", val=np.array([1.0]), units="Pa", is_input=True, desc="input x"),
         Variable(
             name="z", val=np.array([5.0, 2.0]), units="m**2", is_input=True, desc="variable z"
@@ -351,7 +361,7 @@ def test_get_variables_from_problem_sellar_with_promotion_with_computation():
         Variable(name="g1", val=np.array([-22.42830237]), units=None, is_input=False),
         Variable(name="g2", val=np.array([-11.94151185]), units=None, is_input=False),
     ]
-    expected_vars_non_promoted_initial = [
+    expected_variables_non_promoted_initial = [
         Variable(name="indeps.x", val=np.array([1.0]), units="Pa", is_input=True),
         Variable(name="indeps.z", val=np.array([5.0, 2.0]), units="m**2", is_input=True),
         Variable(name="disc1.x", val=np.array([np.nan]), units=None, is_input=True, desc="input x"),
@@ -377,7 +387,7 @@ def test_get_variables_from_problem_sellar_with_promotion_with_computation():
         Variable(name="constraint2.y2", val=np.array([1.0]), units=None, is_input=True),
         Variable(name="constraint2.g2", val=np.array([1.0]), units=None, is_input=False),
     ]
-    expected_vars_non_promoted_computed = [
+    expected_variables_non_promoted_computed = [
         Variable(name="indeps.x", val=np.array([1.0]), units="Pa", is_input=True),
         Variable(name="indeps.z", val=np.array([5.0, 2.0]), units="m**2", is_input=True),
         Variable(name="disc1.x", val=np.array([1.0]), units=None, is_input=True, desc="input x"),
@@ -414,17 +424,23 @@ def test_get_variables_from_problem_sellar_with_promotion_with_computation():
 
     problem.run_model()
 
-    vars = VariableList.from_problem(problem, use_initial_values=True, get_promoted_names=True)
-    _compare_variable_lists(vars, expected_vars_promoted_initial)
+    variables = VariableList.from_problem(problem, use_initial_values=True, get_promoted_names=True)
+    _compare_variable_lists(variables, expected_variables_promoted_initial)
 
-    vars = VariableList.from_problem(problem, use_initial_values=True, get_promoted_names=False)
-    _compare_variable_lists(vars, expected_vars_non_promoted_initial)
+    variables = VariableList.from_problem(
+        problem, use_initial_values=True, get_promoted_names=False
+    )
+    _compare_variable_lists(variables, expected_variables_non_promoted_initial)
 
-    vars = VariableList.from_problem(problem, use_initial_values=False, get_promoted_names=True)
-    _compare_variable_lists(vars, expected_vars_promoted_computed)
+    variables = VariableList.from_problem(
+        problem, use_initial_values=False, get_promoted_names=True
+    )
+    _compare_variable_lists(variables, expected_variables_promoted_computed)
 
-    vars = VariableList.from_problem(problem, use_initial_values=False, get_promoted_names=False)
-    _compare_variable_lists(vars, expected_vars_non_promoted_computed)
+    variables = VariableList.from_problem(
+        problem, use_initial_values=False, get_promoted_names=False
+    )
+    _compare_variable_lists(variables, expected_variables_non_promoted_computed)
 
 
 def test_get_variables_from_problem_sellar_without_promotion_without_computation():
@@ -447,7 +463,7 @@ def test_get_variables_from_problem_sellar_without_promotion_without_computation
     problem.setup()
     problem.final_setup()
 
-    expected_vars_initial = [
+    expected_variables_initial = [
         Variable(name="indeps.x", val=np.array([1.0]), is_input=True),
         Variable(name="indeps.z", val=np.array([5.0, 2.0]), units="m**2", is_input=True),
         Variable(name="disc1.x", val=np.array([np.nan]), units=None, is_input=True, desc="input x"),
@@ -474,36 +490,36 @@ def test_get_variables_from_problem_sellar_without_promotion_without_computation
         Variable(name="constraint2.g2", val=np.array([1.0]), units=None, is_input=False),
     ]
 
-    vars = VariableList.from_problem(
+    variables = VariableList.from_problem(
         problem, use_initial_values=True, get_promoted_names=True, promoted_only=True
     )
-    _compare_variable_lists(vars, [])
+    _compare_variable_lists(variables, [])
 
-    vars = VariableList.from_problem(
+    variables = VariableList.from_problem(
         problem, use_initial_values=True, get_promoted_names=True, promoted_only=False
     )
-    _compare_variable_lists(vars, expected_vars_initial)
+    _compare_variable_lists(variables, expected_variables_initial)
 
-    vars = VariableList.from_problem(
+    variables = VariableList.from_problem(
         problem, use_initial_values=True, get_promoted_names=False, promoted_only=False
     )
-    _compare_variable_lists(vars, expected_vars_initial)
+    _compare_variable_lists(variables, expected_variables_initial)
 
     # use_initial_values=False should have no effect while problem has not been run
-    vars = VariableList.from_problem(
+    variables = VariableList.from_problem(
         problem, use_initial_values=False, get_promoted_names=True, promoted_only=True
     )
-    _compare_variable_lists(vars, [])
+    _compare_variable_lists(variables, [])
 
-    vars = VariableList.from_problem(
+    variables = VariableList.from_problem(
         problem, use_initial_values=False, get_promoted_names=True, promoted_only=False
     )
-    _compare_variable_lists(vars, expected_vars_initial)
+    _compare_variable_lists(variables, expected_variables_initial)
 
-    vars = VariableList.from_problem(
+    variables = VariableList.from_problem(
         problem, use_initial_values=False, get_promoted_names=False, promoted_only=False
     )
-    _compare_variable_lists(vars, expected_vars_initial)
+    _compare_variable_lists(variables, expected_variables_initial)
 
 
 def test_get_variables_from_problem_sellar_without_promotion_with_computation():
@@ -525,7 +541,7 @@ def test_get_variables_from_problem_sellar_without_promotion_with_computation():
     problem = om.Problem(group, reports=False)
     problem.setup()
 
-    expected_vars_initial = [
+    expected_variables_initial = [
         Variable(name="indeps.x", val=np.array([1.0]), is_input=True),
         Variable(name="indeps.z", val=np.array([5.0, 2.0]), units="m**2", is_input=True),
         Variable(name="disc1.x", val=np.array([np.nan]), units=None, is_input=True, desc="input x"),
@@ -551,7 +567,7 @@ def test_get_variables_from_problem_sellar_without_promotion_with_computation():
         Variable(name="constraint2.y2", val=np.array([1.0]), units=None, is_input=True),
         Variable(name="constraint2.g2", val=np.array([1.0]), units=None, is_input=False),
     ]
-    expected_vars_computed = [
+    expected_variables_computed = [
         Variable(name="indeps.x", val=np.array([1.0]), is_input=True),
         Variable(name="indeps.z", val=np.array([5.0, 2.0]), units="m**2", is_input=True),
         Variable(name="disc1.x", val=np.array([1.0]), units=None, is_input=True, desc="input x"),
@@ -587,30 +603,30 @@ def test_get_variables_from_problem_sellar_without_promotion_with_computation():
     ]
     problem.run_model()
 
-    vars = VariableList.from_problem(
+    variables = VariableList.from_problem(
         problem, use_initial_values=True, get_promoted_names=True, promoted_only=True
     )
-    _compare_variable_lists(vars, [])
+    _compare_variable_lists(variables, [])
 
-    vars = VariableList.from_problem(
+    variables = VariableList.from_problem(
         problem, use_initial_values=True, get_promoted_names=True, promoted_only=False
     )
-    _compare_variable_lists(vars, expected_vars_initial)
+    _compare_variable_lists(variables, expected_variables_initial)
 
-    vars = VariableList.from_problem(
+    variables = VariableList.from_problem(
         problem, use_initial_values=True, get_promoted_names=False, promoted_only=False
     )
-    _compare_variable_lists(vars, expected_vars_initial)
+    _compare_variable_lists(variables, expected_variables_initial)
 
-    vars = VariableList.from_problem(
+    variables = VariableList.from_problem(
         problem, use_initial_values=False, get_promoted_names=True, promoted_only=False
     )
-    _compare_variable_lists(vars, expected_vars_computed)
+    _compare_variable_lists(variables, expected_variables_computed)
 
-    vars = VariableList.from_problem(
+    variables = VariableList.from_problem(
         problem, use_initial_values=False, get_promoted_names=False, promoted_only=False
     )
-    _compare_variable_lists(vars, expected_vars_computed)
+    _compare_variable_lists(variables, expected_variables_computed)
 
 
 pytestmark = pytest.mark.filterwarnings(
@@ -621,26 +637,27 @@ pytestmark = pytest.mark.filterwarnings(
 
 def _test_and_check_from_unconnected_inputs(
     problem: om.Problem,
-    expected_mandatory_vars: list[Variable],
-    expected_optional_vars: list[Variable],
+    expected_mandatory_variables: list[Variable],
+    expected_optional_variables: list[Variable],
 ):
     problem.setup()
     problem.final_setup()
-    vars = VariableList.from_unconnected_inputs(problem, with_optional_inputs=False)
-    assert set(vars) == set(expected_mandatory_vars)
+    variables = VariableList.from_unconnected_inputs(problem, with_optional_inputs=False)
+    assert set(variables) == set(expected_mandatory_variables)
 
-    vars_dict = {var.name: var.description for var in vars}
-    expected_vars_dict = {var.name: var.description for var in expected_mandatory_vars}
-    assert vars_dict == expected_vars_dict
+    variables_dict = {var.name: var.description for var in variables}
+    expected_variables_dict = {var.name: var.description for var in expected_mandatory_variables}
+    assert variables_dict == expected_variables_dict
 
-    vars = VariableList.from_unconnected_inputs(problem, with_optional_inputs=True)
-    assert set(vars) == set(expected_mandatory_vars + expected_optional_vars)
+    variables = VariableList.from_unconnected_inputs(problem, with_optional_inputs=True)
+    assert set(variables) == set(expected_mandatory_variables + expected_optional_variables)
 
-    vars_dict = {var.name: var.description for var in vars}
-    expected_vars_dict = {
-        var.name: var.description for var in (expected_mandatory_vars + expected_optional_vars)
+    variables_dict = {var.name: var.description for var in variables}
+    expected_variables_dict = {
+        var.name: var.description
+        for var in (expected_mandatory_variables + expected_optional_variables)
     }
-    assert vars_dict == expected_vars_dict
+    assert variables_dict == expected_variables_dict
 
 
 def test_variables_from_unconnected_inputs_with_an_explicit_component():
@@ -648,7 +665,7 @@ def test_variables_from_unconnected_inputs_with_an_explicit_component():
     group.add_subsystem("disc1", Disc1(), promotes=["*"])
     problem = om.Problem(group, reports=False)
 
-    expected_mandatory_vars = [
+    expected_mandatory_variables = [
         Variable(
             name="x",
             val=np.array([np.nan]),
@@ -658,7 +675,7 @@ def test_variables_from_unconnected_inputs_with_an_explicit_component():
             desc="input x",
         )
     ]
-    expected_optional_vars = [
+    expected_optional_variables = [
         Variable(name="z", val=np.array([5.0, 2.0]), units="m**2", is_input=True, prom_name="z"),
         Variable(
             name="y2",
@@ -670,7 +687,7 @@ def test_variables_from_unconnected_inputs_with_an_explicit_component():
         ),
     ]
     _test_and_check_from_unconnected_inputs(
-        problem, expected_mandatory_vars, expected_optional_vars
+        problem, expected_mandatory_variables, expected_optional_variables
     )
 
 
@@ -680,7 +697,7 @@ def test_variables_from_unconnected_inputs_with_a_group(cleanup):
     group.add_subsystem("disc2", Disc2(), promotes=["*"])
     problem = om.Problem(group, reports=False)
 
-    expected_mandatory_vars = [
+    expected_mandatory_variables = [
         Variable(
             name="x",
             val=np.array([np.nan]),
@@ -690,7 +707,7 @@ def test_variables_from_unconnected_inputs_with_a_group(cleanup):
             desc="input x",
         )
     ]
-    expected_optional_vars = [
+    expected_optional_variables = [
         Variable(
             name="z",
             val=np.array([5.0, 2.0]),
@@ -701,7 +718,7 @@ def test_variables_from_unconnected_inputs_with_a_group(cleanup):
         )
     ]
     _test_and_check_from_unconnected_inputs(
-        problem, expected_mandatory_vars, expected_optional_vars
+        problem, expected_mandatory_variables, expected_optional_variables
     )
 
 
@@ -715,7 +732,7 @@ def test_variables_from_unconnected_inputs_with_sellar_problem(cleanup):
     group.add_subsystem("constaint2", FunctionG2(), promotes=["*"])
     problem = om.Problem(group, reports=False)
 
-    expected_mandatory_vars = [
+    expected_mandatory_variables = [
         Variable(
             name="x",
             val=np.array([np.nan]),
@@ -732,7 +749,7 @@ def test_variables_from_unconnected_inputs_with_sellar_problem(cleanup):
     # is provided in Disc2. We test here that if the kwarg "with_optional_inputs" is true the
     # description of the variable is updated.
 
-    expected_optional_vars = [
+    expected_optional_variables = [
         Variable(
             name="z",
             value=np.array([np.nan, np.nan]),
@@ -743,7 +760,7 @@ def test_variables_from_unconnected_inputs_with_sellar_problem(cleanup):
         )
     ]
     _test_and_check_from_unconnected_inputs(
-        problem, expected_mandatory_vars, expected_optional_vars
+        problem, expected_mandatory_variables, expected_optional_variables
     )
 
 
@@ -766,95 +783,97 @@ def test_get_variables_from_problem_sellar_with_promotion_and_connect():
     group.connect("disc2.y2", "y2")
 
     problem = om.Problem(group, reports=False)
-    vars_before_setup = VariableList.from_problem(
+    variables_before_setup = VariableList.from_problem(
         problem, use_initial_values=False, get_promoted_names=True
     )
     problem.setup()
     problem.final_setup()
-    vars = VariableList.from_problem(problem, use_initial_values=False, get_promoted_names=True)
-    assert vars_before_setup == vars
+    variables = VariableList.from_problem(
+        problem, use_initial_values=False, get_promoted_names=True
+    )
+    assert variables_before_setup == variables
 
     # x should be an output
-    assert not vars["x"].is_input
+    assert not variables["x"].is_input
     # y1 and y2 should be outputs
-    assert not vars["y1"].is_input
-    assert not vars["y2"].is_input
+    assert not variables["y1"].is_input
+    assert not variables["y2"].is_input
     # f, g1 and g2 should be outputs
-    assert not vars["f"].is_input
-    assert not vars["g1"].is_input
-    assert not vars["g2"].is_input
+    assert not variables["f"].is_input
+    assert not variables["g1"].is_input
+    assert not variables["g2"].is_input
     # indep:x and z as indeps should be inputs
-    assert vars["indep:x"].is_input
-    assert vars["z"].is_input
+    assert variables["indep:x"].is_input
+    assert variables["z"].is_input
 
     # Test for io_status
     # Check that all variables are returned
-    vars = VariableList.from_problem(
+    variables = VariableList.from_problem(
         problem, use_initial_values=False, get_promoted_names=True, io_status="all"
     )
 
-    assert "y1" in vars.names()
-    assert "y2" in vars.names()
-    assert "f" in vars.names()
-    assert "g1" in vars.names()
-    assert "g2" in vars.names()
-    assert "x" in vars.names()
-    assert "indep:x" in vars.names()
-    assert "z" in vars.names()
+    assert "y1" in variables.names()
+    assert "y2" in variables.names()
+    assert "f" in variables.names()
+    assert "g1" in variables.names()
+    assert "g2" in variables.names()
+    assert "x" in variables.names()
+    assert "indep:x" in variables.names()
+    assert "z" in variables.names()
 
     # Check that only inputs are returned
-    vars = VariableList.from_problem(
+    variables = VariableList.from_problem(
         problem, use_initial_values=False, get_promoted_names=True, io_status="inputs"
     )
 
-    assert "y1" not in vars.names()
-    assert "y2" not in vars.names()
-    assert "f" not in vars.names()
-    assert "g1" not in vars.names()
-    assert "g2" not in vars.names()
-    assert "indep:x" in vars.names()
-    assert "z" in vars.names()
+    assert "y1" not in variables.names()
+    assert "y2" not in variables.names()
+    assert "f" not in variables.names()
+    assert "g1" not in variables.names()
+    assert "g2" not in variables.names()
+    assert "indep:x" in variables.names()
+    assert "z" in variables.names()
 
     # Check that only outputs are returned
-    vars = VariableList.from_problem(
+    variables = VariableList.from_problem(
         problem, use_initial_values=False, get_promoted_names=True, io_status="outputs"
     )
 
-    assert "y1" in vars.names()
-    assert "y2" in vars.names()
-    assert "f" in vars.names()
-    assert "g1" in vars.names()
-    assert "g2" in vars.names()
-    assert "x" in vars.names()
-    assert "indep:x" not in vars.names()
-    assert "z" not in vars.names()
+    assert "y1" in variables.names()
+    assert "y2" in variables.names()
+    assert "f" in variables.names()
+    assert "g1" in variables.names()
+    assert "g2" in variables.names()
+    assert "x" in variables.names()
+    assert "indep:x" not in variables.names()
+    assert "z" not in variables.names()
 
 
 def test_get_val():
-    vars = VariableList()
-    vars["bar"] = {"value": 1.0, "units": "m"}
-    vars["baq"] = {"value": np.array([1.0])}
-    vars["foo"] = {"value": 1.0, "units": "m**2"}
-    vars["baz"] = {"value": [1.0, 2.0], "units": "m"}
-    vars["bat"] = {"value": (1.0, 2.0), "units": "m"}
-    vars["qux"] = {"value": np.array([1.0, 2.0]), "units": "m"}
-    vars["quux"] = {"value": [[1.0, 2.0], [2.0, 3.0]], "units": "m"}
-    data = vars["bar"].get_val()
+    variables = VariableList()
+    variables["bar"] = {"value": 1.0, "units": "m"}
+    variables["baq"] = {"value": np.array([1.0])}
+    variables["foo"] = {"value": 1.0, "units": "m**2"}
+    variables["baz"] = {"value": [1.0, 2.0], "units": "m"}
+    variables["bat"] = {"value": (1.0, 2.0), "units": "m"}
+    variables["qux"] = {"value": np.array([1.0, 2.0]), "units": "m"}
+    variables["quux"] = {"value": [[1.0, 2.0], [2.0, 3.0]], "units": "m"}
+    data = variables["bar"].get_val()
     assert not isinstance(data, list) and not isinstance(data, np.ndarray)
     assert_allclose(data, 1, rtol=1e-3, atol=1e-5)
     units = "km"
-    data = vars["bar"].get_val(new_units=units)
+    data = variables["bar"].get_val(new_units=units)
     assert_allclose(data, 1e-3, rtol=1e-3, atol=1e-5)
-    data = vars["baq"].get_val()
+    data = variables["baq"].get_val()
     assert not isinstance(data, list) and not isinstance(data, np.ndarray)
     assert_allclose(data, 1, rtol=1e-3, atol=1e-5)
     with pytest.raises(TypeError):
-        data = vars["foo"].get_val(new_units=units)
-    data = vars["baz"].get_val(new_units=units)
+        data = variables["foo"].get_val(new_units=units)
+    data = variables["baz"].get_val(new_units=units)
     assert_allclose(data, [1e-3, 2e-3], rtol=1e-3, atol=1e-5)
-    data = vars["bat"].get_val(new_units=units)
+    data = variables["bat"].get_val(new_units=units)
     assert_allclose(data, [1e-3, 2e-3], rtol=1e-3, atol=1e-5)
-    data = vars["qux"].get_val(new_units=units)
+    data = variables["qux"].get_val(new_units=units)
     assert_allclose(data, [1e-3, 2e-3], rtol=1e-3, atol=1e-5)
-    data = vars["quux"].get_val(new_units=units)
+    data = variables["quux"].get_val(new_units=units)
     assert_allclose(data, [[1e-3, 2e-3], [2e-3, 3e-3]], rtol=1e-3, atol=1e-5)

--- a/src/fastoad/openmdao/variables/_util.py
+++ b/src/fastoad/openmdao/variables/_util.py
@@ -12,6 +12,7 @@
 #  You should have received a copy of the GNU General Public License
 #  along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+import contextlib
 import itertools
 
 import numpy as np
@@ -46,11 +47,10 @@ def get_problem_variables(
     if not problem._metadata or problem._metadata["setup_status"] < _SetupStatus.POST_SETUP:
         problem = get_mpi_safe_problem_copy(problem)
         problem.setup()
-    try:  # This block will execute only if openMDAO >= 3.38
+    with contextlib.suppress(AttributeError):
+        # This block will execute only if openMDAO >= 3.38
         # TODO clean this code once versions < 3.38 are deprecated
         problem.set_setup_status(_SetupStatus.POST_SETUP2)
-    except AttributeError:
-        pass
 
     # Get inputs and outputs
     metadata_keys = (

--- a/src/fastoad/openmdao/variables/variable.py
+++ b/src/fastoad/openmdao/variables/variable.py
@@ -348,8 +348,9 @@ class Variable(Hashable):
 
         # Let's also ignore unimportant keys
         for key in METADATA_TO_IGNORE:
-            my_metadata.pop(key, default=None)
-            other_metadata.pop(key, default=None)
+            default_value = None
+            my_metadata.pop(key, default_value)
+            other_metadata.pop(key, default_value)
 
         return (
             isinstance(other, Variable)

--- a/tests/integration_tests/oad_process/test_oad_process.py
+++ b/tests/integration_tests/oad_process/test_oad_process.py
@@ -84,7 +84,7 @@ def test_non_regression_mission_only(cleanup):
         "CeRAS01_legacy_mission_only_result.xml",
         "non_regression_mission_only",
         use_xfoil=False,
-        vars_to_check=["data:mission:sizing:needed_block_fuel"],
+        variables_to_check=["data:mission:sizing:needed_block_fuel"],
         specific_tolerance=1.0e-2,
         global_tolerance=10.0e-2,
         check_weight_perfo_loop=False,
@@ -114,7 +114,7 @@ def run_non_regression_test(
     result_dir,
     xfoil_path=None,
     global_tolerance=1e-2,
-    vars_to_check=None,
+    variables_to_check=None,
     specific_tolerance=5.0e-3,
     *,
     use_xfoil=False,
@@ -126,9 +126,10 @@ def run_non_regression_test(
     :param legacy_result_file: reference data for inputs and outputs
     :param result_dir: relative name, folder will be in RESULTS_FOLDER_PATH
     :param xfoil_path: used if use_xfoil==True
-    :param vars_to_check: variables that will be concerned by specific_tolerance
+    :param variables_to_check: variables that will be concerned by specific_tolerance
     :param specific_tolerance: test will fail if absolute relative error between computed and
-                               reference values is beyond this value for variables in vars_to_check
+                               reference values is beyond this value for variables
+                               in variables_to_check
     :param global_tolerance: test will fail if absolute relative error between computed and
                              reference values is beyond this value for ANY variable
     :param use_xfoil: if True, XFOIL computation will be activated
@@ -192,8 +193,8 @@ def run_non_regression_test(
     print(df.sort_values(by=["abs_rel_delta"]))
 
     assert_allclose(df.value, df.ref_value, rtol=global_tolerance, atol=1.0e-9)
-    if vars_to_check is not None:
-        for name in vars_to_check:
+    if variables_to_check is not None:
+        for name in variables_to_check:
             row = df.loc[df.name == name]
             assert_allclose(row.value, row.ref_value, rtol=specific_tolerance, atol=1.0e-9)
 


### PR DESCRIPTION
## Summary of Linting Rules Added

This PR introduces a new set of Ruff linting rules to enforce better code quality, style consistency, and security practices. The enabled rule sets are:

- **C4** – Catch incorrect usage of comprehensions and constructors like `dict`, `list`, etc.
- **A** – Warn on shadowing built-in functions or types.
- **COM** – Ensure trailing commas are used where appropriate (often handled by the Ruff formatter).
- **ISC** – Promote consistent and efficient string concatenation practices.
- **ERA** – Detect large blocks of commented-out code.
- **PD** – Apply opinionated linting rules for pandas code usage.
- **SIM** – Include rules from `flake8-simplify` to suggest simpler code patterns.
- **ICN** – Enforce common import conventions (e.g., `import numpy as np` instead of `nump`).
- **NPY** – Catch NumPy-specific anti-patterns and improve usage clarity.
- **PL** – Integrate selected pylint checks for error detection, style, and potential refactor suggestions.
- **S** – Run Bandit security checks for common Python security issues.
- **N** – Enforce naming conventions according to PEP8.
- **E** – Include standard Pycodestyle error checks.
