### PR TITLE
Addition of a way to pass options to propulsion wrapper

### DIFF
--- a/docs/documentation/custom_modules/add_propulsion_module.rst
+++ b/docs/documentation/custom_modules/add_propulsion_module.rst
@@ -160,6 +160,7 @@ Passing options to the wrapper
 
 When developing your propulsion model, you might want to pass options to change how the model behaves and declares inputs. You can do that by accessing the `propulsion_options` option inside the wrapper::
 
+    from openmdao.core.component import Component
     import fastoad.api as oad
 
 

--- a/docs/documentation/custom_modules/add_propulsion_module.rst
+++ b/docs/documentation/custom_modules/add_propulsion_module.rst
@@ -154,3 +154,42 @@ with the `propulsion_id` keyword, as in following example:
       performance:
         id: fastoad.performances.mission
         propulsion_id: star.trek.propulsion
+
+Passing options to the wrapper
+==============================
+
+When developing your propulsion model, you might want to pass options to change how the model behaves and declares inputs. You can do that by accessing the `propulsion_options` option inside the wrapper::
+
+    import fastoad.api as oad
+
+
+    @oad.RegisterPropulsion("star.wars.propulsion")
+    class WarpDriveWrapper(oad.IOMPropulsionWrapper):
+
+        def setup(self, component: Component):
+
+            if component.options["propulsion_options"].get("fidelity_level", None) == "high_fidelity":
+                [ ... ]
+            else:
+                [ ... ]
+
+
+Options can then be declared directly in the configuration file by using :ref:`model options<configuration-model-options>`.
+
+.. code-block:: yaml
+
+    title: OAD Process with custom propulsion model using options
+
+    [ ... ]
+
+    # Definition of OpenMDAO model
+    model:
+      [ ... ]
+      performance:
+        id: fastoad.performances.mission
+        propulsion_id: star.wars.propulsion
+
+    model_options:
+      '*':
+        propulsion_options:
+          fidelity_level: high_fidelity

--- a/docs/documentation/custom_modules/add_propulsion_module.rst
+++ b/docs/documentation/custom_modules/add_propulsion_module.rst
@@ -194,3 +194,20 @@ Options can then be declared directly in the configuration file by using :ref:`m
       '*':
         propulsion_options:
           fidelity_level: high_fidelity
+
+Propulsion options can also be declared by passing them directly to the performance module.
+
+.. code-block:: yaml
+
+    title: OAD Process with custom propulsion model using options
+
+    [ ... ]
+
+    # Definition of OpenMDAO model
+    model:
+      [ ... ]
+      performance:
+        id: fastoad.performances.mission
+        propulsion_id: star.wars.propulsion
+        propulsion_options:
+          fidelity_level: high_fidelity

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -134,6 +134,30 @@ def with_dummy_plugin_2():
 
 
 @pytest.fixture
+def with_dummy_plugin_3():
+    """
+    Reduces plugin list to dummy-dist-2 with plugin test_plugin_3
+    (two configuration files, model folder, no notebooks, 3 source data files).
+
+    Any previous state of plugins is restored during teardown.
+    """
+    _setup()
+    dummy_dist_2 = Mock(importlib_metadata.Distribution)
+    dummy_dist_2.name = "dummy-dist-2"
+    new_entry_points = [
+        importlib_metadata.EntryPoint(
+            name="test_plugin_2",
+            value="tests.dummy_plugins.dist_2.dummy_plugin_3",
+            group=MODEL_PLUGIN_ID,
+        )
+    ]
+    new_entry_points[0].dist = dummy_dist_2
+    _update_entry_map(new_entry_points)
+    yield
+    _teardown()
+
+
+@pytest.fixture
 def with_dummy_plugin_4():
     """
     Reduces plugin list to dummy-dist-1 with plugin test_plugin_4

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -146,7 +146,7 @@ def with_dummy_plugin_3():
     dummy_dist_2.name = "dummy-dist-2"
     new_entry_points = [
         importlib_metadata.EntryPoint(
-            name="test_plugin_2",
+            name="test_plugin_3",
             value="tests.dummy_plugins.dist_2.dummy_plugin_3",
             group=MODEL_PLUGIN_ID,
         )

--- a/src/fastoad/models/performances/mission/openmdao/base.py
+++ b/src/fastoad/models/performances/mission/openmdao/base.py
@@ -120,6 +120,12 @@ class BaseMissionComp(System, metaclass=ABCMeta):
             check_valid=self._update_mission_wrapper,
             desc="How auto-generated names of variables should begin.",
         )
+        self.options.declare(
+            "propulsion_options",
+            default={},
+            types=dict,
+            desc="Defines options for propulsion model using a dictionary",
+        )
 
     @property
     def name_provider(self) -> Enum:

--- a/src/fastoad/models/performances/mission/openmdao/tests/test_mission_run.py
+++ b/src/fastoad/models/performances/mission/openmdao/tests/test_mission_run.py
@@ -107,45 +107,61 @@ def test_mission_run_with_options(cleanup, with_dummy_plugin_3):
     input_file_path = DATA_FOLDER_PATH / "test_mission_run.xml"
     ivc = DataFile(input_file_path).to_ivc()
 
-    problem = FASTOADProblem()
-    model = problem.model = BaseCycleGroup()
+    component = MissionComp(
+        propulsion_id="test.wrapper.propulsion.dummy_engine_with_options",
+        out_file=RESULTS_FOLDER_PATH / "mission.csv",
+        mission_file_path=DATA_FOLDER_PATH / "test_mission.yml",
+        mission_name="operational",
+        reference_area_variable="data:geometry:aircraft:reference_area",
+        variable_prefix="data:payload_range",
+    )
 
-    model.add_subsystem("inputs", ivc, promotes=["*"])
-    model.add_subsystem(
+    high_fi_problem = FASTOADProblem()
+    high_fi_model = high_fi_problem.model = BaseCycleGroup()
+
+    high_fi_model.add_subsystem("inputs", ivc, promotes=["*"])
+    high_fi_model.add_subsystem(
         "component",
-        MissionComp(
-            propulsion_id="test.wrapper.propulsion.dummy_engine_with_options",
-            out_file=RESULTS_FOLDER_PATH / "mission.csv",
-            mission_file_path=DATA_FOLDER_PATH / "test_mission.yml",
-            mission_name="operational",
-            reference_area_variable="data:geometry:aircraft:reference_area",
-            variable_prefix="data:payload_range",
-        ),
+        component,
         promotes=["*"],
     )
 
     # Test one time with an option
-    problem.model_options["*"] = {"propulsion_options": {"gas_turbine_fidelity": "high_fidelity"}}
+    high_fi_problem.model_options["*"] = {
+        "propulsion_options": {"gas_turbine_fidelity": "high_fidelity"}
+    }
 
-    problem.setup()
-    problem.final_setup()
-    problem.run_model()
+    high_fi_problem.setup()
+    high_fi_problem.final_setup()
+    high_fi_problem.run_model()
 
     assert_allclose(
-        problem.get_val("data:payload_range:operational:needed_block_fuel", units="kg"),
+        high_fi_problem.get_val("data:payload_range:operational:needed_block_fuel", units="kg"),
         9340.0,
         atol=1.0,
     )
 
-    # Test one time with a second option and check that results are different
-    problem.model_options["*"] = {"propulsion_options": {"gas_turbine_fidelity": "low_fidelity"}}
+    low_fi_problem = FASTOADProblem()
+    low_fi_model = low_fi_problem.model = BaseCycleGroup()
 
-    problem.setup()
-    problem.final_setup()
-    problem.run_model()
+    low_fi_model.add_subsystem("inputs", ivc, promotes=["*"])
+    low_fi_model.add_subsystem(
+        "component",
+        component,  # Same model
+        promotes=["*"],
+    )
+
+    # Test one time with a second option and check that results are different
+    low_fi_problem.model_options["*"] = {
+        "propulsion_options": {"gas_turbine_fidelity": "low_fidelity"}
+    }
+
+    low_fi_problem.setup()
+    low_fi_problem.final_setup()
+    low_fi_problem.run_model()
 
     assert_allclose(
-        problem.get_val("data:payload_range:operational:needed_block_fuel", units="kg"),
+        low_fi_problem.get_val("data:payload_range:operational:needed_block_fuel", units="kg"),
         10453.0,
         atol=1.0,
     )

--- a/src/fastoad/models/performances/mission/openmdao/tests/test_mission_run.py
+++ b/src/fastoad/models/performances/mission/openmdao/tests/test_mission_run.py
@@ -19,6 +19,8 @@ from numpy.testing import assert_allclose
 from scipy.constants import nautical_mile
 
 from fastoad.io import DataFile
+from fastoad.model_base.openmdao.group import BaseCycleGroup
+from fastoad.openmdao.problem import FASTOADProblem
 from fastoad.testing import run_system
 
 from ..mission_run import MissionComp
@@ -99,3 +101,51 @@ def test_mission_run(cleanup, with_dummy_plugin_2):
         problem["data:payload_range:operational:distance"], 2000.0 * nautical_mile, atol=500.0
     )
     assert_allclose(problem["data:payload_range:operational:duration"], 16573.0, atol=10.0)
+
+
+def test_mission_run_with_options(cleanup, with_dummy_plugin_3):
+    input_file_path = DATA_FOLDER_PATH / "test_mission_run.xml"
+    ivc = DataFile(input_file_path).to_ivc()
+
+    problem = FASTOADProblem()
+    model = problem.model = BaseCycleGroup()
+
+    model.add_subsystem("inputs", ivc, promotes=["*"])
+    model.add_subsystem(
+        "component",
+        MissionComp(
+            propulsion_id="test.wrapper.propulsion.dummy_engine_with_options",
+            out_file=RESULTS_FOLDER_PATH / "mission.csv",
+            mission_file_path=DATA_FOLDER_PATH / "test_mission.yml",
+            mission_name="operational",
+            reference_area_variable="data:geometry:aircraft:reference_area",
+            variable_prefix="data:payload_range",
+        ),
+        promotes=["*"],
+    )
+
+    # Test one time with an option
+    problem.model_options["*"] = {"propulsion_options": {"gas_turbine_fidelity": "high_fidelity"}}
+
+    problem.setup()
+    problem.final_setup()
+    problem.run_model()
+
+    assert_allclose(
+        problem.get_val("data:payload_range:operational:needed_block_fuel", units="kg"),
+        9340.0,
+        atol=1.0,
+    )
+
+    # Test one time with a second option and check that results are different
+    problem.model_options["*"] = {"propulsion_options": {"gas_turbine_fidelity": "low_fidelity"}}
+
+    problem.setup()
+    problem.final_setup()
+    problem.run_model()
+
+    assert_allclose(
+        problem.get_val("data:payload_range:operational:needed_block_fuel", units="kg"),
+        10453.0,
+        atol=1.0,
+    )

--- a/tests/dummy_plugins/dist_2/dummy_plugin_3/models/subpackage/dummy_engine_with_options.py
+++ b/tests/dummy_plugins/dist_2/dummy_plugin_3/models/subpackage/dummy_engine_with_options.py
@@ -52,7 +52,7 @@ class DummyEngineHighFidelity(AbstractFuelPropulsion):
         Dummy engine model.
 
         Max thrust does not depend on flight conditions.
-        SFC varies linearly between a value when thrust rate is nil and another value when thrust
+        SFC varies linearly between a value when thrust rate is nul and another value when thrust
         rate is at 1.
 
         :param max_thrust: thrust when thrust rate = 1.0

--- a/tests/dummy_plugins/dist_2/dummy_plugin_3/models/subpackage/dummy_engine_with_options.py
+++ b/tests/dummy_plugins/dist_2/dummy_plugin_3/models/subpackage/dummy_engine_with_options.py
@@ -52,8 +52,8 @@ class DummyEngineHighFidelity(AbstractFuelPropulsion):
         Dummy engine model.
 
         Max thrust does not depend on flight conditions.
-        SFC varies linearly between a value when thrust rate is nul and another value when thrust
-        rate is at 1.
+        SFC varies linearly between a value when thrust rate is zero and another value when thrust
+        rate is one.
 
         :param max_thrust: thrust when thrust rate = 1.0
         :param sfc_min_thrust_rate: SFC at minimum thrust rate

--- a/tests/dummy_plugins/dist_2/dummy_plugin_3/models/subpackage/dummy_engine_with_options.py
+++ b/tests/dummy_plugins/dist_2/dummy_plugin_3/models/subpackage/dummy_engine_with_options.py
@@ -1,0 +1,113 @@
+#  This file is part of FAST-OAD : A framework for rapid Overall Aircraft Design
+#  Copyright (C) 2026 ONERA & ISAE-SUPAERO
+#  FAST is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#  You should have received a copy of the GNU General Public License
+#  along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from openmdao.core.component import Component
+
+from fastoad.model_base import FlightPoint
+from fastoad.model_base.propulsion import (
+    AbstractFuelPropulsion,
+    FuelEngineSet,
+    IOMPropulsionWrapper,
+    IPropulsion,
+)
+from fastoad.module_management.service_registry import RegisterPropulsion
+
+
+class DummyEngineLowFidelity(AbstractFuelPropulsion):
+    def __init__(self, max_thrust, sfc):
+        """
+        Dummy engine model.
+
+        Max thrust does not depend on flight conditions.
+        SFC is constant
+
+        :param max_thrust: thrust when thrust rate = 1.0
+        :param sfc: SFC
+        """
+        self.max_thrust = max_thrust
+        self.sfc = sfc
+
+    def compute_flight_points(self, flight_point: FlightPoint):
+        if flight_point.thrust_is_regulated or flight_point.thrust_rate is None:
+            flight_point.thrust_rate = flight_point.thrust / self.max_thrust
+        else:
+            flight_point.thrust = self.max_thrust * flight_point.thrust_rate
+
+        flight_point.sfc = self.sfc
+
+
+class DummyEngineHighFidelity(AbstractFuelPropulsion):
+    def __init__(self, max_thrust, sfc_min_thrust_rate, sfc_max_thrust_rate):
+        """
+        Dummy engine model.
+
+        Max thrust does not depend on flight conditions.
+        SFC varies linearly between a value when thrust rate is nil and another value when thrust
+        rate is at 1.
+
+        :param max_thrust: thrust when thrust rate = 1.0
+        :param sfc_min_thrust_rate: SFC at minimum thrust rate
+        :param sfc_max_thrust_rate: SFC at maximum thrust rate
+        """
+        self.max_thrust = max_thrust
+        self.sfc_min_thrust_rate = sfc_min_thrust_rate
+        self.sfc_max_thrust_rate = sfc_max_thrust_rate
+
+    def compute_flight_points(self, flight_point: FlightPoint):
+        if flight_point.thrust_is_regulated or flight_point.thrust_rate is None:
+            flight_point.thrust_rate = flight_point.thrust / self.max_thrust
+        else:
+            flight_point.thrust = self.max_thrust * flight_point.thrust_rate
+
+        flight_point.sfc = self.sfc_min_thrust_rate + (
+                self.sfc_max_thrust_rate - self.sfc_min_thrust_rate
+        ) * flight_point.thrust_rate
+
+
+@RegisterPropulsion("test.wrapper.propulsion.dummy_engine_with_options")
+class DummyEngineWrapper(IOMPropulsionWrapper):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.gas_turbine_fidelity = "low_fidelity"  # By default
+
+    def setup(self, component: Component):
+
+        component.add_input("data:propulsion:dummy_engine:max_thrust", 1.2e5, units="N")
+        component.add_input("data:geometry:propulsion:engine_count", 2, units="unitless")
+
+        if component.options["propulsion_options"].get("gas_turbine_fidelity", None) == "high_fidelity":
+            self.gas_turbine_fidelity = "high_fidelity"
+            component.add_input("data:propulsion:dummy_engine:sfc_min_thrust_rate", 1.5e-5, units="kg/N/s")
+            component.add_input("data:propulsion:dummy_engine:sfc_max_thrust_rate", 0.75e-5, units="kg/N/s")
+        else:
+            self.gas_turbine_fidelity = "low_fidelity"
+            component.add_input("data:propulsion:dummy_engine:sfc", 1.5e-5, units="kg/N/s")
+
+    def get_model(self, inputs) -> IPropulsion:
+        if self.gas_turbine_fidelity == "high_fidelity":
+            return FuelEngineSet(
+                DummyEngineHighFidelity(
+                    inputs["data:propulsion:dummy_engine:max_thrust"],
+                    inputs["data:propulsion:dummy_engine:sfc_min_thrust_rate"],
+                    inputs["data:propulsion:dummy_engine:sfc_max_thrust_rate"],
+                ),
+                inputs["data:geometry:propulsion:engine_count"],
+            )
+        else:
+            return FuelEngineSet(
+                DummyEngineLowFidelity(
+                    inputs["data:propulsion:dummy_engine:max_thrust"],
+                    inputs["data:propulsion:dummy_engine:sfc"],
+                ),
+                inputs["data:geometry:propulsion:engine_count"],
+            )

--- a/tests/dummy_plugins/dist_2/dummy_plugin_3/models/subpackage/dummy_engine_with_options.py
+++ b/tests/dummy_plugins/dist_2/dummy_plugin_3/models/subpackage/dummy_engine_with_options.py
@@ -70,7 +70,7 @@ class DummyEngineHighFidelity(AbstractFuelPropulsion):
             flight_point.thrust = self.max_thrust * flight_point.thrust_rate
 
         flight_point.sfc = self.sfc_min_thrust_rate + (
-                self.sfc_max_thrust_rate - self.sfc_min_thrust_rate
+            self.sfc_max_thrust_rate - self.sfc_min_thrust_rate
         ) * flight_point.thrust_rate
 
 
@@ -87,11 +87,23 @@ class DummyEngineWrapper(IOMPropulsionWrapper):
 
         if component.options["propulsion_options"].get("gas_turbine_fidelity", None) == "high_fidelity":
             self.gas_turbine_fidelity = "high_fidelity"
-            component.add_input("data:propulsion:dummy_engine:sfc_min_thrust_rate", 1.5e-5, units="kg/N/s")
-            component.add_input("data:propulsion:dummy_engine:sfc_max_thrust_rate", 0.75e-5, units="kg/N/s")
+            component.add_input(
+                "data:propulsion:dummy_engine:sfc_min_thrust_rate",
+                1.5e-5,
+                units="kg/N/s"
+            )
+            component.add_input(
+                "data:propulsion:dummy_engine:sfc_max_thrust_rate",
+                0.75e-5,
+                units="kg/N/s"
+            )
         else:
             self.gas_turbine_fidelity = "low_fidelity"
-            component.add_input("data:propulsion:dummy_engine:sfc", 1.5e-5, units="kg/N/s")
+            component.add_input(
+                "data:propulsion:dummy_engine:sfc",
+                1.5e-5,
+                units="kg/N/s"
+            )
 
     def get_model(self, inputs) -> IPropulsion:
         if self.gas_turbine_fidelity == "high_fidelity":


### PR DESCRIPTION
## Summary of Changes

This PR adds a way to pass options to the propulsion wrappers used in the computation of the aircraft's performance. Also adds a test to showcase how it can be used.

## Related Issues
This PR closes #699 

## Checklist

- [x] Have you followed the guidelines in our [Contributing](https://github.com/fast-aircraft-design/FAST-OAD/wiki/Development-environment) wiki?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [x] Have you added new tests to cover your changes?
- [x] Have you made corresponding changes to the documentation? Yes: https://fast-oad.readthedocs.io/en/add_propulsion_options/documentation/custom_modules/add_propulsion_module.html
- [x] Do the existing tests pass with your changes?
- [x] Have you commented on hard-to-understand areas of the code?
- [ ] Does this PR introduce a breaking change?