### PR TITLE
Added initial, final and average altitude for cruise segment as mission output

### DIFF
--- a/src/fastoad/models/performances/mission/openmdao/mission_wrapper.py
+++ b/src/fastoad/models/performances/mission/openmdao/mission_wrapper.py
@@ -137,6 +137,12 @@ class MissionWrapper(MissionBuilder):
                 outputs[name_root + ":fuel"] = start.mass - end.mass
             if name_root + ":distance" in outputs:
                 outputs[name_root + ":distance"] = end.ground_distance - start.ground_distance
+            if name_root + ":initial_altitude" in outputs:
+                outputs[name_root + ":initial_altitude"] = start.altitude
+            if name_root + ":final_altitude" in outputs:
+                outputs[name_root + ":final_altitude"] = end.altitude
+            if name_root + ":average_altitude" in outputs:
+                outputs[name_root + ":average_altitude"] = (start.altitude + end.altitude) / 2
 
         flight_points = mission.compute_from(start_flight_point)
         flight_points.loc[0, "name"] = flight_points.loc[1, "name"]
@@ -239,5 +245,15 @@ class MissionWrapper(MissionBuilder):
             "m",
             f"covered ground distance during {flight_part_desc}",
         )
+        if "cruise" in name_root:
+            output_definition[name_root + ":initial_altitude"] = (
+                "m",
+                "the initial cruise altitude",
+            )
+            output_definition[name_root + ":final_altitude"] = ("m", "the final cruise altitude")
+            output_definition[name_root + ":average_altitude"] = (
+                "m",
+                "the initial cruise altitude",
+            )
 
         return output_definition

--- a/src/fastoad/models/performances/mission/openmdao/tests/test_mission.py
+++ b/src/fastoad/models/performances/mission/openmdao/tests/test_mission.py
@@ -136,6 +136,15 @@ def test_mission_component(cleanup, with_dummy_plugin_2):
     assert_allclose(
         problem["data:mission:operational:main_route:cruise:distance"], 3392590.0, atol=500.0
     )
+    assert_allclose(
+        problem["data:mission:operational:main_route:cruise:initial_altitude"], 10972.8, atol=1
+    )
+    assert_allclose(
+        problem["data:mission:operational:main_route:cruise:final_altitude"], 10972.8, atol=1.0
+    )
+    assert_allclose(
+        problem["data:mission:operational:main_route:cruise:average_altitude"], 10972.8, atol=1.0
+    )
 
     assert_allclose(
         problem["data:mission:operational:main_route:descent:duration"], 1424.0, atol=10.0
@@ -453,15 +462,27 @@ def test_mission_group_with_CL_limitation(cleanup, with_dummy_plugin_2):
         flight_points["name"] == "operational_optimal:main_route_optimal:cruise"
     ]
     CL_end_climb = climb_points.CL.iloc[-1]
-    altitude_end_climb = climb_points.altitude.iloc[-1]
-    altitude_end_cruise = cruise_points.altitude.iloc[-1]
     CL_end_cruise = cruise_points.CL.iloc[-1]
 
     # Check CL and altitude for a climbing cruise at constant CL.
     assert_allclose(CL_end_climb, 0.45, atol=1e-3)
     assert_allclose(CL_end_cruise, 0.45, atol=1e-3)
-    assert_allclose(altitude_end_climb, 9821.85, atol=1e-1)
-    assert_allclose(altitude_end_cruise, 10343.68, atol=1e-1)
+
+    assert_allclose(
+        problem["data:mission:operational_optimal:main_route_optimal:cruise:initial_altitude"],
+        9821.8,
+        atol=1,
+    )
+    assert_allclose(
+        problem["data:mission:operational_optimal:main_route_optimal:cruise:final_altitude"],
+        10343.0,
+        atol=1.0,
+    )
+    assert_allclose(
+        problem["data:mission:operational_optimal:main_route_optimal:cruise:average_altitude"],
+        10082.4,
+        atol=1.0,
+    )
 
 
 def test_mission_group_without_route(cleanup, with_dummy_plugin_2):


### PR DESCRIPTION
## Summary of Changes

In optimal cruise segment, the cruise altitude is adjusted depending on the aircraft mass and the polar. The actual cruise altitude can be a valuable information for other disciplines in the MDA specifically aerodynamics ( in higher fidelity ). This PR adds the initial, final and average altitude for all cruise segments.

## Related Issues

None

## New Dependencies

None

## Checklist

- [x] Have you followed the guidelines in our [Contributing](https://github.com/fast-aircraft-design/FAST-OAD/wiki/Development-environment) wiki?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [x] Have you added new tests to cover your changes?
- [ ] Have you made corresponding changes to the documentation? If yes, please consider providing a link to the updated documentation.
- [x] Do the existing tests pass with your changes?
- [ ] Have you commented on hard-to-understand areas of the code?
- [ ] Does this PR introduce a breaking change?

## Additional Context

Simple code modification, no additional documentation needed.
