### PR TITLE
 Add a local solver on mission groups that adjust fuel

### DIFF
--- a/docs/documentation/mission_module/mission_module.rst
+++ b/docs/documentation/mission_module/mission_module.rst
@@ -138,6 +138,10 @@ The available parameters for this module are:
     If :code:`true`, block fuel will be adjusted to fuel consumption during mission. If :code:`false`,
     the input block fuel will be used.
 
+    This creates a local feedback loop between mission fuel and mission input weight. Therefore,
+    the mission component will install its own local solver for this loop, even if
+    :code:`use_inner_solvers` is set to :code:`false` for the component.
+
 
 :code:`compute_TOW`
 ===================
@@ -158,6 +162,10 @@ The available parameters for this module are:
 
     Setting this option to False will deactivate the local solver of the component. Useful if a
     global solver is used for the MDA problem.
+
+    For mission fuel adjustment, there is one exception: if :code:`adjust_fuel` is
+    :code:`true`, the mission component still adds a mission-specific local solver for its own
+    fuel-adjustment loop, even when :code:`use_inner_solvers` is :code:`false`.
 
 
 :code:`is_sizing`

--- a/docs/documentation/mission_module/mission_module.rst
+++ b/docs/documentation/mission_module/mission_module.rst
@@ -138,9 +138,12 @@ The available parameters for this module are:
     If :code:`true`, block fuel will be adjusted to fuel consumption during mission. If :code:`false`,
     the input block fuel will be used.
 
-    This creates a local feedback loop between mission fuel and mission input weight. Therefore,
-    the mission component will install its own local solver for this loop, even if
-    :code:`use_inner_solvers` is set to :code:`false` for the component.
+    For non-sizing missions, this creates a local feedback loop between mission fuel and mission
+    input weight. Therefore, the mission component may install its own local solver for this loop,
+    even if :code:`use_inner_solvers` is set to :code:`false` for the component.
+
+    This exception is not applied to sizing missions (:code:`is_sizing` set to :code:`true`), which are expected to rely on the outer MDA
+    loop when no inner solver is requested.
 
 
 :code:`compute_TOW`
@@ -163,9 +166,10 @@ The available parameters for this module are:
     Setting this option to False will deactivate the local solver of the component. Useful if a
     global solver is used for the MDA problem.
 
-    For mission fuel adjustment, there is one exception: if :code:`adjust_fuel` is
-    :code:`true`, the mission component still adds a mission-specific local solver for its own
-    fuel-adjustment loop, even when :code:`use_inner_solvers` is :code:`false`.
+    For non-sizing mission fuel adjustment, there is one exception: if :code:`adjust_fuel` is
+    :code:`true`, the mission component may still add a mission-specific local solver for its own
+    fuel-adjustment loop when :code:`use_inner_solvers` is :code:`false` and no local solver is
+    already defined on the component.
 
 
 :code:`is_sizing`

--- a/docs/documentation/mission_module/mission_module.rst
+++ b/docs/documentation/mission_module/mission_module.rst
@@ -138,12 +138,33 @@ The available parameters for this module are:
     If :code:`true`, block fuel will be adjusted to fuel consumption during mission. If :code:`false`,
     the input block fuel will be used.
 
-    For non-sizing missions, this creates a local feedback loop between mission fuel and mission
-    input weight. Therefore, the mission component may install its own local solver for this loop,
-    even if :code:`use_inner_solvers` is set to :code:`false` for the component.
+    This creates a feedback loop between mission fuel, mission input weight, and
+    :code:`needed_block_fuel`. If this loop is not solved, mission mass consistency may be lost,
+    which can lead to incorrect values such as :code:`TOW = ZFW` on a non-sizing evaluation mission.
 
-    This exception is not applied to sizing missions (:code:`is_sizing` set to :code:`true`), which are expected to rely on the outer MDA
-    loop when no inner solver is requested.
+
+:code:`adjust_fuel_solver_mode`
+===============================
+
+    - Optional (Default = :code:`auto` )
+
+    This option provides explicit control over how :code:`OMMission` handles the internal solver
+    need created by :code:`adjust_fuel`.
+
+    The reason for this option is that the fuel-adjustment feedback loop is internal to the mission
+    group itself. In practice, adding a solver only around the mission group is often not enough to
+    converge this loop when the mission is used as a standalone non-sizing evaluation.
+
+    With :code:`auto`, :code:`OMMission` will locally switch :code:`use_inner_solvers` to
+    :code:`true` only for non-sizing missions when :code:`use_inner_solvers` was initially
+    :code:`false`.
+
+    With :code:`always`, the same local switch to :code:`use_inner_solvers=true` is also applied to
+    sizing missions.
+
+    With :code:`never`, :code:`OMMission` never changes :code:`use_inner_solvers`. This keeps full
+    user control and is meant for advanced cases where the mission should explicitly rely on an outer
+    solver, or where the user accepts the unconverged behavior.
 
 
 :code:`compute_TOW`
@@ -166,10 +187,8 @@ The available parameters for this module are:
     Setting this option to False will deactivate the local solver of the component. Useful if a
     global solver is used for the MDA problem.
 
-    For non-sizing mission fuel adjustment, there is one exception: if :code:`adjust_fuel` is
-    :code:`true`, the mission component may still add a mission-specific local solver for its own
-    fuel-adjustment loop when :code:`use_inner_solvers` is :code:`false` and no local solver is
-    already defined on the component.
+    For mission fuel adjustment, prefer :code:`adjust_fuel_solver_mode` when the default
+    :code:`use_inner_solvers` behavior is not precise enough for your use case.
 
 
 :code:`is_sizing`

--- a/src/fastoad/model_base/openmdao/group.py
+++ b/src/fastoad/model_base/openmdao/group.py
@@ -77,8 +77,9 @@ class CycleGroup(om.Group, abc.ABC):
             desc="If True, solvers are added to the group. The solver classes are decided "
             'by options "linear_solver" and "nonlinear_solver". '
             "If False, no solver is added and other solver-related options have no effect. "
-            "Some subclasses may still install a model-specific local solver when their own "
-            "setup requires it (e.g., for some non-sizing mission fuel-adjustment loops).",
+            "Some subclasses may still decide to locally turn this option on during their own "
+            "setup when they expose a dedicated option for that behavior (e.g., for some non-sizing"
+            " mission fuel-adjustment loops).",
         )
         self.options.declare(
             "use_inner_solver",

--- a/src/fastoad/model_base/openmdao/group.py
+++ b/src/fastoad/model_base/openmdao/group.py
@@ -78,7 +78,7 @@ class CycleGroup(om.Group, abc.ABC):
             'by options "linear_solver" and "nonlinear_solver". '
             "If False, no solver is added and other solver-related options have no effect. "
             "Some subclasses may still install a model-specific local solver when their own "
-            "setup requires it (e.g., for mission fuel adjustment).",
+            "setup requires it (e.g., for some non-sizing mission fuel-adjustment loops).",
         )
         self.options.declare(
             "use_inner_solver",

--- a/src/fastoad/model_base/openmdao/group.py
+++ b/src/fastoad/model_base/openmdao/group.py
@@ -76,7 +76,9 @@ class CycleGroup(om.Group, abc.ABC):
             default=self.use_solvers_by_default,
             desc="If True, solvers are added to the group. The solver classes are decided "
             'by options "linear_solver" and "nonlinear_solver". '
-            "If False, no solver is added and other solver-related options have no effect.",
+            "If False, no solver is added and other solver-related options have no effect. "
+            "Some subclasses may still install a model-specific local solver when their own "
+            "setup requires it (e.g., for mission fuel adjustment).",
         )
         self.options.declare(
             "use_inner_solver",

--- a/src/fastoad/models/performances/mission/openmdao/mission.py
+++ b/src/fastoad/models/performances/mission/openmdao/mission.py
@@ -65,11 +65,26 @@ class OMMission(
             default=True,
             types=bool,
             desc="If True, block fuel will fit fuel consumption during mission. In that case, a "
-            "solver (local or global) will be needed. (see `use_inner_solver` option for more"
-            "information). For non-sizing missions, this group may still add its own local "
-            "solver when `use_inner_solvers` is False and no local solver is already defined, "
-            "because fuel adjustment creates a feedback loop.\n"
+            "solver (local or global) will be needed. (see `use_inner_solver` and "
+            "`adjust_fuel_solver_mode` options for more information).\n"
             "If False, block fuel will be taken from input data.",
+        )
+        self.options.declare(
+            "adjust_fuel_solver_mode",
+            default="auto",
+            values=("auto", "always", "never"),
+            desc="Controls how mission fuel adjustment may activate inner solvers when "
+            "`adjust_fuel=True`. This option exists because the mission fuel-adjustment loop is "
+            "internal to `OMMission`, so a solver attached only around the mission may not be "
+            "enough to converge `block_fuel`, mission input weight, and `needed_block_fuel`.\n"
+            "With `auto`, `OMMission` locally switches `use_inner_solvers` to True only for "
+            "non-sizing missions when `use_inner_solvers` was False. This fixes the usual "
+            "standalone evaluation-mission case.\n"
+            "With `always`, the same local switch to `use_inner_solvers=True` is also allowed "
+            "for sizing missions.\n"
+            "With `never`, `OMMission` does not modify `use_inner_solvers`; advanced users can "
+            "therefore fully rely on an outer solver or accept the unconverged behavior if they "
+            "really want to.",
         )
         self.options.declare(
             "compute_input_weight",
@@ -104,9 +119,8 @@ class OMMission(
             desc="If True, a local solver is set for the mission computation.\n"
             "It is useful if `adjust_fuel` is set to True, or to ensure consistency between "
             "ramp weight and takeoff weight + taxi-out fuel.\n"
-            "For non-sizing missions with `adjust_fuel=True`, this mission group may still "
-            "install its own local solver even when `use_inner_solvers` is False, unless a "
-            "local solver is already defined on the component.\n"
+            "For mission fuel adjustment, please prefer `adjust_fuel_solver_mode` if you need "
+            "finer control over when `OMMission` should activate its own inner solver setup.\n"
             "If a global solver is used, using a local solver or not should be only a question"
             "of CPU time consumption and is not expected to modify the results.",
         )
@@ -122,13 +136,10 @@ class OMMission(
         if self.options["adjust_fuel"]:
             self.options["compute_input_weight"] = True
 
-        super().setup()
+        if self._should_activate_inner_solvers_for_adjust_fuel():
+            self.options["use_inner_solvers"] = True
 
-        if self._needs_adjust_fuel_solver():
-            # This keeps the generic use_inner_solvers option untouched while still
-            # converging the non-sizing mission fuel-adjustment cycle on this group
-            # when no other local solver has already been attached.
-            self._add_adjust_fuel_solver()
+        super().setup()
 
         mission_options = {
             key: val for key, val in self.options.items() if key in AdvancedMissionComp().options
@@ -247,34 +258,16 @@ class OMMission(
 
         return self.name_provider.PAYLOAD.value
 
-    def _needs_adjust_fuel_solver(self) -> bool:
-        return (
-            self.options["adjust_fuel"]
-            and not self.options["is_sizing"]
-            and not self.options["use_inner_solvers"]
-            and not self._has_local_solver()
-        )
+    def _should_activate_inner_solvers_for_adjust_fuel(self) -> bool:
+        if not self.options["adjust_fuel"] or self.options["use_inner_solvers"]:
+            return False
 
-    def _has_local_solver(self) -> bool:
-        nonlinear_solver = getattr(self, "nonlinear_solver", None)
-        linear_solver = getattr(self, "linear_solver", None)
-        return not isinstance(nonlinear_solver, om.NonlinearRunOnce) or not isinstance(
-            linear_solver, om.LinearRunOnce
-        )
-
-    def _add_adjust_fuel_solver(self):
-        # Fuel adjustment creates a local feedback loop on this mission group even when
-        # generic inner solvers are disabled at the component level.
-        linear_solver_class = self._get_solver_class("linear_solver")
-        nonlinear_solver_class = self._get_solver_class("nonlinear_solver")
-
-        linear_solver_options = self._get_solver_options("linear_solver_options")
-        nonlinear_solver_options = self._get_solver_options("nonlinear_solver_options")
-
-        if linear_solver_class:
-            self.linear_solver = linear_solver_class(**linear_solver_options)
-        if nonlinear_solver_class:
-            self.nonlinear_solver = nonlinear_solver_class(**nonlinear_solver_options)
+        solver_mode = self.options["adjust_fuel_solver_mode"]
+        if solver_mode == "never":
+            return False
+        if solver_mode == "always":
+            return True
+        return not self.options["is_sizing"]
 
 
 class SpecificBurnedFuelComputation(

--- a/src/fastoad/models/performances/mission/openmdao/mission.py
+++ b/src/fastoad/models/performances/mission/openmdao/mission.py
@@ -66,8 +66,9 @@ class OMMission(
             types=bool,
             desc="If True, block fuel will fit fuel consumption during mission. In that case, a "
             "solver (local or global) will be needed. (see `use_inner_solver` option for more"
-            "information). If `use_inner_solvers` is False, this mission group still adds its "
-            "own local solver because fuel adjustment creates a feedback loop.\n"
+            "information). For non-sizing missions, this group may still add its own local "
+            "solver when `use_inner_solvers` is False and no local solver is already defined, "
+            "because fuel adjustment creates a feedback loop.\n"
             "If False, block fuel will be taken from input data.",
         )
         self.options.declare(
@@ -103,8 +104,9 @@ class OMMission(
             desc="If True, a local solver is set for the mission computation.\n"
             "It is useful if `adjust_fuel` is set to True, or to ensure consistency between "
             "ramp weight and takeoff weight + taxi-out fuel.\n"
-            "If `adjust_fuel` is True, this mission group still installs its own local solver "
-            "even when `use_inner_solvers` is False.\n"
+            "For non-sizing missions with `adjust_fuel=True`, this mission group may still "
+            "install its own local solver even when `use_inner_solvers` is False, unless a "
+            "local solver is already defined on the component.\n"
             "If a global solver is used, using a local solver or not should be only a question"
             "of CPU time consumption and is not expected to modify the results.",
         )
@@ -122,9 +124,10 @@ class OMMission(
 
         super().setup()
 
-        if self.options["adjust_fuel"] and not self.options["use_inner_solvers"]:
+        if self._needs_adjust_fuel_solver():
             # This keeps the generic use_inner_solvers option untouched while still
-            # converging the mission-specific fuel-adjustment cycle on this group.
+            # converging the non-sizing mission fuel-adjustment cycle on this group
+            # when no other local solver has already been attached.
             self._add_adjust_fuel_solver()
 
         mission_options = {
@@ -243,6 +246,21 @@ class OMMission(
             return "data:weight:aircraft:payload"
 
         return self.name_provider.PAYLOAD.value
+
+    def _needs_adjust_fuel_solver(self) -> bool:
+        return (
+            self.options["adjust_fuel"]
+            and not self.options["is_sizing"]
+            and not self.options["use_inner_solvers"]
+            and not self._has_local_solver()
+        )
+
+    def _has_local_solver(self) -> bool:
+        nonlinear_solver = getattr(self, "nonlinear_solver", None)
+        linear_solver = getattr(self, "linear_solver", None)
+        return not isinstance(nonlinear_solver, om.NonlinearRunOnce) or not isinstance(
+            linear_solver, om.LinearRunOnce
+        )
 
     def _add_adjust_fuel_solver(self):
         # Fuel adjustment creates a local feedback loop on this mission group even when

--- a/src/fastoad/models/performances/mission/openmdao/mission.py
+++ b/src/fastoad/models/performances/mission/openmdao/mission.py
@@ -204,7 +204,7 @@ class OMMission(
             ],
             units="kg",
             scaling_factors=[1, 1, -1],
-            desc=f'Takeoff weight for mission "{self.mission_name}"',
+            desc=f'Input weight at mission start/target mass for mission "{self.mission_name}"',
         )
 
         return computation

--- a/src/fastoad/models/performances/mission/openmdao/mission.py
+++ b/src/fastoad/models/performances/mission/openmdao/mission.py
@@ -66,7 +66,8 @@ class OMMission(
             types=bool,
             desc="If True, block fuel will fit fuel consumption during mission. In that case, a "
             "solver (local or global) will be needed. (see `use_inner_solver` option for more"
-            "information)\n"
+            "information). If `use_inner_solvers` is False, this mission group still adds its "
+            "own local solver because fuel adjustment creates a feedback loop.\n"
             "If False, block fuel will be taken from input data.",
         )
         self.options.declare(
@@ -102,6 +103,8 @@ class OMMission(
             desc="If True, a local solver is set for the mission computation.\n"
             "It is useful if `adjust_fuel` is set to True, or to ensure consistency between "
             "ramp weight and takeoff weight + taxi-out fuel.\n"
+            "If `adjust_fuel` is True, this mission group still installs its own local solver "
+            "even when `use_inner_solvers` is False.\n"
             "If a global solver is used, using a local solver or not should be only a question"
             "of CPU time consumption and is not expected to modify the results.",
         )
@@ -120,6 +123,8 @@ class OMMission(
         super().setup()
 
         if self.options["adjust_fuel"] and not self.options["use_inner_solvers"]:
+            # This keeps the generic use_inner_solvers option untouched while still
+            # converging the mission-specific fuel-adjustment cycle on this group.
             self._add_adjust_fuel_solver()
 
         mission_options = {

--- a/src/fastoad/models/performances/mission/openmdao/mission.py
+++ b/src/fastoad/models/performances/mission/openmdao/mission.py
@@ -114,7 +114,13 @@ class OMMission(
         )
 
     def setup(self):
+        if self.options["adjust_fuel"]:
+            self.options["compute_input_weight"] = True
+
         super().setup()
+
+        if self.options["adjust_fuel"] and not self.options["use_inner_solvers"]:
+            self._add_adjust_fuel_solver()
 
         mission_options = {
             key: val for key, val in self.options.items() if key in AdvancedMissionComp().options
@@ -124,7 +130,6 @@ class OMMission(
         self.add_subsystem("ZFW_computation", self._get_zfw_component(), promotes=["*"])
 
         if self.options["adjust_fuel"]:
-            self.options["compute_input_weight"] = True
             self.connect(
                 self.name_provider.NEEDED_BLOCK_FUEL.value,
                 self.name_provider.BLOCK_FUEL.value,
@@ -199,7 +204,7 @@ class OMMission(
             ],
             units="kg",
             scaling_factors=[1, 1, -1],
-            desc=f'Loaded fuel at beginning for mission "{self.mission_name}"',
+            desc=f'Takeoff weight for mission "{self.mission_name}"',
         )
 
         return computation
@@ -223,7 +228,7 @@ class OMMission(
             ],
             units="kg",
             scaling_factors=[1, 1, -1],
-            desc=f'Loaded fuel at beginning for mission "{self.mission_name}"',
+            desc=f'Loaded fuel at beginning of mission "{self.mission_name}"',
         )
 
         return block_fuel_computation
@@ -233,6 +238,20 @@ class OMMission(
             return "data:weight:aircraft:payload"
 
         return self.name_provider.PAYLOAD.value
+
+    def _add_adjust_fuel_solver(self):
+        # Fuel adjustment creates a local feedback loop on this mission group even when
+        # generic inner solvers are disabled at the component level.
+        linear_solver_class = self._get_solver_class("linear_solver")
+        nonlinear_solver_class = self._get_solver_class("nonlinear_solver")
+
+        linear_solver_options = self._get_solver_options("linear_solver_options")
+        nonlinear_solver_options = self._get_solver_options("nonlinear_solver_options")
+
+        if linear_solver_class:
+            self.linear_solver = linear_solver_class(**linear_solver_options)
+        if nonlinear_solver_class:
+            self.nonlinear_solver = nonlinear_solver_class(**nonlinear_solver_options)
 
 
 class SpecificBurnedFuelComputation(

--- a/src/fastoad/models/performances/mission/openmdao/tests/test_mission.py
+++ b/src/fastoad/models/performances/mission/openmdao/tests/test_mission.py
@@ -343,6 +343,55 @@ def test_mission_group_with_fuel_adjustment_adds_local_solver(cleanup, with_dumm
     )
 
 
+def test_sizing_mission_group_with_fuel_adjustment_does_not_add_local_solver(
+    cleanup, with_dummy_plugin_2
+):
+    input_file_path = DATA_FOLDER_PATH / "test_breguet.xml"
+    variables = DataFile(input_file_path)
+    del variables["data:mission:operational:ramp_weight"]
+    ivc = variables.to_ivc()
+
+    problem = run_system(
+        OMMission(
+            propulsion_id="test.wrapper.propulsion.dummy_engine",
+            out_file=RESULTS_FOLDER_PATH / "unforced_sizing_solver_mission_group.csv",
+            use_initializer_iteration=True,
+            mission_file_path=DATA_FOLDER_PATH / "test_breguet.yml",
+            use_inner_solvers=False,
+            reference_area_variable="data:geometry:aircraft:reference_area",
+            is_sizing=True,
+        ),
+        ivc,
+    )
+
+    assert isinstance(problem.model.component.nonlinear_solver, om.NonlinearRunOnce)
+
+
+def test_mission_group_with_fuel_adjustment_keeps_existing_local_solver(
+    cleanup, with_dummy_plugin_2
+):
+    input_file_path = DATA_FOLDER_PATH / "test_mission.xml"
+    variables = DataFile(input_file_path)
+    del variables["data:mission:operational:TOW"]
+    ivc = variables.to_ivc()
+
+    component = OMMission(
+        propulsion_id="test.wrapper.propulsion.dummy_engine",
+        out_file=RESULTS_FOLDER_PATH / "preconfigured_solver_mission_group.csv",
+        use_initializer_iteration=True,
+        mission_file_path=DATA_FOLDER_PATH / "test_mission.yml",
+        mission_name="operational",
+        use_inner_solvers=False,
+        reference_area_variable="data:geometry:aircraft:reference_area",
+    )
+    component.linear_solver = om.DirectSolver()
+    component.nonlinear_solver = om.NewtonSolver(solve_subsystems=False)
+
+    problem = run_system(component, ivc)
+
+    assert isinstance(problem.model.component.nonlinear_solver, om.NewtonSolver)
+
+
 def test_mission_group_breguet_with_fuel_adjustment(cleanup, with_dummy_plugin_2):
     # Also checking behavior when is_sizing is True
 

--- a/src/fastoad/models/performances/mission/openmdao/tests/test_mission.py
+++ b/src/fastoad/models/performances/mission/openmdao/tests/test_mission.py
@@ -15,6 +15,7 @@ import logging
 import shutil
 from pathlib import Path
 
+import openmdao.api as om
 import pytest
 from numpy.testing import assert_allclose
 from scipy.constants import foot, knot, nautical_mile
@@ -310,6 +311,34 @@ def test_mission_group_with_fuel_adjustment(cleanup, with_dummy_plugin_2):
         problem.get_val("data:mission:operational:specific_burned_fuel", "km**-1"),
         1.02283e-4,
         rtol=1.0e-5,
+    )
+
+
+def test_mission_group_with_fuel_adjustment_adds_local_solver(cleanup, with_dummy_plugin_2):
+    input_file_path = DATA_FOLDER_PATH / "test_mission.xml"
+    variables = DataFile(input_file_path)
+    del variables["data:mission:operational:TOW"]
+    ivc = variables.to_ivc()
+
+    problem = run_system(
+        OMMission(
+            propulsion_id="test.wrapper.propulsion.dummy_engine",
+            out_file=RESULTS_FOLDER_PATH / "forced_solver_mission_group.csv",
+            use_initializer_iteration=True,
+            mission_file_path=DATA_FOLDER_PATH / "test_mission.yml",
+            mission_name="operational",
+            use_inner_solvers=False,
+            reference_area_variable="data:geometry:aircraft:reference_area",
+        ),
+        ivc,
+    )
+
+    assert not problem.model.component.options["use_inner_solvers"]
+    assert isinstance(problem.model.component.nonlinear_solver, om.NonlinearBlockGS)
+    assert_allclose(
+        problem["data:mission:operational:needed_block_fuel"],
+        problem["data:mission:operational:block_fuel"],
+        atol=1.0,
     )
 
 

--- a/src/fastoad/models/performances/mission/openmdao/tests/test_mission.py
+++ b/src/fastoad/models/performances/mission/openmdao/tests/test_mission.py
@@ -314,7 +314,9 @@ def test_mission_group_with_fuel_adjustment(cleanup, with_dummy_plugin_2):
     )
 
 
-def test_mission_group_with_fuel_adjustment_adds_local_solver(cleanup, with_dummy_plugin_2):
+def test_mission_group_with_fuel_adjustment_auto_activates_inner_solvers(
+    cleanup, with_dummy_plugin_2
+):
     input_file_path = DATA_FOLDER_PATH / "test_mission.xml"
     variables = DataFile(input_file_path)
     del variables["data:mission:operational:TOW"]
@@ -333,7 +335,7 @@ def test_mission_group_with_fuel_adjustment_adds_local_solver(cleanup, with_dumm
         ivc,
     )
 
-    assert not problem.model.component.options["use_inner_solvers"]
+    assert problem.model.component.options["use_inner_solvers"]
     assert problem.model.component.nonlinear_solver is not None
     assert not isinstance(problem.model.component.nonlinear_solver, om.NonlinearRunOnce)
     assert_allclose(
@@ -364,10 +366,11 @@ def test_sizing_mission_group_with_fuel_adjustment_does_not_add_local_solver(
         ivc,
     )
 
+    assert not problem.model.component.options["use_inner_solvers"]
     assert isinstance(problem.model.component.nonlinear_solver, om.NonlinearRunOnce)
 
 
-def test_mission_group_with_fuel_adjustment_keeps_existing_local_solver(
+def test_mission_group_with_fuel_adjustment_overrides_existing_local_solver(
     cleanup, with_dummy_plugin_2
 ):
     input_file_path = DATA_FOLDER_PATH / "test_mission.xml"
@@ -389,7 +392,60 @@ def test_mission_group_with_fuel_adjustment_keeps_existing_local_solver(
 
     problem = run_system(component, ivc)
 
-    assert isinstance(problem.model.component.nonlinear_solver, om.NewtonSolver)
+    assert problem.model.component.options["use_inner_solvers"]
+    assert isinstance(problem.model.component.nonlinear_solver, om.NonlinearBlockGS)
+
+
+def test_mission_group_with_fuel_adjustment_never_mode_preserves_run_once_solvers(
+    cleanup, with_dummy_plugin_2
+):
+    input_file_path = DATA_FOLDER_PATH / "test_mission.xml"
+    variables = DataFile(input_file_path)
+    del variables["data:mission:operational:TOW"]
+    ivc = variables.to_ivc()
+
+    problem = run_system(
+        OMMission(
+            propulsion_id="test.wrapper.propulsion.dummy_engine",
+            out_file=RESULTS_FOLDER_PATH / "never_mode_solver_mission_group.csv",
+            use_initializer_iteration=True,
+            mission_file_path=DATA_FOLDER_PATH / "test_mission.yml",
+            mission_name="operational",
+            use_inner_solvers=False,
+            adjust_fuel_solver_mode="never",
+            reference_area_variable="data:geometry:aircraft:reference_area",
+        ),
+        ivc,
+    )
+
+    assert not problem.model.component.options["use_inner_solvers"]
+    assert isinstance(problem.model.component.nonlinear_solver, om.NonlinearRunOnce)
+
+
+def test_sizing_mission_group_with_fuel_adjustment_always_mode_activates_inner_solvers(
+    cleanup, with_dummy_plugin_2
+):
+    input_file_path = DATA_FOLDER_PATH / "test_breguet.xml"
+    variables = DataFile(input_file_path)
+    del variables["data:mission:operational:ramp_weight"]
+    ivc = variables.to_ivc()
+
+    problem = run_system(
+        OMMission(
+            propulsion_id="test.wrapper.propulsion.dummy_engine",
+            out_file=RESULTS_FOLDER_PATH / "forced_sizing_solver_mission_group.csv",
+            use_initializer_iteration=True,
+            mission_file_path=DATA_FOLDER_PATH / "test_breguet.yml",
+            use_inner_solvers=False,
+            adjust_fuel_solver_mode="always",
+            reference_area_variable="data:geometry:aircraft:reference_area",
+            is_sizing=True,
+        ),
+        ivc,
+    )
+
+    assert problem.model.component.options["use_inner_solvers"]
+    assert not isinstance(problem.model.component.nonlinear_solver, om.NonlinearRunOnce)
 
 
 def test_mission_group_breguet_with_fuel_adjustment(cleanup, with_dummy_plugin_2):

--- a/src/fastoad/models/performances/mission/openmdao/tests/test_mission.py
+++ b/src/fastoad/models/performances/mission/openmdao/tests/test_mission.py
@@ -334,7 +334,8 @@ def test_mission_group_with_fuel_adjustment_adds_local_solver(cleanup, with_dumm
     )
 
     assert not problem.model.component.options["use_inner_solvers"]
-    assert isinstance(problem.model.component.nonlinear_solver, om.NonlinearBlockGS)
+    assert problem.model.component.nonlinear_solver is not None
+    assert not isinstance(problem.model.component.nonlinear_solver, om.NonlinearRunOnce)
     assert_allclose(
         problem["data:mission:operational:needed_block_fuel"],
         problem["data:mission:operational:block_fuel"],


### PR DESCRIPTION
This PR fixes a convergence issue in the OpenMDAO mission when `adjust_fuel=True`.

For these missions, there is a feedback loop between `needed_block_fuel`, `block_fuel`, and mission input weight. If that loop is left without a solver, the mission can run with inconsistent weights, including cases where `TOW` does not satisfy the expected relation with `ZFW`, `block_fuel`, and `consumed_fuel_before_input_weight`.

To fix this while preserving user control over solvers, `OMMission` now exposes a dedicated `adjust_fuel_solver_mode` option. This makes the behavior explicit instead of overloading `use_inner_solvers` i.e., forcing its val to true even when the user explicitly put it to false.

With the default `auto` mode, `OMMission` locally switches `use_inner_solvers` to `True` only for non-sizing missions when `adjust_fuel=True` and `use_inner_solvers=False`. This fixes the usual standalone evaluation-mission case, where an outer solver around the mission is often not enough because the fuel-adjustment loop is internal to the mission group itself.

Sizing missions are left unchanged in `auto` mode. They are expected to run inside the outer MDA loop, so they continue to rely on that external solver unless the user explicitly asks otherwise.

The new option also restores full symmetry for advanced users: `always` forces the same behavior for sizing missions, while `never` keeps `OMMission` from modifying `use_inner_solvers` at all.

This keeps the bug fix for the common non-sizing evaluation case while making the solver policy explicit and fully configurable.
