### PR TITLE
Cumulative quantities in FlightPoint

### DIFF
--- a/docs/documentation/mission_module/extensibility/flight_point.rst
+++ b/docs/documentation/mission_module/extensibility/flight_point.rst
@@ -84,7 +84,7 @@ outside any class or function::
 Time integration
 ***************************
 
-For those additional fields, it is also possible to define their time derivative. If a time derivative is defined this way, the mission model will automatically perform the integration. This integration will be achieved by incrementing the field at each time step by the product of the time derivative and the time step in seconds.
+For those additional fields, it is also possible to define their time derivative. If a time derivative is defined this way, the mission model will automatically perform the integration. This integration will be achieved by incrementing the field at each time step by the product of the time derivative and the length of the time step in seconds.
 
 The order in which a field and its time derivative are defined is irrelevant. However, the existence of the field containing the time derivative will be verified when the analysis process is run::
 

--- a/docs/documentation/mission_module/extensibility/flight_point.rst
+++ b/docs/documentation/mission_module/extensibility/flight_point.rst
@@ -84,12 +84,12 @@ outside any class or function::
 Time integration
 ***************************
 
-For those additional fields, it is also possible to define their time derivative. If a time derivative is defined this way, the mission model will automatically perform the integration. This integration will be achieved by incrementing the field at each time step by the product of the time derivative and the length of the time step in seconds.
+For those additional user-defined fields, it is also possible to define their time derivative. If a time derivative is defined this way, the mission model will automatically perform the integration. This integration will be achieved by incrementing the field at each time step by the product of the time derivative and the length of the time step in seconds.
 
 The order in which a field and its time derivative are defined is irrelevant. However, the existence of the field containing the time derivative will be verified when the analysis process is run::
 
     # Adding a time-dependent field and declaring the field which contains its derivative
-    # using the 'integrates_from' descriptor.
+    # using the 'integrates_from' field descriptor.
     >>> FlightPoint.add_field(
     ...    "electric_energy",
     ...    unit="J",
@@ -104,4 +104,4 @@ The order in which a field and its time derivative are defined is irrelevant. Ho
     ... "electric_power", default_value=0.0, unit="W", is_cumulative=False
     ... )
 
-    # Field will be incremented as: field[i+1] = field[i] + time_derivative[i] * time_step
+    # Field will be incremented as: field[i+1] = field[i] + time_derivative[i] * time_step[i]

--- a/docs/documentation/mission_module/extensibility/flight_point.rst
+++ b/docs/documentation/mission_module/extensibility/flight_point.rst
@@ -80,3 +80,28 @@ outside any class or function::
     # Removing a field, even an original one
     >>> FlightPoint.remove_field("sfc")
 
+***************************
+Time integration
+***************************
+
+For those additional fields, it is also possible to define their time derivative. If a time derivative is defined this way, the mission model will automatically perform the integration. This integration will be achieved by incrementing the field at each time step by the product of the time derivative and the time step in seconds.
+
+The order in which a field and its time derivative are defined is irrelevant. However, the existence of the field containing the time derivative will be verified when the analysis process is run::
+
+    # Adding a time-dependent field and declaring the field which contains its derivative
+    # using the 'integrates_from' descriptor.
+    >>> FlightPoint.add_field(
+    ...    "electric_energy",
+    ...    unit="J",
+    ...    default_value=0.0,
+    ...    is_cumulative=True,
+    ...    integrates_from="electric_power",
+    ... )
+
+    # Now defining the field that contains the derivative. The unit of the derivative must
+    # be the unit of the original field *per second*
+    >>> FlightPoint.add_field(
+    ... "electric_power", default_value=0.0, unit="W", is_cumulative=False
+    ... )
+
+    # Field will be incremented as: field[i+1] = field[i] + time_derivative[i] * time_step

--- a/src/fastoad/model_base/flight_point.py
+++ b/src/fastoad/model_base/flight_point.py
@@ -99,6 +99,35 @@ class FlightPoint:
             # Removing a field, even an original one
             >>> FlightPoint.remove_field("sfc")
 
+    **Time integration**
+
+        For those additional fields, it is also possible to define their time derivative. If a time
+        derivative is defined this way, the mission model will automatically perform the
+        integration. This integration will be achieved by incrementing the field at each time step
+        by the product of the time derivative and the time step in seconds.
+
+        The order in which a field and its time derivative are defined is irrelevant. However,
+        the existence of the field containing the time derivative will be verified when the
+        analysis process is run::
+
+            # Adding a time-dependent field and declaring the field which contains its derivative
+            # using the 'integrates_from' descriptor.
+            >>> FlightPoint.add_field(
+            ...    "electric_energy",
+            ...    unit="J",
+            ...    default_value=0.0,
+            ...    is_cumulative=True,
+            ...    integrates_from="electric_power",
+            ... )
+
+            # Now defining the field that contains the derivative. The unit of the derivative must
+            # be the unit of the original field *per second*
+            >>> FlightPoint.add_field(
+            ... "electric_power", default_value=0.0, unit="W", is_cumulative=False
+            ... )
+
+            # Field will be incremented as: field[i+1] = field[i] + time_derivative[i] * time_step
+
     .. note::
 
         All original parameters in FlightPoint instances are expected to be in SI units.

--- a/src/fastoad/model_base/flight_point.py
+++ b/src/fastoad/model_base/flight_point.py
@@ -101,17 +101,18 @@ class FlightPoint:
 
     **Time integration**
 
-        For those additional fields, it is also possible to define their time derivative. If a time
-        derivative is defined this way, the mission model will automatically perform the
-        integration. This integration will be achieved by incrementing the field at each time step
-        by the product of the time derivative and the length of the time step in seconds.
+        For those additional user-defined fields, it is also possible to define their time
+        derivative. If a time derivative is defined this way, the mission model will
+        automatically perform the integration. This integration will be achieved by incrementing
+        the field at each time step by the product of the time derivative and the length of the
+        time step in seconds.
 
         The order in which a field and its time derivative are defined is irrelevant. However,
         the existence of the field containing the time derivative will be verified when the
         analysis process is run::
 
             # Adding a time-dependent field and declaring the field which contains its derivative
-            # using the 'integrates_from' descriptor.
+            # using the 'integrates_from' field descriptor.
             >>> FlightPoint.add_field(
             ...    "electric_energy",
             ...    unit="J",
@@ -126,7 +127,8 @@ class FlightPoint:
             ...     "electric_power", default_value=0.0, unit="W", is_cumulative=False
             ... )
 
-            # Field will be incremented as: field[i+1] = field[i] + time_derivative[i] * time_step[i]
+            # Field will be incremented as: field[i+1] = field[i] + time_derivative[i] *
+            # time_step[i]
 
     .. note::
 
@@ -453,11 +455,10 @@ class FlightPoint:
                         # integrable. Worst case, the process won't crash but the results will be
                         # inconsistent
                         if not cls_field.metadata[FIELD_DESCRIPTOR].is_cumulative:
-                            _LOGGER.warning(
-                                "Field '%s' is declared as integrating from another field but is "
-                                "not declared as cumulative. 'integrates_from' will only be used if"
-                                " 'is_cumulative' is True.",
-                                field_name,
+                            raise ValueError(
+                                f"Field '{field_name}' is declared as integrating from another "
+                                f"field but is not declared as cumulative. 'integrates_from' can "
+                                f"only be declared if 'is_cumulative' is True.",
                             )
 
                         # Check that the field we want to integrate from actually exists. If it
@@ -474,7 +475,7 @@ class FlightPoint:
         return cls.__time_integrable_quantities
 
     @classmethod
-    def get_time_integrand(cls, field_name) -> str | None:
+    def get_time_integrand(cls, field_name) -> str:
         """
         Returns the quantity the field integrates from.
         """

--- a/src/fastoad/model_base/flight_point.py
+++ b/src/fastoad/model_base/flight_point.py
@@ -15,6 +15,7 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Mapping, Sequence
 from copy import deepcopy
 from dataclasses import asdict, dataclass, field, fields
@@ -27,6 +28,8 @@ from fastoad._utils.arrays import scalarize
 from fastoad.constants import EngineSetting
 
 FIELD_DESCRIPTOR = "field_descriptor"
+
+_LOGGER = logging.getLogger(__name__)  # Logger for this module
 
 
 @dataclass
@@ -200,7 +203,7 @@ class FlightPoint:
 
     # Will store field metadata when needed. Must be accessed through _get_field_descriptors()
     __field_descriptors: ClassVar[dict] = {}
-    __cumulative_quantities: ClassVar[dict] = {}
+    __time_integrable_quantities: ClassVar[dict] = {}
 
     def __post_init__(self):
         self._relative_parameters = {"ground_distance", "time"}
@@ -346,7 +349,7 @@ class FlightPoint:
                      physical quantity. Set to None, when unit concept does not apply.
         :param is_cumulative: True if field value is summed up during mission
         :param integrates_from: Name of the other field this value is integrated by (in other words,
-                                incremented by that value multiplied by the time step)
+                                incremented by that value multiplied by the time step always in s)
         """
         cls._redeclare_fields()
 
@@ -404,27 +407,49 @@ class FlightPoint:
         return cls._get_field_descriptors().get(field_name, _FieldDescriptor(None, None))
 
     @classmethod
-    def get_cumulative_quantities(cls) -> dict[str, str]:
+    def get_time_integrable_quantities(cls) -> dict[str, str | None]:
         """
         Uses this method instead of accessing cls.__cumulative_quantity to ensure it
         will always be correctly populated.
         """
-        if not cls.__cumulative_quantities:
-            cls.__cumulative_quantities = {
-                cls_field.name: cls_field.metadata[FIELD_DESCRIPTOR].integrates_from
-                for cls_field in fields(cls)
-                if not cls_field.name.startswith("_")
-                and cls_field.metadata[FIELD_DESCRIPTOR].is_cumulative
-            }
+        if not cls.__time_integrable_quantities:
+            for cls_field in fields(cls):
+                field_name = cls_field.name
+                if not field_name.startswith("_"):
+                    time_derivative = cls_field.metadata[FIELD_DESCRIPTOR].integrates_from
+                    if time_derivative is not None:
+                        # Field is declared as having a derivative through the integrated_from
+                        # descriptor but not through the is_cumulative descriptor. It is not
+                        # consistent, so we raise a warning and ignore the field as being
+                        # integrable. Worst case, the process won't crash but the results will be
+                        # inconsistent
+                        if not cls_field.metadata[FIELD_DESCRIPTOR].is_cumulative:
+                            _LOGGER.warning(
+                                "Field '%s' is declared as integrating from another field but is "
+                                "not declared as cumulative. 'integrates_from' will only be used if"
+                                " 'is_cumulative' is True.",
+                                field_name,
+                            )
 
-        return cls.__cumulative_quantities
+                        # Check that the field we want to integrate from actually exists. If it
+                        # doesn't raise an error because the process will actually crash.
+                        if time_derivative not in cls._get_field_descriptors():
+                            raise ValueError(
+                                f"Field '{field_name}' is declared as integrating from "
+                                f"'{time_derivative}', but '{time_derivative}' is not an existing "
+                                f"field.",
+                            )
+
+                        cls.__time_integrable_quantities[field_name] = time_derivative
+
+        return cls.__time_integrable_quantities
 
     @classmethod
-    def get_cumulative_quantity(cls, field_name) -> str | None:
+    def get_time_integrand(cls, field_name) -> str | None:
         """
-        Returns the quantity the field cumulates from if it is cumulative and if it was specified.
+        Returns the quantity the field integrates from.
         """
-        return cls.get_cumulative_quantities().get(field_name, None)
+        return cls.get_time_integrable_quantities().get(field_name, None)
 
     @classmethod
     def _redeclare_fields(cls):
@@ -440,4 +465,4 @@ class FlightPoint:
             )
 
         cls.__field_descriptors = {}  # Will need to rebuild this dict on next usage.
-        cls.__cumulative_quantities = {}  # Will need to rebuild this dict on next usage.
+        cls.__time_integrable_quantities = {}  # Will need to rebuild this dict on next usage.

--- a/src/fastoad/model_base/flight_point.py
+++ b/src/fastoad/model_base/flight_point.py
@@ -104,7 +104,7 @@ class FlightPoint:
         For those additional fields, it is also possible to define their time derivative. If a time
         derivative is defined this way, the mission model will automatically perform the
         integration. This integration will be achieved by incrementing the field at each time step
-        by the product of the time derivative and the time step in seconds.
+        by the product of the time derivative and the length of the time step in seconds.
 
         The order in which a field and its time derivative are defined is irrelevant. However,
         the existence of the field containing the time derivative will be verified when the
@@ -123,7 +123,7 @@ class FlightPoint:
             # Now defining the field that contains the derivative. The unit of the derivative must
             # be the unit of the original field *per second*
             >>> FlightPoint.add_field(
-            ... "electric_power", default_value=0.0, unit="W", is_cumulative=False
+            ...     "electric_power", default_value=0.0, unit="W", is_cumulative=False
             ... )
 
             # Field will be incremented as: field[i+1] = field[i] + time_derivative[i] * time_step

--- a/src/fastoad/model_base/flight_point.py
+++ b/src/fastoad/model_base/flight_point.py
@@ -36,8 +36,8 @@ class _FieldDescriptor:
     """
 
     is_cumulative: bool | None = False
-    cumulates_from: str | None = (
-        None  # Indicates the field in the flight point that increments that values
+    integrates_from: str | None = (
+        None  # Indicates the field in the flight point that is used to integrate that value
     )
     unit: str | None = None
 
@@ -332,7 +332,7 @@ class FlightPoint:
         unit="-",
         *,
         is_cumulative=False,
-        cumulates_from: str | None = None,
+        integrates_from: str | None = None,
     ):
         """
         Adds the named field to FlightPoint class.
@@ -345,7 +345,8 @@ class FlightPoint:
         :param unit: expected unit for the added field. "-" should be provided for a dimensionless
                      physical quantity. Set to None, when unit concept does not apply.
         :param is_cumulative: True if field value is summed up during mission
-        :param cumulates_from: Name of the other field this value incremented by
+        :param integrates_from: Name of the other field this value is integrated by (in other words,
+                                incremented by that value multiplied by the time step)
         """
         cls._redeclare_fields()
 
@@ -357,7 +358,7 @@ class FlightPoint:
                 default=default_value,
                 metadata={
                     FIELD_DESCRIPTOR: _FieldDescriptor(
-                        unit=unit, is_cumulative=is_cumulative, cumulates_from=cumulates_from
+                        unit=unit, is_cumulative=is_cumulative, integrates_from=integrates_from
                     )
                 },
             ),
@@ -403,14 +404,14 @@ class FlightPoint:
         return cls._get_field_descriptors().get(field_name, _FieldDescriptor(None, None))
 
     @classmethod
-    def _get_cumulative_quantities(cls) -> dict[str, str]:
+    def get_cumulative_quantities(cls) -> dict[str, str]:
         """
         Uses this method instead of accessing cls.__cumulative_quantity to ensure it
         will always be correctly populated.
         """
         if not cls.__cumulative_quantities:
             cls.__cumulative_quantities = {
-                cls_field.name: cls_field.metadata[FIELD_DESCRIPTOR].cumulates_from
+                cls_field.name: cls_field.metadata[FIELD_DESCRIPTOR].integrates_from
                 for cls_field in fields(cls)
                 if not cls_field.name.startswith("_")
                 and cls_field.metadata[FIELD_DESCRIPTOR].is_cumulative
@@ -419,11 +420,11 @@ class FlightPoint:
         return cls.__cumulative_quantities
 
     @classmethod
-    def _get_cumulative_quantity(cls, field_name) -> str | None:
+    def get_cumulative_quantity(cls, field_name) -> str | None:
         """
         Returns the quantity the field cumulates from if it is cumulative and if it was specified.
         """
-        return cls._get_cumulative_quantities().get(field_name, None)
+        return cls.get_cumulative_quantities().get(field_name, None)
 
     @classmethod
     def _redeclare_fields(cls):

--- a/src/fastoad/model_base/flight_point.py
+++ b/src/fastoad/model_base/flight_point.py
@@ -126,7 +126,7 @@ class FlightPoint:
             ...     "electric_power", default_value=0.0, unit="W", is_cumulative=False
             ... )
 
-            # Field will be incremented as: field[i+1] = field[i] + time_derivative[i] * time_step
+            # Field will be incremented as: field[i+1] = field[i] + time_derivative[i] * time_step[i]
 
     .. note::
 

--- a/src/fastoad/model_base/flight_point.py
+++ b/src/fastoad/model_base/flight_point.py
@@ -36,6 +36,9 @@ class _FieldDescriptor:
     """
 
     is_cumulative: bool | None = False
+    cumulates_from: str | None = (
+        None  # Indicates the field in the flight point that increments that values
+    )
     unit: str | None = None
 
 
@@ -197,6 +200,7 @@ class FlightPoint:
 
     # Will store field metadata when needed. Must be accessed through _get_field_descriptors()
     __field_descriptors: ClassVar[dict] = {}
+    __cumulative_quantities: ClassVar[dict] = {}
 
     def __post_init__(self):
         self._relative_parameters = {"ground_distance", "time"}
@@ -328,6 +332,7 @@ class FlightPoint:
         unit="-",
         *,
         is_cumulative=False,
+        cumulates_from: str | None = None,
     ):
         """
         Adds the named field to FlightPoint class.
@@ -340,6 +345,7 @@ class FlightPoint:
         :param unit: expected unit for the added field. "-" should be provided for a dimensionless
                      physical quantity. Set to None, when unit concept does not apply.
         :param is_cumulative: True if field value is summed up during mission
+        :param cumulates_from: Name of the other field this value incremented by
         """
         cls._redeclare_fields()
 
@@ -350,7 +356,9 @@ class FlightPoint:
             field(
                 default=default_value,
                 metadata={
-                    FIELD_DESCRIPTOR: _FieldDescriptor(unit=unit, is_cumulative=is_cumulative)
+                    FIELD_DESCRIPTOR: _FieldDescriptor(
+                        unit=unit, is_cumulative=is_cumulative, cumulates_from=cumulates_from
+                    )
                 },
             ),
         )
@@ -395,6 +403,29 @@ class FlightPoint:
         return cls._get_field_descriptors().get(field_name, _FieldDescriptor(None, None))
 
     @classmethod
+    def _get_cumulative_quantities(cls) -> dict[str, str]:
+        """
+        Uses this method instead of accessing cls.__cumulative_quantity to ensure it
+        will always be correctly populated.
+        """
+        if not cls.__cumulative_quantities:
+            cls.__cumulative_quantities = {
+                cls_field.name: cls_field.metadata[FIELD_DESCRIPTOR].cumulates_from
+                for cls_field in fields(cls)
+                if not cls_field.name.startswith("_")
+                and cls_field.metadata[FIELD_DESCRIPTOR].is_cumulative
+            }
+
+        return cls.__cumulative_quantities
+
+    @classmethod
+    def _get_cumulative_quantity(cls, field_name) -> str | None:
+        """
+        Returns the quantity the field cumulates from if it is cumulative and if it was specified.
+        """
+        return cls._get_cumulative_quantities().get(field_name, None)
+
+    @classmethod
     def _redeclare_fields(cls):
         """
         To be done before "re-dataclassing" cls.
@@ -408,3 +439,4 @@ class FlightPoint:
             )
 
         cls.__field_descriptors = {}  # Will need to rebuild this dict on next usage.
+        cls.__cumulative_quantities = {}  # Will need to rebuild this dict on next usage.

--- a/src/fastoad/model_base/tests/test_flight_point.py
+++ b/src/fastoad/model_base/tests/test_flight_point.py
@@ -116,8 +116,8 @@ def test_cumulative_quantities():
     # the field they cumulate from is handled case by case so they have no field they cumulate from
 
     assert FlightPoint.is_cumulative("time")
-    assert "time" in FlightPoint._get_cumulative_quantities()  # Those two lines do the same thing
-    assert not FlightPoint._get_cumulative_quantity(
+    assert "time" in FlightPoint.get_cumulative_quantities()  # Those two lines do the same thing
+    assert not FlightPoint.get_cumulative_quantity(
         "time"
     )  # Time, like other default cumulative quantities in FlightPoint, have no quantity it
     # cumulates from
@@ -131,9 +131,9 @@ def test_cumulative_quantities():
         default_value=1337.0,
         unit="slug/ft",
         is_cumulative=True,
-        cumulates_from="foo",
+        integrates_from="foo",
     )
 
     assert FlightPoint.is_cumulative("bar")
-    assert "bar" in FlightPoint._get_cumulative_quantities()
-    assert FlightPoint._get_cumulative_quantity("bar") == "foo"
+    assert "bar" in FlightPoint.get_cumulative_quantities()
+    assert FlightPoint.get_cumulative_quantity("bar") == "foo"

--- a/src/fastoad/model_base/tests/test_flight_point.py
+++ b/src/fastoad/model_base/tests/test_flight_point.py
@@ -127,7 +127,7 @@ def test_time_integrable_quantities(caplog):
         "bar",
         annotation_type=float,
         default_value=1337.0,
-        unit="slug/ft",
+        unit="slug",
         is_cumulative=True,
         integrates_from="foo",
     )
@@ -141,13 +141,13 @@ def test_time_integrable_quantities(caplog):
 
     # Declare the field it integrates from but also redeclare bar as being not cumulative.
     FlightPoint.add_field(
-        "foo", annotation_type=float, default_value=42.0, unit="m", is_cumulative=False
+        "foo", annotation_type=float, default_value=42.0, unit="slug/s", is_cumulative=False
     )
     FlightPoint.add_field(
         "bar",
         annotation_type=float,
         default_value=1337.0,
-        unit="slug/ft",
+        unit="slug",
         is_cumulative=False,
         integrates_from="foo",
     )
@@ -165,7 +165,7 @@ def test_time_integrable_quantities(caplog):
         "bar",
         annotation_type=float,
         default_value=1337.0,
-        unit="slug/ft",
+        unit="slug",
         is_cumulative=True,
         integrates_from="foo",
     )

--- a/src/fastoad/model_base/tests/test_flight_point.py
+++ b/src/fastoad/model_base/tests/test_flight_point.py
@@ -109,3 +109,31 @@ def test_descriptors():
 
     assert FlightPoint.get_unit("altitude") == "m"
     assert FlightPoint.get_unit("engine_setting") is None
+
+
+def test_cumulative_quantities():
+    # On a default flight point, there are cumulative quantities (fuel, ground distance, ...) but
+    # the field they cumulate from is handled case by case so they have no field they cumulate from
+
+    assert FlightPoint.is_cumulative("time")
+    assert "time" in FlightPoint._get_cumulative_quantities()  # Those two lines do the same thing
+    assert not FlightPoint._get_cumulative_quantity(
+        "time"
+    )  # Time, like other default cumulative quantities in FlightPoint, have no quantity it
+    # cumulates from
+
+    FlightPoint.add_field(
+        "foo", annotation_type=float, default_value=42.0, unit="m", is_cumulative=False
+    )
+    FlightPoint.add_field(
+        "bar",
+        annotation_type=float,
+        default_value=1337.0,
+        unit="slug/ft",
+        is_cumulative=True,
+        cumulates_from="foo",
+    )
+
+    assert FlightPoint.is_cumulative("bar")
+    assert "bar" in FlightPoint._get_cumulative_quantities()
+    assert FlightPoint._get_cumulative_quantity("bar") == "foo"

--- a/src/fastoad/model_base/tests/test_flight_point.py
+++ b/src/fastoad/model_base/tests/test_flight_point.py
@@ -83,32 +83,35 @@ def test_scalarize():
 
 
 def test_descriptors():
-    FlightPoint.add_field(
-        "foo", annotation_type=float, default_value=42.0, unit="m", is_cumulative=False
-    )
-    # Testing redeclaration
-    FlightPoint.add_field(
-        "foo",
-        annotation_type=float,
-        default_value=42.0,
-        unit="slug/ft",
-        is_cumulative=True,
-    )
+    try:
+        FlightPoint.add_field(
+            "foo", annotation_type=float, default_value=42.0, unit="m", is_cumulative=False
+        )
+        # Testing redeclaration
+        FlightPoint.add_field(
+            "foo",
+            annotation_type=float,
+            default_value=42.0,
+            unit="slug/ft",
+            is_cumulative=True,
+        )
 
-    assert FlightPoint.get_units()["time"] == "s"
-    assert FlightPoint.get_units()["foo"] == "slug/ft"
+        assert FlightPoint.get_units()["time"] == "s"
+        assert FlightPoint.get_units()["foo"] == "slug/ft"
 
-    assert FlightPoint.get_unit("time") == "s"
-    assert FlightPoint.get_unit("foo") == "slug/ft"
+        assert FlightPoint.get_unit("time") == "s"
+        assert FlightPoint.get_unit("foo") == "slug/ft"
 
-    assert FlightPoint.is_cumulative("time")
-    assert not FlightPoint.is_cumulative("altitude")
-    assert FlightPoint.is_cumulative("foo")
+        assert FlightPoint.is_cumulative("time")
+        assert not FlightPoint.is_cumulative("altitude")
+        assert FlightPoint.is_cumulative("foo")
 
-    FlightPoint.remove_field("foo")
+        assert FlightPoint.get_unit("altitude") == "m"
+        assert FlightPoint.get_unit("engine_setting") is None
 
-    assert FlightPoint.get_unit("altitude") == "m"
-    assert FlightPoint.get_unit("engine_setting") is None
+    finally:
+        # Free the fields we added to ensure that there is no interference with other tests.
+        FlightPoint.remove_field("foo")
 
 
 def test_time_integrable_quantities():
@@ -121,57 +124,60 @@ def test_time_integrable_quantities():
     assert FlightPoint.is_cumulative("time")
     assert "time" not in FlightPoint.get_time_integrable_quantities()
 
-    # Add a quantity which is declared as having a time derivative but the field it is integrated
-    # from does not exist
-    FlightPoint.add_field(
-        "bar",
-        annotation_type=float,
-        default_value=1337.0,
-        unit="slug",
-        is_cumulative=True,
-        integrates_from="foo",
-    )
-    with pytest.raises(ValueError) as exc_info:
-        FlightPoint.get_time_integrable_quantities()
+    try:
+        # Add a quantity which is declared as having a time derivative but the field it is
+        # integrated from does not exist
+        FlightPoint.add_field(
+            "bar",
+            annotation_type=float,
+            default_value=1337.0,
+            unit="slug",
+            is_cumulative=True,
+            integrates_from="foo",
+        )
+        with pytest.raises(ValueError) as exc_info:
+            FlightPoint.get_time_integrable_quantities()
 
-    assert (
-        "Field 'bar' is declared as integrating from 'foo', but 'foo' is not an existing field."
-        in str(exc_info.value)
-    )
+        assert (
+            "Field 'bar' is declared as integrating from 'foo', but 'foo' is not an existing field."
+            in str(exc_info.value)
+        )
 
-    # Declare the field it integrates from but also redeclare bar as being not cumulative.
-    FlightPoint.add_field(
-        "foo", annotation_type=float, default_value=42.0, unit="slug/s", is_cumulative=False
-    )
-    FlightPoint.add_field(
-        "bar",
-        annotation_type=float,
-        default_value=1337.0,
-        unit="slug",
-        is_cumulative=False,
-        integrates_from="foo",
-    )
-    with pytest.raises(ValueError) as exc_info:
-        FlightPoint.get_time_integrable_quantities()
+        # Declare the field it integrates from but also redeclare bar as being not cumulative.
+        FlightPoint.add_field(
+            "foo", annotation_type=float, default_value=42.0, unit="slug/s", is_cumulative=False
+        )
+        FlightPoint.add_field(
+            "bar",
+            annotation_type=float,
+            default_value=1337.0,
+            unit="slug",
+            is_cumulative=False,
+            integrates_from="foo",
+        )
+        with pytest.raises(ValueError) as exc_info:
+            FlightPoint.get_time_integrable_quantities()
 
-    assert (
-        "Field 'bar' is declared as integrating from another field but is not declared as "
-        "cumulative. 'integrates_from' can only be declared if 'is_cumulative' is True."
-        in str(exc_info.value)
-    )
+        assert (
+            "Field 'bar' is declared as integrating from another field but is not declared as "
+            "cumulative. 'integrates_from' can only be declared if 'is_cumulative' is True."
+            in str(exc_info.value)
+        )
 
-    # Finally declare it cleanly
-    FlightPoint.add_field(
-        "bar",
-        annotation_type=float,
-        default_value=1337.0,
-        unit="slug",
-        is_cumulative=True,
-        integrates_from="foo",
-    )
+        # Finally declare it cleanly
+        FlightPoint.add_field(
+            "bar",
+            annotation_type=float,
+            default_value=1337.0,
+            unit="slug",
+            is_cumulative=True,
+            integrates_from="foo",
+        )
 
-    assert "bar" in FlightPoint.get_time_integrable_quantities()
-    assert FlightPoint.get_time_integrand("bar") == "foo"
+        assert "bar" in FlightPoint.get_time_integrable_quantities()
+        assert FlightPoint.get_time_integrand("bar") == "foo"
 
-    FlightPoint.remove_field("foo")
-    FlightPoint.remove_field("bar")
+    finally:
+        # Free the fields we added to ensure that there is no interference with other tests.
+        FlightPoint.remove_field("foo")
+        FlightPoint.remove_field("bar")

--- a/src/fastoad/model_base/tests/test_flight_point.py
+++ b/src/fastoad/model_base/tests/test_flight_point.py
@@ -111,20 +111,56 @@ def test_descriptors():
     assert FlightPoint.get_unit("engine_setting") is None
 
 
-def test_cumulative_quantities():
+def test_time_integrable_quantities(caplog):
     # On a default flight point, there are cumulative quantities (fuel, ground distance, ...) but
-    # the field they cumulate from is handled case by case so they have no field they cumulate from
+    # they are not time integrated in the sense that there is no other field (as of right now) that
+    # we use to "integrate" them. While it might be complicated for the time because of how the
+    # construction of the mission is handled, it might be feasible for fuel and ground distance :>
 
+    # Time is cumulative but not time integrable
     assert FlightPoint.is_cumulative("time")
-    assert "time" in FlightPoint.get_cumulative_quantities()  # Those two lines do the same thing
-    assert not FlightPoint.get_cumulative_quantity(
-        "time"
-    )  # Time, like other default cumulative quantities in FlightPoint, have no quantity it
-    # cumulates from
+    assert "time" not in FlightPoint.get_time_integrable_quantities()
 
+    # Add a quantity which is declared as having a time derivative but the field it is integrated
+    # from does not exist
+    FlightPoint.add_field(
+        "bar",
+        annotation_type=float,
+        default_value=1337.0,
+        unit="slug/ft",
+        is_cumulative=True,
+        integrates_from="foo",
+    )
+    with pytest.raises(ValueError) as exc_info:
+        FlightPoint.get_time_integrable_quantities()
+
+    assert (
+        "Field 'bar' is declared as integrating from 'foo', but 'foo' is not an existing field."
+        in str(exc_info.value)
+    )
+
+    # Declare the field it integrates from but also redeclare bar as being not cumulative.
     FlightPoint.add_field(
         "foo", annotation_type=float, default_value=42.0, unit="m", is_cumulative=False
     )
+    FlightPoint.add_field(
+        "bar",
+        annotation_type=float,
+        default_value=1337.0,
+        unit="slug/ft",
+        is_cumulative=False,
+        integrates_from="foo",
+    )
+    with caplog.at_level("WARNING"):
+        FlightPoint.get_time_integrable_quantities()
+
+    assert (
+        "Field 'bar' is declared as integrating from another field but is not declared as "
+        "cumulative. 'integrates_from' will only be used if 'is_cumulative' is True."
+        in caplog.records[0].message
+    )
+
+    # Finally declare it cleanly
     FlightPoint.add_field(
         "bar",
         annotation_type=float,
@@ -134,6 +170,5 @@ def test_cumulative_quantities():
         integrates_from="foo",
     )
 
-    assert FlightPoint.is_cumulative("bar")
-    assert "bar" in FlightPoint.get_cumulative_quantities()
-    assert FlightPoint.get_cumulative_quantity("bar") == "foo"
+    assert "bar" in FlightPoint.get_time_integrable_quantities()
+    assert FlightPoint.get_time_integrand("bar") == "foo"

--- a/src/fastoad/model_base/tests/test_flight_point.py
+++ b/src/fastoad/model_base/tests/test_flight_point.py
@@ -172,3 +172,6 @@ def test_time_integrable_quantities():
 
     assert "bar" in FlightPoint.get_time_integrable_quantities()
     assert FlightPoint.get_time_integrand("bar") == "foo"
+
+    FlightPoint.remove_field("foo")
+    FlightPoint.remove_field("bar")

--- a/src/fastoad/model_base/tests/test_flight_point.py
+++ b/src/fastoad/model_base/tests/test_flight_point.py
@@ -111,7 +111,7 @@ def test_descriptors():
     assert FlightPoint.get_unit("engine_setting") is None
 
 
-def test_time_integrable_quantities(caplog):
+def test_time_integrable_quantities():
     # On a default flight point, there are cumulative quantities (fuel, ground distance, ...) but
     # they are not time integrated in the sense that there is no other field (as of right now) that
     # we use to "integrate" them. While it might be complicated for the time because of how the
@@ -151,13 +151,13 @@ def test_time_integrable_quantities(caplog):
         is_cumulative=False,
         integrates_from="foo",
     )
-    with caplog.at_level("WARNING"):
+    with pytest.raises(ValueError) as exc_info:
         FlightPoint.get_time_integrable_quantities()
 
     assert (
         "Field 'bar' is declared as integrating from another field but is not declared as "
-        "cumulative. 'integrates_from' will only be used if 'is_cumulative' is True."
-        in caplog.records[0].message
+        "cumulative. 'integrates_from' can only be declared if 'is_cumulative' is True."
+        in str(exc_info.value)
     )
 
     # Finally declare it cleanly

--- a/src/fastoad/models/performances/mission/segments/time_step_base.py
+++ b/src/fastoad/models/performances/mission/segments/time_step_base.py
@@ -280,6 +280,7 @@ class AbstractTimeStepFlightSegment(
         )
         next_point.alpha = self.get_next_alpha(previous, time_step)
         self._compute_next_altitude(next_point, previous)
+        self._increment_cumulative_quantities(next_point, previous, time_step)
 
         if self.target.true_airspeed == self.constant_value_name:
             next_point.true_airspeed = previous.true_airspeed
@@ -376,6 +377,19 @@ class AbstractTimeStepFlightSegment(
                 distance_to_optimum, x0=altitude_guess, x1=altitude_guess - 1000.0
             ).root
         )
+
+    @staticmethod
+    def _increment_cumulative_quantities(
+        next_point: FlightPoint, previous_point: FlightPoint, time_step
+    ):
+        for cumulative_field, integrand_field in FlightPoint.get_cumulative_quantities().items():
+            if integrand_field:  # To avoid incrementing default cumulative quantity
+                setattr(
+                    next_point,
+                    cumulative_field,
+                    getattr(previous_point, cumulative_field)
+                    + getattr(previous_point, integrand_field) * time_step,
+                )
 
 
 @dataclass

--- a/src/fastoad/models/performances/mission/segments/time_step_base.py
+++ b/src/fastoad/models/performances/mission/segments/time_step_base.py
@@ -390,6 +390,8 @@ class AbstractTimeStepFlightSegment(
                     getattr(previous_point, cumulative_field)
                     + getattr(previous_point, integrand_field) * time_step,
                 )
+                # If the phenomena that needs to be incremented has a different time constant, this
+                # could cause some issues
 
 
 @dataclass

--- a/src/fastoad/models/performances/mission/segments/time_step_base.py
+++ b/src/fastoad/models/performances/mission/segments/time_step_base.py
@@ -382,12 +382,15 @@ class AbstractTimeStepFlightSegment(
     def _increment_cumulative_quantities(
         next_point: FlightPoint, previous_point: FlightPoint, time_step
     ):
-        for cumulative_field, integrand_field in FlightPoint.get_cumulative_quantities().items():
+        for (
+            integrable_field,
+            integrand_field,
+        ) in FlightPoint.get_time_integrable_quantities().items():
             if integrand_field:  # To avoid incrementing default cumulative quantity
                 setattr(
                     next_point,
-                    cumulative_field,
-                    getattr(previous_point, cumulative_field)
+                    integrable_field,
+                    getattr(previous_point, integrable_field)
                     + getattr(previous_point, integrand_field) * time_step,
                 )
                 # If the phenomena that needs to be incremented has a different time constant, this

--- a/src/fastoad/models/performances/mission/tests/conftest.py
+++ b/src/fastoad/models/performances/mission/tests/conftest.py
@@ -25,7 +25,10 @@ from fastoad.model_base import FlightPoint
 from fastoad.model_base.datacls import MANDATORY_FIELD
 from fastoad.model_base.propulsion import FuelEngineSet, IPropulsion
 from fastoad.models.performances.mission.base import FlightSequence
-from tests.dummy_plugins.dist_2.dummy_plugin_2.models.subpackage.dummy_engine import DummyEngine
+from tests.dummy_plugins.dist_2.dummy_plugin_2.models.subpackage.dummy_engine import (
+    DummyEngine,
+    DummyHybridEngine,
+)
 
 from ..polar import Polar
 from ..segments.registered.altitude_change import AltitudeChangeSegment
@@ -36,6 +39,11 @@ from ..segments.registered.taxi import TaxiSegment
 @pytest.fixture(scope="module")
 def propulsion():
     return FuelEngineSet(DummyEngine(1.0e5, 1.0e-4), 2)
+
+
+@pytest.fixture(scope="module")
+def hybrid_propulsion():
+    return FuelEngineSet(DummyHybridEngine(1.0e5, 0.1, 1.0e-4, 0.95), 2)
 
 
 @pytest.fixture

--- a/src/fastoad/models/performances/mission/tests/test_mission.py
+++ b/src/fastoad/models/performances/mission/tests/test_mission.py
@@ -296,3 +296,6 @@ def test_hybrid_mission(low_speed_polar, high_speed_polar, hybrid_propulsion):
         flight_points.electric_power.iloc[:100].to_numpy(),
         1e-6,
     )
+
+    FlightPoint.remove_field("electric_energy")
+    FlightPoint.remove_field("electric_power")

--- a/src/fastoad/models/performances/mission/tests/test_mission.py
+++ b/src/fastoad/models/performances/mission/tests/test_mission.py
@@ -280,7 +280,13 @@ def test_hybrid_mission(low_speed_polar, high_speed_polar, hybrid_propulsion):
         0.0,
         1e-6,
     )
-    # Check that the electric energy consumed since the start has been constructed properly
+    # Check for the final value of the electric energy
+    assert_allclose(
+        flight_points.electric_energy.iloc[-1],
+        3.890237e9,
+        1e-6,
+    )
+    # Check that the electric energy consumed since the start has been constructed properly.
     assert_allclose(
         (
             flight_points.electric_energy.iloc[1:101].to_numpy()

--- a/src/fastoad/models/performances/mission/tests/test_mission.py
+++ b/src/fastoad/models/performances/mission/tests/test_mission.py
@@ -203,3 +203,90 @@ def test_mission(low_speed_polar, high_speed_polar, propulsion):
         atol=1e-10,
         rtol=1e-6,
     )
+
+
+def test_hybrid_mission(low_speed_polar, high_speed_polar, hybrid_propulsion):
+
+    FlightPoint.add_field(
+        "electric_power", annotation_type=float, default_value=0.0, unit="W", is_cumulative=False
+    )
+    FlightPoint.add_field(
+        "electric_energy",
+        annotation_type=float,
+        default_value=0.0,
+        unit="J",  # SI unit for energy is Joules, even though W*h are more convenient.
+        # Besides, the integrand will be multiplied by the time step in s
+        is_cumulative=True,
+        integrates_from="electric_power",
+    )
+
+    route_distance = 2.0e6
+    kwargs = {"propulsion": hybrid_propulsion, "reference_area": 120.0}
+
+    first_route = RangedRoute(
+        name="route_1",
+        climb_phases=[
+            InitialClimbPhase(
+                **kwargs,
+                polar=low_speed_polar,
+                thrust_rate=1.0,
+                name="initial_climb1",
+                time_step=0.2,
+            ),
+            ClimbPhase(
+                **kwargs,
+                polar=high_speed_polar,
+                thrust_rate=0.8,
+                target_altitude="mach",
+                maximum_mach=0.78,
+                name="climb1",
+                time_step=5.0,
+            ),
+        ],
+        cruise_segment=CruiseSegment(
+            **kwargs,
+            target=FlightPoint(ground_distance=0.0),
+            polar=high_speed_polar,
+            engine_setting=EngineSetting.CRUISE,
+            name=FlightPhase.CRUISE.value,
+        ),
+        descent_phases=[
+            DescentPhase(
+                **kwargs,
+                polar=high_speed_polar,
+                thrust_rate=0.05,
+                target_altitude=1500.0 * foot,
+                name=FlightPhase.DESCENT.value,
+                time_step=5.0,
+            )
+        ],
+        flight_distance=route_distance,
+    )
+    mission_1 = Mission(name="mission1")
+    mission_1.extend([first_route])
+
+    start = FlightPoint(
+        true_airspeed=150.0 * knot,
+        altitude=100.0 * foot,
+        mass=70000.0,
+        ground_distance=100000.0,
+    )
+
+    flight_points = mission_1.compute_from(start)
+
+    # Check that the integration got done correctly, starting with the right initialization
+    assert_allclose(
+        flight_points.electric_energy.iloc[0],
+        0.0,
+        1e-6,
+    )
+    # Check that the electric energy consumed since the start has been constructed properly
+    assert_allclose(
+        (
+            flight_points.electric_energy.iloc[1:101].to_numpy()
+            - flight_points.electric_energy.iloc[:100].to_numpy()
+        )
+        / (flight_points.time.iloc[1:101].to_numpy() - flight_points.time.iloc[:100].to_numpy()),
+        flight_points.electric_power.iloc[:100].to_numpy(),
+        1e-6,
+    )

--- a/src/fastoad/models/performances/mission/tests/test_mission.py
+++ b/src/fastoad/models/performances/mission/tests/test_mission.py
@@ -207,19 +207,6 @@ def test_mission(low_speed_polar, high_speed_polar, propulsion):
 
 def test_hybrid_mission(low_speed_polar, high_speed_polar, hybrid_propulsion):
 
-    FlightPoint.add_field(
-        "electric_power", annotation_type=float, default_value=0.0, unit="W", is_cumulative=False
-    )
-    FlightPoint.add_field(
-        "electric_energy",
-        annotation_type=float,
-        default_value=0.0,
-        unit="J",  # SI unit for energy is Joules, even though W*h are more convenient.
-        # Besides, the integrand will be multiplied by the time step in s
-        is_cumulative=True,
-        integrates_from="electric_power",
-    )
-
     route_distance = 2.0e6
     kwargs = {"propulsion": hybrid_propulsion, "reference_area": 120.0}
 
@@ -272,30 +259,51 @@ def test_hybrid_mission(low_speed_polar, high_speed_polar, hybrid_propulsion):
         ground_distance=100000.0,
     )
 
-    flight_points = mission_1.compute_from(start)
-
-    # Check that the integration got done correctly, starting with the right initialization
-    assert_allclose(
-        flight_points.electric_energy.iloc[0],
-        0.0,
-        1e-6,
-    )
-    # Check for the final value of the electric energy
-    assert_allclose(
-        flight_points.electric_energy.iloc[-1],
-        3.890237e9,
-        1e-6,
-    )
-    # Check that the electric energy consumed since the start has been constructed properly.
-    assert_allclose(
-        (
-            flight_points.electric_energy.iloc[1:101].to_numpy()
-            - flight_points.electric_energy.iloc[:100].to_numpy()
+    try:
+        FlightPoint.add_field(
+            "electric_power",
+            annotation_type=float,
+            default_value=0.0,
+            unit="W",
+            is_cumulative=False,
         )
-        / (flight_points.time.iloc[1:101].to_numpy() - flight_points.time.iloc[:100].to_numpy()),
-        flight_points.electric_power.iloc[:100].to_numpy(),
-        1e-6,
-    )
+        FlightPoint.add_field(
+            "electric_energy",
+            annotation_type=float,
+            default_value=0.0,
+            unit="J",  # SI unit for energy is Joules, even though W*h are more convenient.
+            # Besides, the integrand will be multiplied by the time step in s
+            is_cumulative=True,
+            integrates_from="electric_power",
+        )
+        flight_points = mission_1.compute_from(start)
 
-    FlightPoint.remove_field("electric_energy")
-    FlightPoint.remove_field("electric_power")
+        # Check that the integration got done correctly, starting with the right initialization
+        assert_allclose(
+            flight_points.electric_energy.iloc[0],
+            0.0,
+            1e-6,
+        )
+        # Check for the final value of the electric energy
+        assert_allclose(
+            flight_points.electric_energy.iloc[-1],
+            3.890237e9,
+            1e-6,
+        )
+        # Check that the electric energy consumed since the start has been constructed properly.
+        assert_allclose(
+            (
+                flight_points.electric_energy.iloc[1:101].to_numpy()
+                - flight_points.electric_energy.iloc[:100].to_numpy()
+            )
+            / (
+                flight_points.time.iloc[1:101].to_numpy() - flight_points.time.iloc[:100].to_numpy()
+            ),
+            flight_points.electric_power.iloc[:100].to_numpy(),
+            1e-6,
+        )
+
+    finally:
+        # Free the fields we added to ensure that there is no interference with other tests.
+        FlightPoint.remove_field("electric_energy")
+        FlightPoint.remove_field("electric_power")

--- a/tests/dummy_plugins/dist_2/dummy_plugin_2/models/subpackage/dummy_engine.py
+++ b/tests/dummy_plugins/dist_2/dummy_plugin_2/models/subpackage/dummy_engine.py
@@ -75,6 +75,7 @@ class DummyHybridEngine(AbstractFuelPropulsion):
         Electric branch efficiency is assumed constant.
 
         :param max_thrust: thrust when thrust rate = 1.0
+        :param hybridization_ratio: share of thermal power, between 0.0 and 1.0
         :param max_sfc: SFC when thrust rate = 1.0
         :param eta_electric: electric branch efficiency
         """
@@ -91,24 +92,3 @@ class DummyHybridEngine(AbstractFuelPropulsion):
 
         flight_point.sfc = self.max_sfc * (1.0 + flight_point.thrust_rate) / 2.0 * (1.0 - self.hybridization_ratio)
         flight_point.electric_power = flight_point.thrust * flight_point.true_airspeed * self.hybridization_ratio / self.eta_electric
-
-
-@RegisterPropulsion("test.wrapper.propulsion.dummy_hybrid_engine")
-class DummyHybridEngineWrapper(IOMPropulsionWrapper):
-    def setup(self, component: Component):
-        component.add_input("data:propulsion:dummy_engine:max_thrust", 1.2e5, units="N")
-        component.add_input("data:propulsion:dummy_engine:hybridization_ratio", 0.1, units="unitless")
-        component.add_input("data:propulsion:dummy_engine:max_sfc", 1.5e-5, units="kg/N/s")
-        component.add_input("data:propulsion:dummy_engine:electric_efficiency", 0.95, units="unitless")
-        component.add_input("data:geometry:propulsion:engine_count", 2)
-
-    def get_model(self, inputs) -> IPropulsion:
-        return FuelEngineSet(
-            DummyHybridEngine(
-                inputs["data:propulsion:dummy_engine:max_thrust"],
-                inputs["data:propulsion:dummy_engine:hybridization_ratio"],
-                inputs["data:propulsion:dummy_engine:max_sfc"],
-                inputs["data:propulsion:dummy_engine:electric_efficiency"],
-            ),
-            inputs["data:geometry:propulsion:engine_count"],
-        )

--- a/tests/dummy_plugins/dist_2/dummy_plugin_2/models/subpackage/dummy_engine.py
+++ b/tests/dummy_plugins/dist_2/dummy_plugin_2/models/subpackage/dummy_engine.py
@@ -61,3 +61,54 @@ class DummyEngineWrapper(IOMPropulsionWrapper):
             ),
             inputs["data:geometry:propulsion:engine_count"],
         )
+
+
+class DummyHybridEngine(AbstractFuelPropulsion):
+    def __init__(self, max_thrust, hybridization_ratio, max_sfc, eta_electric):
+        """
+        Dummy engine model.
+
+        Hybridization ratio is considered constant.
+        Max thrust does not depend on flight conditions.
+        SFC varies linearly with thrust_rate, from max_sfc/2. when thrust rate is 0.,
+        to max_sfc when thrust_rate is 1.0
+        Electric branch efficiency is assumed constant.
+
+        :param max_thrust: thrust when thrust rate = 1.0
+        :param max_sfc: SFC when thrust rate = 1.0
+        :param eta_electric: electric branch efficiency
+        """
+        self.max_thrust = max_thrust
+        self.hybridization_ratio = hybridization_ratio
+        self.max_sfc = max_sfc
+        self.eta_electric = eta_electric
+
+    def compute_flight_points(self, flight_point: FlightPoint):
+        if flight_point.thrust_is_regulated or flight_point.thrust_rate is None:
+            flight_point.thrust_rate = flight_point.thrust / self.max_thrust
+        else:
+            flight_point.thrust = self.max_thrust * flight_point.thrust_rate
+
+        flight_point.sfc = self.max_sfc * (1.0 + flight_point.thrust_rate) / 2.0 * (1.0 - self.hybridization_ratio)
+        flight_point.electric_power = flight_point.thrust * flight_point.true_airspeed * self.hybridization_ratio / self.eta_electric
+
+
+@RegisterPropulsion("test.wrapper.propulsion.dummy_hybrid_engine")
+class DummyHybridEngineWrapper(IOMPropulsionWrapper):
+    def setup(self, component: Component):
+        component.add_input("data:propulsion:dummy_engine:max_thrust", 1.2e5, units="N")
+        component.add_input("data:propulsion:dummy_engine:hybridization_ratio", 0.1, units="unitless")
+        component.add_input("data:propulsion:dummy_engine:max_sfc", 1.5e-5, units="kg/N/s")
+        component.add_input("data:propulsion:dummy_engine:electric_efficiency", 0.95, units="unitless")
+        component.add_input("data:geometry:propulsion:engine_count", 2)
+
+    def get_model(self, inputs) -> IPropulsion:
+        return FuelEngineSet(
+            DummyHybridEngine(
+                inputs["data:propulsion:dummy_engine:max_thrust"],
+                inputs["data:propulsion:dummy_engine:hybridization_ratio"],
+                inputs["data:propulsion:dummy_engine:max_sfc"],
+                inputs["data:propulsion:dummy_engine:electric_efficiency"],
+            ),
+            inputs["data:geometry:propulsion:engine_count"],
+        )


### PR DESCRIPTION
## Summary of Changes

- Expands the notion of cumulative quantities in the FlightPoint class with a way of defining how they are incremented (it doesn't apply to quantities by default in the FlightPoint)
- Expands time-step-based segments so that cumulative quantities are automatically incremented (will not work for other segments and Breguet-type cruise)
- Adds an example of how this could be used for hybrid propulsion (random example)

## Checklist

- [x] Have you followed the guidelines in our [Contributing](https://github.com/fast-aircraft-design/FAST-OAD/wiki/Development-environment) wiki?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [x] Have you added new tests to cover your changes?
- [x] Have you made corresponding changes to the documentation? If yes, please consider providing a link to the updated documentation.
- [x] Do the existing tests pass with your changes?
- [x] Have you commented on hard-to-understand areas of the code?
- [ ] Does this PR introduce a breaking change?

## Additional Context

<!-- Add any other context or screenshots about the PR here -->
<!-- If you have modified the doc and you have the rights, please provide here the link of the updated Read the Docs documentation -->
