### PR TITLE
Fix XDSM generation

### DIFF
--- a/src/fastoad/cmd/api.py
+++ b/src/fastoad/cmd/api.py
@@ -659,7 +659,9 @@ def write_xdsm(
     problem.setup()
     problem.final_setup()
 
-    fastoad.openmdao.whatsopt.write_xdsm(problem, xdsm_file_path, depth, wop_server_url, dry_run)
+    fastoad.openmdao.whatsopt.write_xdsm(
+        problem, xdsm_file_path, depth, wop_server_url, dry_run=dry_run
+    )
     return xdsm_file_path
 
 


### PR DESCRIPTION
## Summary of Changes
This PR fixes a bug in the XDSM generation which had gone unnoticed due to some tests being bypassed. After the introduction of new linting rules, `dry_run` became a named argument in the method actually calling WhatsOpt, while in the CLI and API it wasn't. As the usage of the `write_xdsm` method of the `whatsopt.py` script wasn't updated, this led to an error preventing the generation of the XDSM. This can easily be reproduced, pre-fix, using the CLI.

## Checklist

- [x] Have you followed the guidelines in our [Contributing](https://github.com/fast-aircraft-design/FAST-OAD/wiki/Development-environment) wiki?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../../pulls) for the same update/change?
- [x] Do the existing tests pass with your changes?
- [x] Does this PR introduce a breaking change? No !
