### PR TITLE
Add TOFL based on CS-25.113(a)

### DIFF
--- a/src/fastoad/models/performances/mission/openmdao/mission_wrapper.py
+++ b/src/fastoad/models/performances/mission/openmdao/mission_wrapper.py
@@ -40,6 +40,8 @@ from ..mission_definition.schema import (
     MissionDefinition,
 )
 
+TOFL_FACTOR = 1.15
+
 
 class MissionWrapper(MissionBuilder):
     """
@@ -141,7 +143,7 @@ class MissionWrapper(MissionBuilder):
             if name_root + ":distance" in outputs:
                 outputs[name_root + ":distance"] = distance
             if name_root + ":TOFL" in outputs:
-                outputs[name_root + ":TOFL"] = 1.15 * distance
+                outputs[name_root + ":TOFL"] = TOFL_FACTOR * distance
             if name_root + ":initial_altitude" in outputs:
                 outputs[name_root + ":initial_altitude"] = start.altitude
             if name_root + ":final_altitude" in outputs:
@@ -258,8 +260,8 @@ class MissionWrapper(MissionBuilder):
         if self._is_takeoff_phase(part_structure):
             output_definition[name_root + ":TOFL"] = (
                 "m",
-                "estimated takeoff field length (CS-25.113(a), 1.15 x AEO takeoff distance)"
-                f" during {flight_part_desc}",
+                f"estimated takeoff field length (CS-25.113(a), {TOFL_FACTOR} x AEO takeoff "
+                f"distance) during {flight_part_desc}",
             )
         # Check if this is an optimal cruise or any cruise-like segment
         if part_structure:

--- a/src/fastoad/models/performances/mission/openmdao/mission_wrapper.py
+++ b/src/fastoad/models/performances/mission/openmdao/mission_wrapper.py
@@ -133,12 +133,15 @@ class MissionWrapper(MissionBuilder):
 
         def _compute_vars(name_root, start: FlightPoint, end: FlightPoint):
             """Computes duration, burned fuel and covered distance."""
+            distance = end.ground_distance - start.ground_distance
             if name_root + ":duration" in outputs:
                 outputs[name_root + ":duration"] = end.time - start.time
             if name_root + ":fuel" in outputs:
                 outputs[name_root + ":fuel"] = start.mass - end.mass
             if name_root + ":distance" in outputs:
-                outputs[name_root + ":distance"] = end.ground_distance - start.ground_distance
+                outputs[name_root + ":distance"] = distance
+            if name_root + ":TOFL" in outputs:
+                outputs[name_root + ":TOFL"] = 1.15 * distance
             if name_root + ":initial_altitude" in outputs:
                 outputs[name_root + ":initial_altitude"] = start.altitude
             if name_root + ":final_altitude" in outputs:
@@ -200,7 +203,7 @@ class MissionWrapper(MissionBuilder):
                 )
             elif part[TYPE_TAG] == PHASE_TAG:
                 subpart_name = part[NAME_TAG]
-                output_definition.update(self._add_vars(subpart_name))
+                output_definition.update(self._add_vars(subpart_name, part))
             elif part[TYPE_TAG] == ROUTE_TAG:
                 route_name = part[NAME_TAG]
                 output_definition.update(self._add_vars(route_name))
@@ -251,6 +254,13 @@ class MissionWrapper(MissionBuilder):
             "m",
             f"covered ground distance during {flight_part_desc}",
         )
+
+        if self._is_takeoff_phase(part_structure):
+            output_definition[name_root + ":TOFL"] = (
+                "m",
+                "estimated takeoff field length (CS-25.113(a), 1.15 x AEO takeoff distance)"
+                f" during {flight_part_desc}",
+            )
         # Check if this is an optimal cruise or any cruise-like segment
         if part_structure:
             if part_structure.get(SEGMENT_TYPE_TAG) == "optimal_cruise":
@@ -279,3 +289,16 @@ class MissionWrapper(MissionBuilder):
                 )
 
         return output_definition
+
+    @staticmethod
+    def _is_takeoff_phase(part_structure: dict | None) -> bool:
+        """Returns True when provided phase structure looks like a takeoff phase."""
+        if not isinstance(part_structure, dict):
+            return False
+
+        for part in part_structure.get(PARTS_TAG, []):
+            segment_type = part.get(SEGMENT_TYPE_TAG)
+            if segment_type in {"takeoff", "rotation", "end_of_takeoff"}:
+                return True
+
+        return False

--- a/src/fastoad/models/performances/mission/openmdao/tests/test_mission_takeoff.py
+++ b/src/fastoad/models/performances/mission/openmdao/tests/test_mission_takeoff.py
@@ -117,7 +117,10 @@ def test_mission_component(cleanup, with_dummy_plugin_2):
     take_off_distance = problem[
         "data:mission:operational_wo_gnd_effect:takeoff_wo_gnd_effect:distance"
     ]
+    take_off_tofl = problem["data:mission:operational_wo_gnd_effect:takeoff_wo_gnd_effect:TOFL"]
     assert_allclose(take_off_distance, 1774, atol=1.0)
+    assert_allclose(take_off_tofl, 1.15 * take_off_distance, atol=1.0e-8)
+    assert_allclose(take_off_tofl, 2040.1, atol=1.0)
     assert_allclose(
         problem["data:mission:operational_wo_gnd_effect:needed_block_fuel"], 6505, atol=1.0
     )
@@ -161,7 +164,10 @@ def test_ground_effect(cleanup, with_dummy_plugin_2):
     # Useful for debugging
     # plot_flight(problem.model.component.flight_points, "test_mission.png")  # noqa: ERA001
     take_off_distance = problem["data:mission:operational:takeoff:distance"]
+    take_off_tofl = problem["data:mission:operational:takeoff:TOFL"]
     assert_allclose(take_off_distance, 1762, atol=1.0)
+    assert_allclose(take_off_tofl, 1.15 * take_off_distance, atol=1.0e-8)
+    assert_allclose(take_off_tofl, 2026.3, atol=1.0)
     assert_allclose(problem["data:mission:operational:takeoff:fuel"], 122.1, atol=1e-1)
     assert_allclose(problem["data:mission:operational:takeoff:duration"], 33.9, atol=1e-1)
 
@@ -196,6 +202,10 @@ def test_start_stop(cleanup, with_dummy_plugin_2):
     start_stop_distance = problem["data:mission:start_stop_mission:start_stop:distance"]
     assert_allclose(start_stop_distance, 1659, atol=1.0)
     assert_allclose(problem["data:mission:start_stop_mission:start_stop:duration"], 42.8, atol=1e-1)
+    with pytest.raises(
+        KeyError
+    ):  # no takeoff specific outputs should be present in start-stop mission
+        _ = problem["data:mission:start_stop_mission:start_stop:TOFL"]
 
 
 def test_mission_group_without_loop(cleanup, with_dummy_plugin_2):


### PR DESCRIPTION
This pull request adds support for estimating and outputting the Takeoff Field Length (TOFL) for takeoff phases in the mission performance model. It introduces logic to identify takeoff phases, computes the TOFL as 1.15 times the takeoff distance, and ensures this value is only present when a takeoff phase is done (we only output automatic variables on the xml for phases and not segments).

New tests have been added to validate the correct calculation and presence of the TOFL output.