### PR TITLE
Addition of option to avoid copying an output file in local folder with Calc_runner

### DIFF
--- a/src/fastoad/cmd/calc_runner.py
+++ b/src/fastoad/cmd/calc_runner.py
@@ -92,7 +92,7 @@ class CalcRunner:
 
         if calculation_folder:
             make_parent_dir(calculation_folder)
-            configuration.make_local(calculation_folder)
+            configuration.make_local(calculation_folder, copy_output_file=False)
             if input_values:
                 input_data = DataFile(configuration.input_file_path)
                 input_data.update(input_values, merge_metadata=True)

--- a/src/fastoad/io/configuration/configuration.py
+++ b/src/fastoad/io/configuration/configuration.py
@@ -300,7 +300,7 @@ class FASTOADProblemConfigurator:
 
         self._data[KEY_INPUT_FILE] = self._make_path_local(self.input_file_path, new_folder_path)
         self._data[KEY_OUTPUT_FILE] = self._make_path_local(
-            self.output_file_path, new_folder_path, copy=copy_output_file
+            self.output_file_path, new_folder_path, copy_path=copy_output_file
         )
         if copy_models:
             new_model_folders = []
@@ -420,7 +420,7 @@ class FASTOADProblemConfigurator:
         original_path: str | PathLike,
         new_folder_path: str | PathLike,
         local_path: str | PathLike | None = None,
-        copy: bool | int = True,  # noqa: FBT001, FBT002
+        copy_path: bool | int = True,  # noqa: FBT001, FBT002
     ) -> str:
         """
         For 'original_path' "/foo/bar/baz[.ext]", returns "./baz[.ext]" or
@@ -432,7 +432,7 @@ class FASTOADProblemConfigurator:
         :param original_path:
         :param new_folder_path:
         :param local_path:
-        :param copy: Whether to copy the original file or folder. If False, only the path is
+        :param copy_path: Whether to copy the original file or folder. If False, only the path is
         modified, but no file is copied.
         :return: the relative path
         """
@@ -442,9 +442,9 @@ class FASTOADProblemConfigurator:
             new_path /= local_path
         new_path.mkdir(parents=True, exist_ok=True)
         new_path /= original_path.name
-        if original_path.is_file() and copy:
+        if original_path.is_file() and copy_path:
             shutil.copy(original_path, new_path)
-        if original_path.is_dir() and copy:
+        if original_path.is_dir() and copy_path:
             shutil.copytree(original_path, new_path, dirs_exist_ok=True)
         return new_path.relative_to(new_folder_path).as_posix()  # new_relative_path
 

--- a/src/fastoad/io/configuration/configuration.py
+++ b/src/fastoad/io/configuration/configuration.py
@@ -280,7 +280,13 @@ class FASTOADProblemConfigurator:
         subpart = {"optimization": subpart}
         self._data.update(subpart)
 
-    def make_local(self, new_folder_path: str | PathLike, *, copy_models: bool = False):
+    def make_local(
+        self,
+        new_folder_path: str | PathLike,
+        *,
+        copy_models: bool = False,
+        copy_output_file: bool = True,
+    ):
         """
         Modify the current configurator so that all input and output files will be in
         the indicated folder.
@@ -288,11 +294,14 @@ class FASTOADProblemConfigurator:
         :param new_folder_path: the folder path that will contain in/out files
         :param copy_models: True if local models (declared in `module_folders`) should
                             be copied in `new_folder_path`
+        :param copy_output_file: True if the output file should be copied in `new_folder_path`
         """
         new_folder_path = as_path(new_folder_path)
 
         self._data[KEY_INPUT_FILE] = self._make_path_local(self.input_file_path, new_folder_path)
-        self._data[KEY_OUTPUT_FILE] = self._make_path_local(self.output_file_path, new_folder_path)
+        self._data[KEY_OUTPUT_FILE] = self._make_path_local(
+            self.output_file_path, new_folder_path, copy=copy_output_file
+        )
         if copy_models:
             new_model_folders = []
             for i, module_folder_path in enumerate(self._get_module_folder_paths()):
@@ -411,6 +420,7 @@ class FASTOADProblemConfigurator:
         original_path: str | PathLike,
         new_folder_path: str | PathLike,
         local_path: str | PathLike | None = None,
+        copy: bool | int = True,  # noqa: FBT001, FBT002
     ) -> str:
         """
         For 'original_path' "/foo/bar/baz[.ext]", returns "./baz[.ext]" or
@@ -422,6 +432,8 @@ class FASTOADProblemConfigurator:
         :param original_path:
         :param new_folder_path:
         :param local_path:
+        :param copy: Whether to copy the original file or folder. If False, only the path is
+        modified, but no file is copied.
         :return: the relative path
         """
         original_path = as_path(original_path)
@@ -430,9 +442,9 @@ class FASTOADProblemConfigurator:
             new_path /= local_path
         new_path.mkdir(parents=True, exist_ok=True)
         new_path /= original_path.name
-        if original_path.is_file():
+        if original_path.is_file() and copy:
             shutil.copy(original_path, new_path)
-        if original_path.is_dir():
+        if original_path.is_dir() and copy:
             shutil.copytree(original_path, new_path, dirs_exist_ok=True)
         return new_path.relative_to(new_folder_path).as_posix()  # new_relative_path
 


### PR DESCRIPTION
Currently when using Calc_runner, a local folder is created in which all the required files to run FAST-OAD on the specific point are copied. This includes the output file if the output file specified in the configuration file already exists. This is problematic because if the FAST-OAD run on this point fails, an output file will still be present in the local folder, making the detection of failed runs complex.  

## Summary of Changes

- An option was added to _make_path_local to not copy the file in the local folder, default behavior is unchanged and will copy the file
- When running Calc_runner, the option is used to not copy the output file in the local calc folder

## Related Issues

closes #600