### PR TITLE
Fix watchman test, preparing to update the openMDAO bounds in master branch

### DIFF
--- a/src/fastoad/openmdao/tests/test_problem.py
+++ b/src/fastoad/openmdao/tests/test_problem.py
@@ -145,10 +145,7 @@ def test_problem_read_inputs_before_setup(cleanup):
     assert_allclose(problem["f"], 21.7572, atol=1.0e-4)
 
     # We start from solution, so we should converge with only 2 iterations.
-    iter_count = [
-        iter_desc[2]
-        for iter_desc in problem.iter_count_iter(include_driver=False, include_solvers=True)
-    ][0]
+    iter_count = problem.model.sellar.nonlinear_solver._iter_count
     assert iter_count == 2
 
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Summary of Changes

Since https://github.com/OpenMDAO/OpenMDAO/commit/d77604c52f883cbfdfeb46b1c2fb8240425f5f97 the iter_count_iter method has been removed. This is the only thing that keeps the watchman tests failing. We now access the number of calls to NLBGS directly without using a specialized method.

Watchman tests now pass again.
