### PR TITLE
Better handling of failed module logging

### DIFF
--- a/src/fastoad/module_management/tests/data/module_sellar_example/disc_4/__init__.py
+++ b/src/fastoad/module_management/tests/data/module_sellar_example/disc_4/__init__.py
@@ -1,3 +1,12 @@
-# This file is part of FAST-OAD_CS23-HE : A framework for rapid Overall Aircraft Design of Hybrid
-# Electric Aircraft.
-# Copyright (C) 2022 ISAE-SUPAERO
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
+#  Copyright (C) 2025 ONERA & ISAE-SUPAERO
+#  FAST is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.

--- a/src/fastoad/module_management/tests/data/module_sellar_example/disc_4/disc4.py
+++ b/src/fastoad/module_management/tests/data/module_sellar_example/disc_4/disc4.py
@@ -1,6 +1,6 @@
-"""Sellar discipline 2"""
+"""Sample discipline 4"""
 #  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
-#  Copyright (C) 2024 ONERA & ISAE-SUPAERO
+#  Copyright (C) 2025 ONERA & ISAE-SUPAERO
 #  FAST is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU General Public License as published by
 #  the Free Software Foundation, either version 3 of the License, or

--- a/src/fastoad/module_management/tests/test_register_openmdao_system.py
+++ b/src/fastoad/module_management/tests/test_register_openmdao_system.py
@@ -184,3 +184,13 @@ def test_sellar(load):
 
     fastoad_problem.run_driver()
     assert classical_problem["f"] == fastoad_problem["f"]  # both problems have run
+
+
+def test_un_registrable_module(load):
+    """
+    Tests the case where modules can't be registered and are not recognized are package. Ensures
+    it returns no errors other than a FastBundleLoaderUnknownFactoryNameError
+    """
+
+    with pytest.raises(FastBundleLoaderUnknownFactoryNameError):
+        RegisterOpenMDAOSystem.get_system("module_management_test.sellar.disc4")


### PR DESCRIPTION
## Summary of Changes
This PR slightly alters the handling of the logging of failed modules.

## Related Issues
 For some specific cases were modules were defined and registered through a `RegisterOpenMDAOSystem.explore_folder`, the failed variable was returned as a `set`. this was then passed to the `_log_failed_modules` method which expects `dict` resulting in an Error when doing `failed_modules.items()`. This can be reproduced by adding the disc_4 package in src\fastoad\module_management\tests\data\module_sellar_example and running 
```console
fastoad list_modules src\fastoad\module_management\tests\data\module_sellar_example
```

## New Dependencies
No new dependency

## Checklist

- [x] Have you followed the guidelines in our [Contributing](https://github.com/fast-aircraft-design/FAST-OAD/wiki/Development-environment) wiki?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [ ] Have you added new tests to cover your changes?
- [ ] Have you made corresponding changes to the documentation? If yes, please consider providing a link to the updated documentation.
- [x] Do the existing tests pass with your changes?
- [x] Have you commented on hard-to-understand areas of the code?
- [ ] Does this PR introduce a breaking change?

## Additional Context
<img width="1224" height="701" alt="image" src="https://github.com/user-attachments/assets/16eb1060-b704-4a34-abef-200b43d3d3ce" />
